### PR TITLE
feat: implement `Factory` for each adapter

### DIFF
--- a/packages/platform-sdk-ada/src/services/link.ts
+++ b/packages/platform-sdk-ada/src/services/link.ts
@@ -8,8 +8,16 @@ export class LinkService implements Contracts.LinkService {
 
 	readonly #baseUrl: string;
 
-	public constructor(mode: string) {
+	private constructor(mode: string) {
 		this.#baseUrl = this.#urls[mode];
+	}
+
+	public static async construct(opts: Contracts.KeyValuePair): Promise<LinkService> {
+		return new LinkService(opts.mode);
+	}
+
+	public async destruct(): Promise<void> {
+		//
 	}
 
 	public block(id: string): string {

--- a/packages/platform-sdk-ark/src/factory.ts
+++ b/packages/platform-sdk-ark/src/factory.ts
@@ -1,0 +1,33 @@
+import { Contracts } from "@arkecosystem/platform-sdk";
+
+import {
+	ClientService,
+	IdentityService,
+	LinkService,
+	MessageService,
+	PeerService,
+	TransactionService,
+} from "./services";
+
+export class Factory extends Contracts.AbstractFactory {
+	public static async construct(options: Contracts.FactoryOptions): Promise<Factory> {
+		return new Factory({
+			services: {
+				message: await MessageService.construct(options.services.message),
+				client: await ClientService.construct(options.services.client),
+				identity: await IdentityService.construct(options.services.identity),
+				link: await LinkService.construct(options.services.link),
+				peer: await PeerService.construct(options.services.peer),
+				transaction: await TransactionService.construct(options.services.transaction),
+			},
+		});
+	}
+
+	public async destruct(): Promise<void> {
+		await this.options.services.message.destruct();
+		await this.options.services.client.destruct();
+		await this.options.services.identity.destruct();
+		await this.options.services.peer.destruct();
+		await this.options.services.transaction.destruct();
+	}
+}

--- a/packages/platform-sdk-ark/src/index.ts
+++ b/packages/platform-sdk-ark/src/index.ts
@@ -1,3 +1,3 @@
 export * as DTO from "./dto";
-export * as Services from "./services";
+export * from "./factory";
 export * from "./manifest";

--- a/packages/platform-sdk-ark/src/services/link.ts
+++ b/packages/platform-sdk-ark/src/services/link.ts
@@ -8,8 +8,16 @@ export class LinkService implements Contracts.LinkService {
 
 	readonly #baseUrl: string;
 
-	public constructor(mode: string) {
+	private constructor(mode: string) {
 		this.#baseUrl = this.#urls[mode];
+	}
+
+	public static async construct(opts: Contracts.KeyValuePair): Promise<LinkService> {
+		return new LinkService(opts.mode);
+	}
+
+	public async destruct(): Promise<void> {
+		//
 	}
 
 	public block(id: string): string {

--- a/packages/platform-sdk-atom/src/factory.ts
+++ b/packages/platform-sdk-atom/src/factory.ts
@@ -1,0 +1,33 @@
+import { Contracts } from "@arkecosystem/platform-sdk";
+
+import {
+	ClientService,
+	IdentityService,
+	LinkService,
+	MessageService,
+	PeerService,
+	TransactionService,
+} from "./services";
+
+export class Factory extends Contracts.AbstractFactory {
+	public static async construct(options: Contracts.FactoryOptions): Promise<Factory> {
+		return new Factory({
+			services: {
+				message: await MessageService.construct(options.services.message),
+				client: await ClientService.construct(options.services.client),
+				identity: await IdentityService.construct(options.services.identity),
+				link: await LinkService.construct(options.services.link),
+				peer: await PeerService.construct(options.services.peer),
+				transaction: await TransactionService.construct(options.services.transaction),
+			},
+		});
+	}
+
+	public async destruct(): Promise<void> {
+		await this.options.services.message.destruct();
+		await this.options.services.client.destruct();
+		await this.options.services.identity.destruct();
+		await this.options.services.peer.destruct();
+		await this.options.services.transaction.destruct();
+	}
+}

--- a/packages/platform-sdk-atom/src/index.ts
+++ b/packages/platform-sdk-atom/src/index.ts
@@ -1,3 +1,3 @@
 export * as DTO from "./dto";
-export * as Services from "./services";
+export * from "./factory";
 export * from "./manifest";

--- a/packages/platform-sdk-atom/src/services/link.ts
+++ b/packages/platform-sdk-atom/src/services/link.ts
@@ -8,8 +8,16 @@ export class LinkService implements Contracts.LinkService {
 
 	readonly #baseUrl: string;
 
-	public constructor(mode: string) {
+	private constructor(mode: string) {
 		this.#baseUrl = this.#urls[mode];
+	}
+
+	public static async construct(opts: Contracts.KeyValuePair): Promise<LinkService> {
+		return new LinkService(opts.mode);
+	}
+
+	public async destruct(): Promise<void> {
+		//
 	}
 
 	public block(id: string): string {

--- a/packages/platform-sdk-btc/src/factory.ts
+++ b/packages/platform-sdk-btc/src/factory.ts
@@ -1,0 +1,33 @@
+import { Contracts } from "@arkecosystem/platform-sdk";
+
+import {
+	ClientService,
+	IdentityService,
+	LinkService,
+	MessageService,
+	PeerService,
+	TransactionService,
+} from "./services";
+
+export class Factory extends Contracts.AbstractFactory {
+	public static async construct(options: Contracts.FactoryOptions): Promise<Factory> {
+		return new Factory({
+			services: {
+				message: await MessageService.construct(options.services.message),
+				client: await ClientService.construct(options.services.client),
+				identity: await IdentityService.construct(options.services.identity),
+				link: await LinkService.construct(options.services.link),
+				peer: await PeerService.construct(options.services.peer),
+				transaction: await TransactionService.construct(options.services.transaction),
+			},
+		});
+	}
+
+	public async destruct(): Promise<void> {
+		await this.options.services.message.destruct();
+		await this.options.services.client.destruct();
+		await this.options.services.identity.destruct();
+		await this.options.services.peer.destruct();
+		await this.options.services.transaction.destruct();
+	}
+}

--- a/packages/platform-sdk-btc/src/index.ts
+++ b/packages/platform-sdk-btc/src/index.ts
@@ -1,3 +1,3 @@
 export * as DTO from "./dto";
-export * as Services from "./services";
+export * from "./factory";
 export * from "./manifest";

--- a/packages/platform-sdk-btc/src/services/link.ts
+++ b/packages/platform-sdk-btc/src/services/link.ts
@@ -8,8 +8,16 @@ export class LinkService implements Contracts.LinkService {
 
 	readonly #baseUrl: string;
 
-	public constructor(mode: string) {
+	private constructor(mode: string) {
 		this.#baseUrl = this.#urls[mode];
+	}
+
+	public static async construct(opts: Contracts.KeyValuePair): Promise<LinkService> {
+		return new LinkService(opts.mode);
+	}
+
+	public async destruct(): Promise<void> {
+		//
 	}
 
 	public block(id: string): string {

--- a/packages/platform-sdk-eos/src/factory.ts
+++ b/packages/platform-sdk-eos/src/factory.ts
@@ -1,0 +1,33 @@
+import { Contracts } from "@arkecosystem/platform-sdk";
+
+import {
+	ClientService,
+	IdentityService,
+	LinkService,
+	MessageService,
+	PeerService,
+	TransactionService,
+} from "./services";
+
+export class Factory extends Contracts.AbstractFactory {
+	public static async construct(options: Contracts.FactoryOptions): Promise<Factory> {
+		return new Factory({
+			services: {
+				message: await MessageService.construct(options.services.message),
+				client: await ClientService.construct(options.services.client),
+				identity: await IdentityService.construct(options.services.identity),
+				link: await LinkService.construct(options.services.link),
+				peer: await PeerService.construct(options.services.peer),
+				transaction: await TransactionService.construct(options.services.transaction),
+			},
+		});
+	}
+
+	public async destruct(): Promise<void> {
+		await this.options.services.message.destruct();
+		await this.options.services.client.destruct();
+		await this.options.services.identity.destruct();
+		await this.options.services.peer.destruct();
+		await this.options.services.transaction.destruct();
+	}
+}

--- a/packages/platform-sdk-eos/src/index.ts
+++ b/packages/platform-sdk-eos/src/index.ts
@@ -1,3 +1,3 @@
 export * as DTO from "./dto";
-export * as Services from "./services";
+export * from "./factory";
 export * from "./manifest";

--- a/packages/platform-sdk-eos/src/services/link.ts
+++ b/packages/platform-sdk-eos/src/services/link.ts
@@ -8,8 +8,16 @@ export class LinkService implements Contracts.LinkService {
 
 	readonly #baseUrl: string;
 
-	public constructor(mode: string) {
+	private constructor(mode: string) {
 		this.#baseUrl = this.#urls[mode];
+	}
+
+	public static async construct(opts: Contracts.KeyValuePair): Promise<LinkService> {
+		return new LinkService(opts.mode);
+	}
+
+	public async destruct(): Promise<void> {
+		//
 	}
 
 	public block(id: string): string {

--- a/packages/platform-sdk-eth/src/factory.ts
+++ b/packages/platform-sdk-eth/src/factory.ts
@@ -1,0 +1,33 @@
+import { Contracts } from "@arkecosystem/platform-sdk";
+
+import {
+	ClientService,
+	IdentityService,
+	LinkService,
+	MessageService,
+	PeerService,
+	TransactionService,
+} from "./services";
+
+export class Factory extends Contracts.AbstractFactory {
+	public static async construct(options: Contracts.FactoryOptions): Promise<Factory> {
+		return new Factory({
+			services: {
+				message: await MessageService.construct(options.services.message),
+				client: await ClientService.construct(options.services.client),
+				identity: await IdentityService.construct(options.services.identity),
+				link: await LinkService.construct(options.services.link),
+				peer: await PeerService.construct(options.services.peer),
+				transaction: await TransactionService.construct(options.services.transaction),
+			},
+		});
+	}
+
+	public async destruct(): Promise<void> {
+		await this.options.services.message.destruct();
+		await this.options.services.client.destruct();
+		await this.options.services.identity.destruct();
+		await this.options.services.peer.destruct();
+		await this.options.services.transaction.destruct();
+	}
+}

--- a/packages/platform-sdk-eth/src/index.ts
+++ b/packages/platform-sdk-eth/src/index.ts
@@ -1,3 +1,3 @@
 export * as DTO from "./dto";
-export * as Services from "./services";
+export * from "./factory";
 export * from "./manifest";

--- a/packages/platform-sdk-eth/src/services/link.ts
+++ b/packages/platform-sdk-eth/src/services/link.ts
@@ -8,8 +8,16 @@ export class LinkService implements Contracts.LinkService {
 
 	readonly #baseUrl: string;
 
-	public constructor(mode: string) {
+	private constructor(mode: string) {
 		this.#baseUrl = this.#urls[mode];
+	}
+
+	public static async construct(opts: Contracts.KeyValuePair): Promise<LinkService> {
+		return new LinkService(opts.mode);
+	}
+
+	public async destruct(): Promise<void> {
+		//
 	}
 
 	public block(id: string): string {

--- a/packages/platform-sdk-lsk/src/factory.ts
+++ b/packages/platform-sdk-lsk/src/factory.ts
@@ -1,0 +1,33 @@
+import { Contracts } from "@arkecosystem/platform-sdk";
+
+import {
+	ClientService,
+	IdentityService,
+	LinkService,
+	MessageService,
+	PeerService,
+	TransactionService,
+} from "./services";
+
+export class Factory extends Contracts.AbstractFactory {
+	public static async construct(options: Contracts.FactoryOptions): Promise<Factory> {
+		return new Factory({
+			services: {
+				message: await MessageService.construct(options.services.message),
+				client: await ClientService.construct(options.services.client),
+				identity: await IdentityService.construct(options.services.identity),
+				link: await LinkService.construct(options.services.link),
+				peer: await PeerService.construct(options.services.peer),
+				transaction: await TransactionService.construct(options.services.transaction),
+			},
+		});
+	}
+
+	public async destruct(): Promise<void> {
+		await this.options.services.message.destruct();
+		await this.options.services.client.destruct();
+		await this.options.services.identity.destruct();
+		await this.options.services.peer.destruct();
+		await this.options.services.transaction.destruct();
+	}
+}

--- a/packages/platform-sdk-lsk/src/index.ts
+++ b/packages/platform-sdk-lsk/src/index.ts
@@ -1,3 +1,3 @@
 export * as DTO from "./dto";
-export * as Services from "./services";
+export * from "./factory";
 export * from "./manifest";

--- a/packages/platform-sdk-lsk/src/services/link.ts
+++ b/packages/platform-sdk-lsk/src/services/link.ts
@@ -8,8 +8,16 @@ export class LinkService implements Contracts.LinkService {
 
 	readonly #baseUrl: string;
 
-	public constructor(mode: string) {
+	private constructor(mode: string) {
 		this.#baseUrl = this.#urls[mode];
+	}
+
+	public static async construct(opts: Contracts.KeyValuePair): Promise<LinkService> {
+		return new LinkService(opts.mode);
+	}
+
+	public async destruct(): Promise<void> {
+		//
 	}
 
 	public block(id: string): string {

--- a/packages/platform-sdk-neo/src/factory.ts
+++ b/packages/platform-sdk-neo/src/factory.ts
@@ -1,0 +1,33 @@
+import { Contracts } from "@arkecosystem/platform-sdk";
+
+import {
+	ClientService,
+	IdentityService,
+	LinkService,
+	MessageService,
+	PeerService,
+	TransactionService,
+} from "./services";
+
+export class Factory extends Contracts.AbstractFactory {
+	public static async construct(options: Contracts.FactoryOptions): Promise<Factory> {
+		return new Factory({
+			services: {
+				message: await MessageService.construct(options.services.message),
+				client: await ClientService.construct(options.services.client),
+				identity: await IdentityService.construct(options.services.identity),
+				link: await LinkService.construct(options.services.link),
+				peer: await PeerService.construct(options.services.peer),
+				transaction: await TransactionService.construct(options.services.transaction),
+			},
+		});
+	}
+
+	public async destruct(): Promise<void> {
+		await this.options.services.message.destruct();
+		await this.options.services.client.destruct();
+		await this.options.services.identity.destruct();
+		await this.options.services.peer.destruct();
+		await this.options.services.transaction.destruct();
+	}
+}

--- a/packages/platform-sdk-neo/src/index.ts
+++ b/packages/platform-sdk-neo/src/index.ts
@@ -1,3 +1,3 @@
 export * as DTO from "./dto";
-export * as Services from "./services";
+export * from "./factory";
 export * from "./manifest";

--- a/packages/platform-sdk-neo/src/services/link.ts
+++ b/packages/platform-sdk-neo/src/services/link.ts
@@ -8,8 +8,16 @@ export class LinkService implements Contracts.LinkService {
 
 	readonly #baseUrl: string;
 
-	public constructor(mode: string) {
+	private constructor(mode: string) {
 		this.#baseUrl = this.#urls[mode];
+	}
+
+	public static async construct(opts: Contracts.KeyValuePair): Promise<LinkService> {
+		return new LinkService(opts.mode);
+	}
+
+	public async destruct(): Promise<void> {
+		//
 	}
 
 	public block(id: string): string {

--- a/packages/platform-sdk-trx/src/factory.ts
+++ b/packages/platform-sdk-trx/src/factory.ts
@@ -1,0 +1,33 @@
+import { Contracts } from "@arkecosystem/platform-sdk";
+
+import {
+	ClientService,
+	IdentityService,
+	LinkService,
+	MessageService,
+	PeerService,
+	TransactionService,
+} from "./services";
+
+export class Factory extends Contracts.AbstractFactory {
+	public static async construct(options: Contracts.FactoryOptions): Promise<Factory> {
+		return new Factory({
+			services: {
+				message: await MessageService.construct(options.services.message),
+				client: await ClientService.construct(options.services.client),
+				identity: await IdentityService.construct(options.services.identity),
+				link: await LinkService.construct(options.services.link),
+				peer: await PeerService.construct(options.services.peer),
+				transaction: await TransactionService.construct(options.services.transaction),
+			},
+		});
+	}
+
+	public async destruct(): Promise<void> {
+		await this.options.services.message.destruct();
+		await this.options.services.client.destruct();
+		await this.options.services.identity.destruct();
+		await this.options.services.peer.destruct();
+		await this.options.services.transaction.destruct();
+	}
+}

--- a/packages/platform-sdk-trx/src/index.ts
+++ b/packages/platform-sdk-trx/src/index.ts
@@ -1,3 +1,3 @@
 export * as DTO from "./dto";
-export * as Services from "./services";
+export * from "./factory";
 export * from "./manifest";

--- a/packages/platform-sdk-trx/src/services/link.ts
+++ b/packages/platform-sdk-trx/src/services/link.ts
@@ -8,8 +8,16 @@ export class LinkService implements Contracts.LinkService {
 
 	readonly #baseUrl: string;
 
-	public constructor(mode: string) {
+	private constructor(mode: string) {
 		this.#baseUrl = this.#urls[mode];
+	}
+
+	public static async construct(opts: Contracts.KeyValuePair): Promise<LinkService> {
+		return new LinkService(opts.mode);
+	}
+
+	public async destruct(): Promise<void> {
+		//
 	}
 
 	public block(id: string): string {

--- a/packages/platform-sdk-xmr/src/factory.ts
+++ b/packages/platform-sdk-xmr/src/factory.ts
@@ -1,0 +1,33 @@
+import { Contracts } from "@arkecosystem/platform-sdk";
+
+import {
+	ClientService,
+	IdentityService,
+	LinkService,
+	MessageService,
+	PeerService,
+	TransactionService,
+} from "./services";
+
+export class Factory extends Contracts.AbstractFactory {
+	public static async construct(options: Contracts.FactoryOptions): Promise<Factory> {
+		return new Factory({
+			services: {
+				message: await MessageService.construct(options.services.message),
+				client: await ClientService.construct(options.services.client),
+				identity: await IdentityService.construct(options.services.identity),
+				link: await LinkService.construct(options.services.link),
+				peer: await PeerService.construct(options.services.peer),
+				transaction: await TransactionService.construct(options.services.transaction),
+			},
+		});
+	}
+
+	public async destruct(): Promise<void> {
+		await this.options.services.message.destruct();
+		await this.options.services.client.destruct();
+		await this.options.services.identity.destruct();
+		await this.options.services.peer.destruct();
+		await this.options.services.transaction.destruct();
+	}
+}

--- a/packages/platform-sdk-xmr/src/index.ts
+++ b/packages/platform-sdk-xmr/src/index.ts
@@ -1,3 +1,3 @@
 export * as DTO from "./dto";
-export * as Services from "./services";
+export * from "./factory";
 export * from "./manifest";

--- a/packages/platform-sdk-xmr/src/services/link.ts
+++ b/packages/platform-sdk-xmr/src/services/link.ts
@@ -8,8 +8,16 @@ export class LinkService implements Contracts.LinkService {
 
 	readonly #baseUrl: string;
 
-	public constructor(mode: string) {
+	private constructor(mode: string) {
 		this.#baseUrl = this.#urls[mode];
+	}
+
+	public static async construct(opts: Contracts.KeyValuePair): Promise<LinkService> {
+		return new LinkService(opts.mode);
+	}
+
+	public async destruct(): Promise<void> {
+		//
 	}
 
 	public block(id: string): string {

--- a/packages/platform-sdk-xrp/src/factory.ts
+++ b/packages/platform-sdk-xrp/src/factory.ts
@@ -1,0 +1,33 @@
+import { Contracts } from "@arkecosystem/platform-sdk";
+
+import {
+	ClientService,
+	IdentityService,
+	LinkService,
+	MessageService,
+	PeerService,
+	TransactionService,
+} from "./services";
+
+export class Factory extends Contracts.AbstractFactory {
+	public static async construct(options: Contracts.FactoryOptions): Promise<Factory> {
+		return new Factory({
+			services: {
+				message: await MessageService.construct(options.services.message),
+				client: await ClientService.construct(options.services.client),
+				identity: await IdentityService.construct(options.services.identity),
+				link: await LinkService.construct(options.services.link),
+				peer: await PeerService.construct(options.services.peer),
+				transaction: await TransactionService.construct(options.services.transaction),
+			},
+		});
+	}
+
+	public async destruct(): Promise<void> {
+		await this.options.services.message.destruct();
+		await this.options.services.client.destruct();
+		await this.options.services.identity.destruct();
+		await this.options.services.peer.destruct();
+		await this.options.services.transaction.destruct();
+	}
+}

--- a/packages/platform-sdk-xrp/src/index.ts
+++ b/packages/platform-sdk-xrp/src/index.ts
@@ -1,3 +1,3 @@
 export * as DTO from "./dto";
-export * as Services from "./services";
+export * from "./factory";
 export * from "./manifest";

--- a/packages/platform-sdk-xrp/src/services/link.ts
+++ b/packages/platform-sdk-xrp/src/services/link.ts
@@ -8,8 +8,16 @@ export class LinkService implements Contracts.LinkService {
 
 	readonly #baseUrl: string;
 
-	public constructor(mode: string) {
+	private constructor(mode: string) {
 		this.#baseUrl = this.#urls[mode];
+	}
+
+	public static async construct(opts: Contracts.KeyValuePair): Promise<LinkService> {
+		return new LinkService(opts.mode);
+	}
+
+	public async destruct(): Promise<void> {
+		//
 	}
 
 	public block(id: string): string {

--- a/packages/platform-sdk/src/contracts/coins/client.ts
+++ b/packages/platform-sdk/src/contracts/coins/client.ts
@@ -7,6 +7,8 @@ export interface CollectionResponse<T> {
 }
 
 export interface ClientService {
+	destruct(): Promise<void>;
+
 	transaction(id: string): Promise<TransactionData>;
 	transactions(query: KeyValuePair): Promise<CollectionResponse<TransactionData>>;
 

--- a/packages/platform-sdk/src/contracts/coins/factory.ts
+++ b/packages/platform-sdk/src/contracts/coins/factory.ts
@@ -1,0 +1,51 @@
+import { ClientService, IdentityService, LinkService, MessageService, PeerService, TransactionService } from ".";
+
+interface FactoryConstructorOptions {
+	services: {
+		message: MessageService;
+		client: ClientService;
+		identity: IdentityService;
+		link: LinkService;
+		peer: PeerService;
+		transaction: TransactionService;
+	};
+}
+
+export interface FactoryOptions {
+	services: {
+		message: { peer?: string };
+		client: { peer?: string };
+		identity: { peer?: string };
+		link: { mode: string };
+		peer: { network?: string };
+		transaction: { peer?: string };
+	};
+}
+
+export abstract class AbstractFactory {
+	public constructor(protected readonly options: FactoryConstructorOptions) {}
+
+	public messageService(): MessageService {
+		return this.options.services.message;
+	}
+
+	public clientService(): ClientService {
+		return this.options.services.client;
+	}
+
+	public identityService(): IdentityService {
+		return this.options.services.identity;
+	}
+
+	public linkService(): LinkService {
+		return this.options.services.link;
+	}
+
+	public peerService(): PeerService {
+		return this.options.services.peer;
+	}
+
+	public transactionService(): TransactionService {
+		return this.options.services.transaction;
+	}
+}

--- a/packages/platform-sdk/src/contracts/coins/identity.ts
+++ b/packages/platform-sdk/src/contracts/coins/identity.ts
@@ -1,6 +1,8 @@
 import { KeyValuePair } from "../types";
 
 export interface IdentityService {
+	destruct(): Promise<void>;
+
 	address(opts: KeyValuePair): Promise<string>;
 
 	publicKey(opts: KeyValuePair): Promise<string>;

--- a/packages/platform-sdk/src/contracts/coins/index.ts
+++ b/packages/platform-sdk/src/contracts/coins/index.ts
@@ -1,5 +1,6 @@
 export * from "./client";
 export * from "./data";
+export * from "./factory";
 export * from "./identity";
 export * from "./link";
 export * from "./message";

--- a/packages/platform-sdk/src/contracts/coins/link.ts
+++ b/packages/platform-sdk/src/contracts/coins/link.ts
@@ -1,4 +1,6 @@
 export interface LinkService {
+	destruct(): Promise<void>;
+
 	block(id: string): string;
 
 	transaction(id: string): string;

--- a/packages/platform-sdk/src/contracts/coins/message.ts
+++ b/packages/platform-sdk/src/contracts/coins/message.ts
@@ -1,4 +1,6 @@
 export interface MessageService {
+	destruct(): Promise<void>;
+
 	sign(input: MessageInput): Promise<SignedMessage>;
 
 	verify(input: SignedMessage): Promise<boolean>;

--- a/packages/platform-sdk/src/contracts/coins/peer.ts
+++ b/packages/platform-sdk/src/contracts/coins/peer.ts
@@ -17,6 +17,8 @@ export interface PeerResponse {
 }
 
 export interface PeerService {
+	destruct(): Promise<void>;
+
 	getSeeds(): Peer[];
 
 	withVersion(version: string): PeerService;

--- a/packages/platform-sdk/src/contracts/coins/transaction.ts
+++ b/packages/platform-sdk/src/contracts/coins/transaction.ts
@@ -2,6 +2,7 @@
 export type SignedTransaction = any;
 
 export interface TransactionService {
+	destruct(): Promise<void>;
 	transfer(data: TransferInput): Promise<SignedTransaction>;
 	secondSignature(data: SecondSignatureInput): Promise<SignedTransaction>;
 	delegateRegistration(data: DelegateRegistrationInput): Promise<SignedTransaction>;


### PR DESCRIPTION
> Resolves https://github.com/ArkEcosystem/platform-sdk/issues/99

Each adapter exports a `Factory` class which can be used to create an instance of all underlying services. **Services itself are no longer exported, the factory has to be used.**