### PR TITLE
fix: utc declaration for dayjs

### DIFF
--- a/packages/platform-sdk/src/utils/dayjs.ts
+++ b/packages/platform-sdk/src/utils/dayjs.ts
@@ -2,6 +2,7 @@ import day from "dayjs";
 import advancedFormat from "dayjs/plugin/advancedFormat";
 import localizedFormat from "dayjs/plugin/localizedFormat";
 import utc from "dayjs/plugin/utc";
+import "dayjs/plugin/utc";
 
 day.extend(advancedFormat);
 day.extend(localizedFormat);


### PR DESCRIPTION
## Summary

Importing the plugin globally forces the compiler to add it to the declaration file.

Fixes #110 

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
