### PR TITLE
refactor: drop `ClientService#searchTransactions` and `ClientService#searchWallets`

### DIFF
--- a/packages/platform-sdk-ada/src/manifest.ts
+++ b/packages/platform-sdk-ada/src/manifest.ts
@@ -5,10 +5,8 @@ export const manifest = {
 		Client: {
 			transaction: false,
 			transactions: false,
-			searchTransactions: false,
 			wallet: false,
 			wallets: false,
-			searchWallets: false,
 			delegate: false,
 			delegates: false,
 			configuration: false,

--- a/packages/platform-sdk-ark/__tests__/services/client.test.ts
+++ b/packages/platform-sdk-ark/__tests__/services/client.test.ts
@@ -30,10 +30,10 @@ describe("ClientService", function () {
 	describe("#transactions", () => {
 		it("should succeed", async () => {
 			nock("https://dexplorer.ark.io/api")
-				.get("/transactions")
+				.post("/transactions")
 				.reply(200, require(`${__dirname}/../__fixtures__/client/transactions.json`));
 
-			const result = await subject.transactions();
+			const result = await subject.transactions({ address: 'DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8' });
 
 			expect(result.data).toBeArray();
 			expect(result.data[0]).toBeInstanceOf(TransactionData);
@@ -55,10 +55,10 @@ describe("ClientService", function () {
 	describe("#wallets", () => {
 		it("should succeed", async () => {
 			nock("https://dexplorer.ark.io/api")
-				.get("/wallets")
+				.post("/wallets")
 				.reply(200, require(`${__dirname}/../__fixtures__/client/wallets.json`));
 
-			const result = await subject.wallets();
+			const result = await subject.wallets({ address: 'DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8' });
 
 			expect(result.data).toBeArray();
 			expect(result.data[0]).toBeInstanceOf(WalletData);

--- a/packages/platform-sdk-ark/__tests__/services/client.test.ts
+++ b/packages/platform-sdk-ark/__tests__/services/client.test.ts
@@ -30,7 +30,7 @@ describe("ClientService", function () {
 	describe("#transactions", () => {
 		it("should succeed", async () => {
 			nock("https://dexplorer.ark.io/api")
-				.post("/transactions")
+				.post("/transactions/search")
 				.reply(200, require(`${__dirname}/../__fixtures__/client/transactions.json`));
 
 			const result = await subject.transactions({ address: 'DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8' });
@@ -55,7 +55,7 @@ describe("ClientService", function () {
 	describe("#wallets", () => {
 		it("should succeed", async () => {
 			nock("https://dexplorer.ark.io/api")
-				.post("/wallets")
+				.post("/wallets/search")
 				.reply(200, require(`${__dirname}/../__fixtures__/client/wallets.json`));
 
 			const result = await subject.wallets({ address: 'DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8' });

--- a/packages/platform-sdk-ark/__tests__/services/client.test.ts
+++ b/packages/platform-sdk-ark/__tests__/services/client.test.ts
@@ -40,19 +40,6 @@ describe("ClientService", function () {
 		});
 	});
 
-	describe("#searchTransactions", () => {
-		it("should succeed", async () => {
-			nock("https://dexplorer.ark.io/api")
-				.post("/transactions/search")
-				.reply(200, require(`${__dirname}/../__fixtures__/client/transactions.json`));
-
-			const result = await subject.searchTransactions({});
-
-			expect(result.data).toBeArray();
-			expect(result.data[0]).toBeInstanceOf(TransactionData);
-		});
-	});
-
 	describe("#wallet", () => {
 		it("should succeed", async () => {
 			nock("https://dexplorer.ark.io/api")
@@ -72,19 +59,6 @@ describe("ClientService", function () {
 				.reply(200, require(`${__dirname}/../__fixtures__/client/wallets.json`));
 
 			const result = await subject.wallets();
-
-			expect(result.data).toBeArray();
-			expect(result.data[0]).toBeInstanceOf(WalletData);
-		});
-	});
-
-	describe("#searchWallets", () => {
-		it("should succeed", async () => {
-			nock("https://dexplorer.ark.io/api")
-				.post("/wallets/search")
-				.reply(200, require(`${__dirname}/../__fixtures__/client/wallets.json`));
-
-			const result = await subject.searchWallets({});
 
 			expect(result.data).toBeArray();
 			expect(result.data[0]).toBeInstanceOf(WalletData);

--- a/packages/platform-sdk-ark/src/manifest.ts
+++ b/packages/platform-sdk-ark/src/manifest.ts
@@ -5,10 +5,8 @@ export const manifest = {
 		Client: {
 			transaction: true,
 			transactions: true,
-			searchTransactions: true,
 			wallet: true,
 			wallets: true,
-			searchWallets: true,
 			delegate: true,
 			delegates: true,
 			configuration: true,

--- a/packages/platform-sdk-ark/src/services/client.ts
+++ b/packages/platform-sdk-ark/src/services/client.ts
@@ -27,14 +27,6 @@ export class ClientService implements Contracts.ClientService {
 	public async transactions(
 		query?: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
-		const { body } = await this.connection.api("transactions").all(query);
-
-		return { meta: body.meta, data: body.data.map((transaction) => new TransactionData(transaction)) };
-	}
-
-	public async searchTransactions(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
 		const { body } = await this.connection.api("transactions").search(query);
 
 		return { meta: body.meta, data: body.data.map((transaction) => new TransactionData(transaction)) };
@@ -48,14 +40,6 @@ export class ClientService implements Contracts.ClientService {
 
 	public async wallets(
 		query?: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
-		const { body } = await this.connection.api("wallets").all(query);
-
-		return { meta: body.meta, data: body.data.map((wallet) => new WalletData(wallet)) };
-	}
-
-	public async searchWallets(
-		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
 		const { body } = await this.connection.api("wallets").search(query);
 

--- a/packages/platform-sdk-ark/src/services/client.ts
+++ b/packages/platform-sdk-ark/src/services/client.ts
@@ -25,7 +25,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async transactions(
-		query?: Contracts.KeyValuePair,
+		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
 		const { body } = await this.connection.api("transactions").search(query);
 
@@ -39,7 +39,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async wallets(
-		query?: Contracts.KeyValuePair,
+		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
 		const { body } = await this.connection.api("wallets").search(query);
 

--- a/packages/platform-sdk-atom/src/manifest.ts
+++ b/packages/platform-sdk-atom/src/manifest.ts
@@ -5,10 +5,8 @@ export const manifest = {
 		Client: {
 			transaction: false,
 			transactions: false,
-			searchTransactions: false,
 			wallet: false,
 			wallets: false,
-			searchWallets: false,
 			delegate: false,
 			delegates: false,
 			configuration: false,

--- a/packages/platform-sdk-atom/src/services/client.ts
+++ b/packages/platform-sdk-atom/src/services/client.ts
@@ -32,12 +32,6 @@ export class ClientService implements Contracts.ClientService {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transactions");
 	}
 
-	public async searchTransactions(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchTransactions");
-	}
-
 	public async wallet(id: string): Promise<Contracts.WalletData> {
 		const response = await this.get(`auth/accounts/${id}`);
 
@@ -48,12 +42,6 @@ export class ClientService implements Contracts.ClientService {
 		query?: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "wallets");
-	}
-
-	public async searchWallets(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchWallets");
 	}
 
 	public async delegate(id: string): Promise<Contracts.DelegateData> {

--- a/packages/platform-sdk-atom/src/services/client.ts
+++ b/packages/platform-sdk-atom/src/services/client.ts
@@ -24,7 +24,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async transactions(
-		query?: Contracts.KeyValuePair,
+		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
 		const response = await this.get("txs", query);
 		console.log(JSON.stringify(response));
@@ -39,7 +39,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async wallets(
-		query?: Contracts.KeyValuePair,
+		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "wallets");
 	}

--- a/packages/platform-sdk-btc/src/manifest.ts
+++ b/packages/platform-sdk-btc/src/manifest.ts
@@ -5,10 +5,8 @@ export const manifest = {
 		Client: {
 			transaction: false,
 			transactions: false,
-			searchTransactions: false,
 			wallet: false,
 			wallets: false,
-			searchWallets: false,
 			delegate: false,
 			delegates: false,
 			configuration: false,

--- a/packages/platform-sdk-btc/src/services/client.ts
+++ b/packages/platform-sdk-btc/src/services/client.ts
@@ -32,12 +32,6 @@ export class ClientService implements Contracts.ClientService {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transactions");
 	}
 
-	public async searchTransactions(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchTransactions");
-	}
-
 	public async wallet(id: string): Promise<Contracts.WalletData> {
 		const response = await this.get(`rawaddr/${id}`);
 
@@ -48,12 +42,6 @@ export class ClientService implements Contracts.ClientService {
 		query?: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "wallets");
-	}
-
-	public async searchWallets(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchWallets");
 	}
 
 	public async delegate(id: string): Promise<Contracts.DelegateData> {

--- a/packages/platform-sdk-btc/src/services/client.ts
+++ b/packages/platform-sdk-btc/src/services/client.ts
@@ -27,7 +27,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async transactions(
-		query?: Contracts.KeyValuePair,
+		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transactions");
 	}
@@ -39,7 +39,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async wallets(
-		query?: Contracts.KeyValuePair,
+		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "wallets");
 	}

--- a/packages/platform-sdk-eos/src/manifest.ts
+++ b/packages/platform-sdk-eos/src/manifest.ts
@@ -5,10 +5,8 @@ export const manifest = {
 		Client: {
 			transaction: false,
 			transactions: false,
-			searchTransactions: false,
 			wallet: false,
 			wallets: false,
-			searchWallets: false,
 			delegate: false,
 			delegates: false,
 			configuration: false,

--- a/packages/platform-sdk-eos/src/services/client.ts
+++ b/packages/platform-sdk-eos/src/services/client.ts
@@ -36,7 +36,7 @@ export class ClientService implements Contracts.ClientService {
 
 	// https://developers.eos.io/manuals/eosjs/latest/how-to-guides/how-to-get-table-information
 	public async transactions(
-		query?: Contracts.KeyValuePair,
+		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transactions");
 	}
@@ -46,7 +46,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async wallets(
-		query?: Contracts.KeyValuePair,
+		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "wallets");
 	}

--- a/packages/platform-sdk-eos/src/services/client.ts
+++ b/packages/platform-sdk-eos/src/services/client.ts
@@ -41,12 +41,6 @@ export class ClientService implements Contracts.ClientService {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transactions");
 	}
 
-	public async searchTransactions(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchTransactions");
-	}
-
 	public async wallet(id: string): Promise<Contracts.WalletData> {
 		return new WalletData(await this.#rpc.get_account(id));
 	}
@@ -55,12 +49,6 @@ export class ClientService implements Contracts.ClientService {
 		query?: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "wallets");
-	}
-
-	public async searchWallets(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchWallets");
 	}
 
 	public async delegate(id: string): Promise<Contracts.DelegateData> {

--- a/packages/platform-sdk-eth/src/manifest.ts
+++ b/packages/platform-sdk-eth/src/manifest.ts
@@ -5,10 +5,8 @@ export const manifest = {
 		Client: {
 			transaction: true,
 			transactions: false,
-			searchTransactions: false,
 			wallet: true,
 			wallets: false,
-			searchWallets: false,
 			delegate: false,
 			delegates: false,
 			configuration: false,

--- a/packages/platform-sdk-eth/src/services/client.ts
+++ b/packages/platform-sdk-eth/src/services/client.ts
@@ -27,7 +27,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async transactions(
-		query?: Contracts.KeyValuePair,
+		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
 		const endBlock: number = await this.#connection.eth.getBlockNumber();
 		const startBlock: number = endBlock - (query?.count ?? ClientService.MONTH_IN_SECONDS);
@@ -59,7 +59,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async wallets(
-		query?: Contracts.KeyValuePair,
+		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "wallets");
 	}

--- a/packages/platform-sdk-eth/src/services/client.ts
+++ b/packages/platform-sdk-eth/src/services/client.ts
@@ -52,12 +52,6 @@ export class ClientService implements Contracts.ClientService {
 		return { meta: {}, data: transactions };
 	}
 
-	public async searchTransactions(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchTransactions");
-	}
-
 	public async wallet(id: string): Promise<Contracts.WalletData> {
 		const result = await this.#connection.eth.getBalance(id);
 
@@ -68,12 +62,6 @@ export class ClientService implements Contracts.ClientService {
 		query?: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "wallets");
-	}
-
-	public async searchWallets(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchWallets");
 	}
 
 	public async delegate(id: string): Promise<Contracts.DelegateData> {

--- a/packages/platform-sdk-lsk/__tests__/services/client.test.ts
+++ b/packages/platform-sdk-lsk/__tests__/services/client.test.ts
@@ -26,10 +26,10 @@ describe("ClientService", function () {
 	describe("#transactions", () => {
 		it("should succeed", async () => {
 			nock("https://betanet.lisk.io:443")
-				.get("/api/transactions")
+				.get("/api/transactions?address=6566229458323231555L")
 				.reply(200, require(`${__dirname}/../__fixtures__/client/transactions.json`));
 
-			const result = await subject.transactions();
+			const result = await subject.transactions({ address: '6566229458323231555L' });
 
 			expect(result.data).toBeArray();
 			expect(result.data[0]).toBeInstanceOf(TransactionData);
@@ -51,10 +51,10 @@ describe("ClientService", function () {
 	describe("#wallets", () => {
 		it("should succeed", async () => {
 			nock("https://betanet.lisk.io:443")
-				.get("/api/accounts")
+				.get("/api/accounts?address=6566229458323231555L")
 				.reply(200, require(`${__dirname}/../__fixtures__/client/wallets.json`));
 
-			const result = await subject.wallets();
+			const result = await subject.wallets({ address: '6566229458323231555L' });
 
 			expect(result.data).toBeArray();
 			expect(result.data[0]).toBeInstanceOf(WalletData);

--- a/packages/platform-sdk-lsk/src/manifest.ts
+++ b/packages/platform-sdk-lsk/src/manifest.ts
@@ -5,10 +5,8 @@ export const manifest = {
 		Client: {
 			transaction: true,
 			transactions: true,
-			searchTransactions: false,
 			wallet: true,
 			wallets: true,
-			searchWallets: false,
 			delegate: true,
 			delegates: true,
 			configuration: false,

--- a/packages/platform-sdk-lsk/src/services/client.ts
+++ b/packages/platform-sdk-lsk/src/services/client.ts
@@ -24,7 +24,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async transactions(
-		query?: Contracts.KeyValuePair,
+		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
 		const result = await this.get("transactions", query);
 
@@ -38,7 +38,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async wallets(
-		query?: Contracts.KeyValuePair,
+		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
 		const result = await this.get("accounts", query);
 

--- a/packages/platform-sdk-lsk/src/services/client.ts
+++ b/packages/platform-sdk-lsk/src/services/client.ts
@@ -31,12 +31,6 @@ export class ClientService implements Contracts.ClientService {
 		return { meta: result.meta, data: result.data.map((transaction) => new TransactionData(transaction)) };
 	}
 
-	public async searchTransactions(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchTransactions");
-	}
-
 	public async wallet(id: string): Promise<Contracts.WalletData> {
 		const result = await this.get("accounts", { address: id });
 
@@ -49,12 +43,6 @@ export class ClientService implements Contracts.ClientService {
 		const result = await this.get("accounts", query);
 
 		return { meta: result.meta, data: result.data.map((wallet) => new WalletData(wallet)) };
-	}
-
-	public async searchWallets(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchWallets");
 	}
 
 	public async delegate(id: string): Promise<Contracts.DelegateData> {

--- a/packages/platform-sdk-neo/src/manifest.ts
+++ b/packages/platform-sdk-neo/src/manifest.ts
@@ -5,10 +5,8 @@ export const manifest = {
 		Client: {
 			transaction: false,
 			transactions: false,
-			searchTransactions: false,
 			wallet: false,
 			wallets: false,
-			searchWallets: false,
 			delegate: false,
 			delegates: false,
 			configuration: false,

--- a/packages/platform-sdk-neo/src/services/client.ts
+++ b/packages/platform-sdk-neo/src/services/client.ts
@@ -27,12 +27,6 @@ export class ClientService implements Contracts.ClientService {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transactions");
 	}
 
-	public async searchTransactions(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchTransactions");
-	}
-
 	public async wallet(id: string): Promise<Contracts.WalletData> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "wallet");
 	}
@@ -41,12 +35,6 @@ export class ClientService implements Contracts.ClientService {
 		query?: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "wallets");
-	}
-
-	public async searchWallets(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchWallets");
 	}
 
 	public async delegate(id: string): Promise<Contracts.DelegateData> {

--- a/packages/platform-sdk-neo/src/services/client.ts
+++ b/packages/platform-sdk-neo/src/services/client.ts
@@ -22,7 +22,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async transactions(
-		query?: Contracts.KeyValuePair,
+		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transactions");
 	}
@@ -32,7 +32,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async wallets(
-		query?: Contracts.KeyValuePair,
+		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "wallets");
 	}

--- a/packages/platform-sdk-trx/src/manifest.ts
+++ b/packages/platform-sdk-trx/src/manifest.ts
@@ -5,10 +5,8 @@ export const manifest = {
 		Client: {
 			transaction: true,
 			transactions: false,
-			searchTransactions: false,
 			wallet: true,
 			wallets: false,
-			searchWallets: false,
 			delegate: false,
 			delegates: false,
 			configuration: false,

--- a/packages/platform-sdk-trx/src/services/client.ts
+++ b/packages/platform-sdk-trx/src/services/client.ts
@@ -32,12 +32,6 @@ export class ClientService implements Contracts.ClientService {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transactions");
 	}
 
-	public async searchTransactions(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchTransactions");
-	}
-
 	public async wallet(id: string): Promise<Contracts.WalletData> {
 		const result = await this.#connection.trx.getAccount(id);
 
@@ -48,12 +42,6 @@ export class ClientService implements Contracts.ClientService {
 		query?: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "wallets");
-	}
-
-	public async searchWallets(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchWallets");
 	}
 
 	public async delegate(id: string): Promise<Contracts.DelegateData> {

--- a/packages/platform-sdk-trx/src/services/client.ts
+++ b/packages/platform-sdk-trx/src/services/client.ts
@@ -27,7 +27,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async transactions(
-		query?: Contracts.KeyValuePair,
+		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transactions");
 	}
@@ -39,7 +39,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async wallets(
-		query?: Contracts.KeyValuePair,
+		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "wallets");
 	}

--- a/packages/platform-sdk-xmr/src/manifest.ts
+++ b/packages/platform-sdk-xmr/src/manifest.ts
@@ -5,10 +5,8 @@ export const manifest = {
 		Client: {
 			transaction: false,
 			transactions: false,
-			searchTransactions: false,
 			wallet: false,
 			wallets: false,
-			searchWallets: false,
 			delegate: false,
 			delegates: false,
 			configuration: false,

--- a/packages/platform-sdk-xmr/src/services/client.ts
+++ b/packages/platform-sdk-xmr/src/services/client.ts
@@ -27,12 +27,6 @@ export class ClientService implements Contracts.ClientService {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transactions");
 	}
 
-	public async searchTransactions(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchTransactions");
-	}
-
 	public async wallet(id: string): Promise<Contracts.WalletData> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "wallet");
 	}
@@ -41,12 +35,6 @@ export class ClientService implements Contracts.ClientService {
 		query?: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "wallets");
-	}
-
-	public async searchWallets(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchWallets");
 	}
 
 	public async delegate(id: string): Promise<Contracts.DelegateData> {

--- a/packages/platform-sdk-xmr/src/services/client.ts
+++ b/packages/platform-sdk-xmr/src/services/client.ts
@@ -22,7 +22,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async transactions(
-		query?: Contracts.KeyValuePair,
+		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transactions");
 	}
@@ -32,7 +32,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async wallets(
-		query?: Contracts.KeyValuePair,
+		query: Contracts.KeyValuePair,
 	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "wallets");
 	}

--- a/packages/platform-sdk-xrp/src/manifest.ts
+++ b/packages/platform-sdk-xrp/src/manifest.ts
@@ -5,10 +5,8 @@ export const manifest = {
 		Client: {
 			transaction: false,
 			transactions: false,
-			searchTransactions: false,
 			wallet: false,
 			wallets: false,
-			searchWallets: false,
 			delegate: false,
 			delegates: false,
 			configuration: false,

--- a/packages/platform-sdk-xrp/src/services/client.ts
+++ b/packages/platform-sdk-xrp/src/services/client.ts
@@ -37,12 +37,6 @@ export class ClientService implements Contracts.ClientService {
 		return { meta: {}, data: transactions.map((transaction) => new TransactionData(transaction)) };
 	}
 
-	public async searchTransactions(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.TransactionData>> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchTransactions");
-	}
-
 	public async wallet(id: string): Promise<Contracts.WalletData> {
 		const wallet = await this.#connection.getAccountInfo(id);
 
@@ -51,12 +45,6 @@ export class ClientService implements Contracts.ClientService {
 
 	public async wallets(query?: Contracts.KeyValuePair): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "wallets");
-	}
-
-	public async searchWallets(
-		query: Contracts.KeyValuePair,
-	): Promise<Contracts.CollectionResponse<Contracts.WalletData>> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchWallets");
 	}
 
 	public async delegate(id: string): Promise<Contracts.DelegateData> {

--- a/packages/platform-sdk/src/contracts/coins/client.ts
+++ b/packages/platform-sdk/src/contracts/coins/client.ts
@@ -8,10 +8,10 @@ export interface CollectionResponse<T> {
 
 export interface ClientService {
 	transaction(id: string): Promise<TransactionData>;
-	transactions(query?: KeyValuePair): Promise<CollectionResponse<TransactionData>>;
+	transactions(query: KeyValuePair): Promise<CollectionResponse<TransactionData>>;
 
 	wallet(id: string): Promise<WalletData>;
-	wallets(query?: KeyValuePair): Promise<CollectionResponse<WalletData>>;
+	wallets(query: KeyValuePair): Promise<CollectionResponse<WalletData>>;
 
 	delegate(id: string): Promise<DelegateData>;
 	delegates(query?: KeyValuePair): Promise<CollectionResponse<DelegateData>>;

--- a/packages/platform-sdk/src/contracts/coins/client.ts
+++ b/packages/platform-sdk/src/contracts/coins/client.ts
@@ -9,11 +9,9 @@ export interface CollectionResponse<T> {
 export interface ClientService {
 	transaction(id: string): Promise<TransactionData>;
 	transactions(query?: KeyValuePair): Promise<CollectionResponse<TransactionData>>;
-	searchTransactions(query: KeyValuePair): Promise<CollectionResponse<TransactionData>>;
 
 	wallet(id: string): Promise<WalletData>;
 	wallets(query?: KeyValuePair): Promise<CollectionResponse<WalletData>>;
-	searchWallets(query: KeyValuePair): Promise<CollectionResponse<WalletData>>;
 
 	delegate(id: string): Promise<DelegateData>;
 	delegates(query?: KeyValuePair): Promise<CollectionResponse<DelegateData>>;


### PR DESCRIPTION
> Resolves https://github.com/ArkEcosystem/platform-sdk/issues/102

The `getTransactions` and `getWallets` methods will instead merge their behaviour into themselves.