### PR TITLE
refactor: remove `ClientService#configuration`

### DIFF
--- a/packages/platform-sdk-ark/__tests__/__fixtures__/client/syncing.json
+++ b/packages/platform-sdk-ark/__tests__/__fixtures__/client/syncing.json
@@ -2,7 +2,7 @@
 	"data": {
 		"syncing": false,
 		"blocks": 0,
-		"height": 4648261,
+		"height": 4006000,
 		"id": "2f52baaf394231746f7c358f43abff6cad4f4cdb64b61d69555110bc3a9f5e46"
 	}
 }

--- a/packages/platform-sdk-ark/__tests__/services/client.test.ts
+++ b/packages/platform-sdk-ark/__tests__/services/client.test.ts
@@ -116,20 +116,6 @@ describe("ClientService", function () {
 		});
 	});
 
-	describe("#configuration", () => {
-		it("should succeed", async () => {
-			nock("https://dexplorer.ark.io/api")
-				.get("/node/configuration")
-				.reply(200, require(`${__dirname}/../__fixtures__/client/configuration.json`))
-				.get("/node/configuration/crypto")
-				.reply(200, require(`${__dirname}/../__fixtures__/client/cryptoConfiguration.json`));
-
-			const result = await subject.configuration();
-
-			expect(result).toBeObject();
-		});
-	});
-
 	describe("#syncing", () => {
 		it("should succeed", async () => {
 			nock("https://dexplorer.ark.io/api")

--- a/packages/platform-sdk-ark/__tests__/services/transaction.test.ts
+++ b/packages/platform-sdk-ark/__tests__/services/transaction.test.ts
@@ -1,11 +1,25 @@
 import "jest-extended";
 import { Transactions } from "@arkecosystem/crypto";
+import nock from "nock";
 
 import { TransactionService } from "../../src/services/transaction";
 
 let subject: TransactionService;
 
-beforeEach(async () => (subject = await TransactionService.construct({ network: "devnet" })));
+beforeEach(async () => {
+	nock("https://dexplorer.ark.io/api")
+		.get("/node/configuration/crypto")
+		.reply(200, require(`${__dirname}/../__fixtures__/client/cryptoConfiguration.json`))
+		.get("/node/syncing")
+		.reply(200, require(`${__dirname}/../__fixtures__/client/syncing.json`))
+		.persist();
+
+	subject = await TransactionService.construct({ peer: "https://dexplorer.ark.io/api" });
+});
+
+afterEach(() => nock.cleanAll());
+
+beforeAll(() => nock.disableNetConnect());
 
 describe("TransactionService", () => {
 	describe("#transfer", () => {

--- a/packages/platform-sdk-ark/src/services/client.ts
+++ b/packages/platform-sdk-ark/src/services/client.ts
@@ -70,16 +70,6 @@ export class ClientService implements Contracts.ClientService {
 		return { meta: body.meta, data: body.data.map((wallet) => new WalletData(wallet)) };
 	}
 
-	public async configuration(): Promise<Contracts.KeyValuePair> {
-		const node = await this.connection.api("node").configuration();
-		const crypto = await this.connection.api("node").crypto();
-
-		return {
-			node: node.body.data,
-			crypto: crypto.body.data,
-		};
-	}
-
 	public async syncing(): Promise<boolean> {
 		const { body } = await this.connection.api("node").syncing();
 

--- a/packages/platform-sdk-ark/src/services/transaction.ts
+++ b/packages/platform-sdk-ark/src/services/transaction.ts
@@ -1,10 +1,16 @@
+import { Connection } from "@arkecosystem/client";
 import { Managers, Transactions } from "@arkecosystem/crypto";
 import { Contracts } from "@arkecosystem/platform-sdk";
 
 export class TransactionService implements Contracts.TransactionService {
 	public static async construct(opts: Contracts.KeyValuePair): Promise<TransactionService> {
-		Managers.configManager.setFromPreset(opts.network === "live" ? "mainnet" : "devnet");
-		Managers.configManager.setHeight(10_000_000); // todo: determine this automatically
+		const connection = new Connection(opts.peer);
+
+		const { body: config } = await connection.api("node").crypto();
+		Managers.configManager.setConfig(config.data as any);
+
+		const { body: status } = await connection.api("node").syncing();
+		Managers.configManager.setHeight(status.data.height);
 
 		return new TransactionService();
 	}

--- a/packages/platform-sdk-atom/src/services/client.ts
+++ b/packages/platform-sdk-atom/src/services/client.ts
@@ -64,10 +64,6 @@ export class ClientService implements Contracts.ClientService {
 		throw new Exceptions.NotImplemented(this.constructor.name, "voters");
 	}
 
-	public async configuration(): Promise<Contracts.KeyValuePair> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "configuration");
-	}
-
 	public async syncing(): Promise<boolean> {
 		const { syncing } = await this.get("syncing");
 

--- a/packages/platform-sdk-atom/src/services/identity.ts
+++ b/packages/platform-sdk-atom/src/services/identity.ts
@@ -3,6 +3,7 @@ import { secp256k1 } from "bcrypto";
 import bech32 from "bech32";
 import * as bip32 from "bip32";
 import * as bip39 from "bip39";
+
 import { manifest } from "../manifest";
 
 export class IdentityService implements Contracts.IdentityService {
@@ -20,7 +21,7 @@ export class IdentityService implements Contracts.IdentityService {
 		if (input.passphrase) {
 			const seed = await bip39.mnemonicToSeed(input.passphrase);
 			const node = bip32.fromSeed(seed);
-			const child = node.derivePath(manifest.derivePath);
+			const child = node.derivePath(manifest.derivePath + "0");
 			const words = bech32.toWords(child.identifier);
 
 			return bech32.encode(this.#bech32Prefix, words);
@@ -96,7 +97,7 @@ export class IdentityService implements Contracts.IdentityService {
 	public async keyPair(input: Contracts.KeyPairInput): Promise<Contracts.KeyPair> {
 		if (input.passphrase) {
 			const masterKey = this.deriveMasterKey(input.passphrase);
-			const privateKey: Buffer | undefined = masterKey.derivePath(manifest.derivePath).privateKey;
+			const privateKey: Buffer | undefined = masterKey.derivePath(manifest.derivePath + "0").privateKey;
 
 			if (!privateKey) {
 				throw new Error("Failed to derive private key.");

--- a/packages/platform-sdk-btc/src/services/client.ts
+++ b/packages/platform-sdk-btc/src/services/client.ts
@@ -53,10 +53,6 @@ export class ClientService implements Contracts.ClientService {
 		throw new Exceptions.NotImplemented(this.constructor.name, "voters");
 	}
 
-	public async configuration(): Promise<Contracts.KeyValuePair> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "searchBlocks");
-	}
-
 	public async syncing(): Promise<boolean> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "syncing");
 	}

--- a/packages/platform-sdk-eos/src/services/client.ts
+++ b/packages/platform-sdk-eos/src/services/client.ts
@@ -67,10 +67,6 @@ export class ClientService implements Contracts.ClientService {
 		throw new Exceptions.NotImplemented(this.constructor.name, "voters");
 	}
 
-	public async configuration(): Promise<Contracts.KeyValuePair> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "configuration");
-	}
-
 	public async syncing(): Promise<boolean> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "syncing");
 	}

--- a/packages/platform-sdk-eth/src/services/client.ts
+++ b/packages/platform-sdk-eth/src/services/client.ts
@@ -75,10 +75,6 @@ export class ClientService implements Contracts.ClientService {
 		throw new Exceptions.NotImplemented(this.constructor.name, "voters");
 	}
 
-	public async configuration(): Promise<Contracts.KeyValuePair> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "configuration");
-	}
-
 	public async syncing(): Promise<boolean> {
 		return (await this.get("status")).syncing === false;
 	}

--- a/packages/platform-sdk-lsk/src/services/client.ts
+++ b/packages/platform-sdk-lsk/src/services/client.ts
@@ -65,10 +65,6 @@ export class ClientService implements Contracts.ClientService {
 		throw new Exceptions.NotImplemented(this.constructor.name, "voters");
 	}
 
-	public async configuration(): Promise<Contracts.KeyValuePair> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "configuration");
-	}
-
 	public async syncing(): Promise<boolean> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "syncing");
 	}

--- a/packages/platform-sdk-neo/src/services/client.ts
+++ b/packages/platform-sdk-neo/src/services/client.ts
@@ -53,10 +53,6 @@ export class ClientService implements Contracts.ClientService {
 		throw new Exceptions.NotImplemented(this.constructor.name, "voters");
 	}
 
-	public async configuration(): Promise<Contracts.KeyValuePair> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "configuration");
-	}
-
 	public async syncing(): Promise<boolean> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "syncing");
 	}

--- a/packages/platform-sdk-trx/src/services/client.ts
+++ b/packages/platform-sdk-trx/src/services/client.ts
@@ -60,10 +60,6 @@ export class ClientService implements Contracts.ClientService {
 		throw new Exceptions.NotImplemented(this.constructor.name, "voters");
 	}
 
-	public async configuration(): Promise<Contracts.KeyValuePair> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "configuration");
-	}
-
 	public async syncing(): Promise<boolean> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "syncing");
 	}

--- a/packages/platform-sdk-xmr/src/services/client.ts
+++ b/packages/platform-sdk-xmr/src/services/client.ts
@@ -53,10 +53,6 @@ export class ClientService implements Contracts.ClientService {
 		throw new Exceptions.NotImplemented(this.constructor.name, "voters");
 	}
 
-	public async configuration(): Promise<Contracts.KeyValuePair> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "configuration");
-	}
-
 	public async syncing(): Promise<boolean> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "syncing");
 	}

--- a/packages/platform-sdk-xrp/src/services/client.ts
+++ b/packages/platform-sdk-xrp/src/services/client.ts
@@ -65,10 +65,6 @@ export class ClientService implements Contracts.ClientService {
 		throw new Exceptions.NotImplemented(this.constructor.name, "voters");
 	}
 
-	public async configuration(): Promise<Contracts.KeyValuePair> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "configuration");
-	}
-
 	public async syncing(): Promise<boolean> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "syncing");
 	}

--- a/packages/platform-sdk/src/contracts/coins/client.ts
+++ b/packages/platform-sdk/src/contracts/coins/client.ts
@@ -21,8 +21,6 @@ export interface ClientService {
 	votes(id: string): Promise<CollectionResponse<TransactionData>>;
 	voters(id: string): Promise<CollectionResponse<WalletData>>;
 
-	configuration(): Promise<KeyValuePair>;
-
 	syncing(): Promise<boolean>;
 
 	broadcast(transactions: object[]): Promise<void>;


### PR DESCRIPTION
> Resolves https://github.com/ArkEcosystem/platform-sdk/issues/127

The ARK crypto package is now autoconfigured based on the peer that is being used initially.