### PR TITLE
refactor: always treat `nonce` as `BigNumber`

### DIFF
--- a/docs/coins/index.md
+++ b/docs/coins/index.md
@@ -3,13 +3,14 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
--   [Architecture](#architecture)
-    -   [Contracts](#contracts)
-    -   [Not Supported](#not-supported)
-    -   [Not Implemented](#not-implemented)
-    -   [Async Operations](#async-operations)
--   [Functionality](#functionality)
--   [API Methods](#api-methods)
+
+- [Architecture](#architecture)
+  - [Contracts](#contracts)
+  - [Not Supported](#not-supported)
+  - [Not Implemented](#not-implemented)
+  - [Async Operations](#async-operations)
+- [Functionality](#functionality)
+- [API Methods](#api-methods)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/packages/platform-sdk-ark/__tests__/dto/transaction.test.ts
+++ b/packages/platform-sdk-ark/__tests__/dto/transaction.test.ts
@@ -30,7 +30,7 @@ describe("TransactionData", function () {
 	});
 
 	test("#nonce", () => {
-		expect(subject.nonce()).toBe("1");
+		expect(subject.nonce()).toEqual(BigNumber.make(1));
 	});
 
 	test("#sender", () => {

--- a/packages/platform-sdk-ark/src/dto/transaction.ts
+++ b/packages/platform-sdk-ark/src/dto/transaction.ts
@@ -22,8 +22,8 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return BigNumber.make(this.data.confirmations);
 	}
 
-	public nonce(): string | undefined {
-		return this.data.nonce;
+	public nonce(): BigNumber {
+		return BigNumber.make(this.data.nonce);
 	}
 
 	public sender(): string {

--- a/packages/platform-sdk-atom/__tests__/dto/transaction.test.ts
+++ b/packages/platform-sdk-atom/__tests__/dto/transaction.test.ts
@@ -15,7 +15,7 @@ describe("TransactionData", function () {
 		expect(result.typeGroup()).toBeUndefined();
 		expect(result.timestamp()).toBe(1576957341000);
 		expect(result.confirmations()).toEqual(BigNumber.ZERO);
-		expect(result.nonce()).toBeUndefined();
+		expect(result.nonce()).toEqual(BigNumber.ZERO);
 		expect(result.sender()).toBe("cosmos1de7pk372jkp9vrul0gv5j6r3l9mt3wa6m4h6h0");
 		expect(result.recipient()).toBe("cosmos14ddvyl5t0hzmknceuv3zzu5szuum4rkygpq5ln");
 		expect(result.amount()).toEqual(BigNumber.make(10680));

--- a/packages/platform-sdk-atom/__tests__/services/client.test.ts
+++ b/packages/platform-sdk-atom/__tests__/services/client.test.ts
@@ -29,7 +29,7 @@ describe("ClientService", function () {
 			expect(result.typeGroup()).toBeUndefined();
 			expect(result.timestamp()).toBe(1576957341000);
 			expect(result.confirmations()).toEqual(BigNumber.ZERO);
-			expect(result.nonce()).toBeUndefined();
+			expect(result.nonce()).toEqual(BigNumber.ZERO);
 			expect(result.sender()).toBe("cosmos1de7pk372jkp9vrul0gv5j6r3l9mt3wa6m4h6h0");
 			expect(result.recipient()).toBe("cosmos14ddvyl5t0hzmknceuv3zzu5szuum4rkygpq5ln");
 			expect(result.amount()).toEqual(BigNumber.make(10680));
@@ -56,7 +56,7 @@ describe("ClientService", function () {
 			expect(result.data[0].typeGroup()).toBeUndefined();
 			expect(result.data[0].timestamp()).toBe(1576957341000);
 			expect(result.data[0].confirmations()).toEqual(BigNumber.ZERO);
-			expect(result.data[0].nonce()).toBeUndefined();
+			expect(result.data[0].nonce()).toEqual(BigNumber.ZERO);
 			expect(result.data[0].sender()).toBe("cosmos1de7pk372jkp9vrul0gv5j6r3l9mt3wa6m4h6h0");
 			expect(result.data[0].recipient()).toBe("cosmos14ddvyl5t0hzmknceuv3zzu5szuum4rkygpq5ln");
 			expect(result.data[0].amount()).toEqual(BigNumber.make(10680));

--- a/packages/platform-sdk-atom/src/dto/transaction.ts
+++ b/packages/platform-sdk-atom/src/dto/transaction.ts
@@ -22,8 +22,8 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return BigNumber.ZERO;
 	}
 
-	public nonce(): string | undefined {
-		return undefined;
+	public nonce(): BigNumber {
+		return BigNumber.ZERO;
 	}
 
 	public sender(): string {

--- a/packages/platform-sdk-btc/__tests__/dto/transaction.test.ts
+++ b/packages/platform-sdk-btc/__tests__/dto/transaction.test.ts
@@ -15,7 +15,7 @@ describe("TransactionData", function () {
 		expect(result.typeGroup()).toBeUndefined();
 		expect(result.timestamp()).toBe(1561095453000);
 		expect(result.confirmations()).toEqual(BigNumber.make(159414));
-		// expect(result.nonce()).toBe("...");
+		expect(result.nonce()).toEqual(BigNumber.ZERO);
 		// expect(result.sender()).toBe("...");
 		// expect(result.recipient()).toBe("...");
 		expect(result.amount()).toEqual(BigNumber.make(3050000));

--- a/packages/platform-sdk-btc/__tests__/services/client.test.ts
+++ b/packages/platform-sdk-btc/__tests__/services/client.test.ts
@@ -30,7 +30,7 @@ describe("ClientService", function () {
 			expect(result.typeGroup()).toBeUndefined();
 			expect(result.timestamp()).toBe(1561095453000);
 			expect(result.confirmations()).toEqual(BigNumber.make(159414));
-			// expect(result.nonce()).toBe("...");
+			expect(result.nonce()).toEqual(BigNumber.ZERO);
 			// expect(result.sender()).toBe("...");
 			// expect(result.recipient()).toBe("...");
 			expect(result.amount()).toEqual(BigNumber.make(3050000));

--- a/packages/platform-sdk-btc/src/dto/transaction.ts
+++ b/packages/platform-sdk-btc/src/dto/transaction.ts
@@ -22,8 +22,8 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return BigNumber.make(this.data.confirmations);
 	}
 
-	public nonce(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "nonce");
+	public nonce(): BigNumber {
+		return BigNumber.ZERO;
 	}
 
 	public sender(): string {

--- a/packages/platform-sdk-eos/src/dto/transaction.ts
+++ b/packages/platform-sdk-eos/src/dto/transaction.ts
@@ -22,8 +22,8 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return BigNumber.make(0);
 	}
 
-	public nonce(): string {
-		return this.data.nonce;
+	public nonce(): BigNumber {
+		return BigNumber.make(this.data.nonce);
 	}
 
 	public sender(): string {

--- a/packages/platform-sdk-eth/__tests__/dto/transaction.test.ts
+++ b/packages/platform-sdk-eth/__tests__/dto/transaction.test.ts
@@ -30,7 +30,7 @@ describe("TransactionData", function () {
 	});
 
 	test("#nonce", () => {
-		expect(subject.nonce()).toBe(0);
+		expect(subject.nonce()).toEqual(BigNumber.ZERO);
 	});
 
 	test("#sender", () => {

--- a/packages/platform-sdk-eth/__tests__/services/client.test.ts
+++ b/packages/platform-sdk-eth/__tests__/services/client.test.ts
@@ -30,7 +30,7 @@ describe("ClientService", function () {
 			expect(result.typeGroup()).toBeUndefined();
 			expect(result.timestamp()).toBeUndefined();
 			expect(result.confirmations()).toEqual(BigNumber.ZERO);
-			expect(result.nonce()).toBe(0);
+			expect(result.nonce()).toEqual(BigNumber.ZERO);
 			expect(result.sender()).toBe("0x4581A610f96878266008993475F1476cA9997081");
 			expect(result.recipient()).toBe("0x230b2A8C0CcE28fd6eFF491c47aeBa244b10A12c");
 			expect(result.amount()).toEqual(BigNumber.make("79000000000000"));

--- a/packages/platform-sdk-eth/src/dto/transaction.ts
+++ b/packages/platform-sdk-eth/src/dto/transaction.ts
@@ -22,8 +22,8 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return BigNumber.make(0);
 	}
 
-	public nonce(): string {
-		return this.data.nonce;
+	public nonce(): BigNumber {
+		return BigNumber.make(parseInt(this.data.nonce, 16));
 	}
 
 	public sender(): string {

--- a/packages/platform-sdk-lsk/__tests__/dto/transaction.test.ts
+++ b/packages/platform-sdk-lsk/__tests__/dto/transaction.test.ts
@@ -30,7 +30,7 @@ describe("TransactionData", function () {
 	});
 
 	test("#nonce", () => {
-		expect(subject.nonce()).toBeUndefined();
+		expect(subject.nonce()).toEqual(BigNumber.ZERO);
 	});
 
 	test("#sender", () => {

--- a/packages/platform-sdk-lsk/src/dto/transaction.ts
+++ b/packages/platform-sdk-lsk/src/dto/transaction.ts
@@ -22,8 +22,8 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return BigNumber.make(this.data.confirmations);
 	}
 
-	public nonce(): string | undefined {
-		return this.data.nonce;
+	public nonce(): BigNumber {
+		return BigNumber.make(this.data.nonce);
 	}
 
 	public sender(): string {

--- a/packages/platform-sdk-lsk/src/dto/transaction.ts
+++ b/packages/platform-sdk-lsk/src/dto/transaction.ts
@@ -23,7 +23,7 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 	}
 
 	public nonce(): BigNumber {
-		return BigNumber.make(this.data.nonce);
+		return BigNumber.ZERO;
 	}
 
 	public sender(): string {

--- a/packages/platform-sdk-neo/__tests__/dto/transaction.test.ts
+++ b/packages/platform-sdk-neo/__tests__/dto/transaction.test.ts
@@ -22,7 +22,7 @@ describe("TransactionData", function () {
 		// expect(result.typeGroup()).toBeUndefined();
 		expect(result.timestamp()).toBe(1588930966);
 		expect(result.confirmations()).toEqual(BigNumber.ZERO);
-		// expect(result.nonce()).toBe("...");
+		expect(result.nonce()).toEqual(BigNumber.ZERO);
 		expect(result.sender()).toBe("AStJyBXGGBK6bwrRfRUHSjp993PB5C9QgF");
 		expect(result.recipient()).toBe("Ab9QkPeMzx7ehptvjbjHviAXUfdhAmEAUF");
 		expect(result.amount()).toEqual(BigNumber.make(1));

--- a/packages/platform-sdk-neo/__tests__/services/client.test.ts
+++ b/packages/platform-sdk-neo/__tests__/services/client.test.ts
@@ -29,7 +29,7 @@ describe("ClientService", function () {
 			// expect(result.data[0].typeGroup()).toBeUndefined();
 			expect(result.data[0].timestamp()).toBe(1588930966);
 			expect(result.data[0].confirmations()).toEqual(BigNumber.ZERO);
-			// expect(result.data[0].nonce()).toBe("...");
+			expect(result.data[0].nonce()).toEqual(BigNumber.ZERO);
 			expect(result.data[0].sender()).toBe("AStJyBXGGBK6bwrRfRUHSjp993PB5C9QgF");
 			expect(result.data[0].recipient()).toBe("Ab9QkPeMzx7ehptvjbjHviAXUfdhAmEAUF");
 			expect(result.data[0].amount()).toEqual(BigNumber.make(1));

--- a/packages/platform-sdk-neo/src/dto/transaction.ts
+++ b/packages/platform-sdk-neo/src/dto/transaction.ts
@@ -22,8 +22,8 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return BigNumber.ZERO;
 	}
 
-	public nonce(): string | undefined {
-		return "0";
+	public nonce(): BigNumber {
+		return BigNumber.ZERO;
 	}
 
 	public sender(): string {

--- a/packages/platform-sdk-trx/src/dto/transaction.ts
+++ b/packages/platform-sdk-trx/src/dto/transaction.ts
@@ -22,7 +22,7 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		throw new Exceptions.NotImplemented(this.constructor.name, "confirmations");
 	}
 
-	public nonce(): string {
+	public nonce(): BigNumber {
 		throw new Exceptions.NotImplemented(this.constructor.name, "nonce");
 	}
 

--- a/packages/platform-sdk-xlm/__tests__/services/client.test.ts
+++ b/packages/platform-sdk-xlm/__tests__/services/client.test.ts
@@ -36,7 +36,7 @@ describe("ClientService", function () {
 			// expect(result.typeGroup()).toBeUndefined();
 			expect(result.timestamp()).toBe(1554840865000);
 			// expect(result.confirmations()).toEqual(BigNumber.make(159414));
-			expect(result.nonce()).toBe("4660039994869");
+			expect(result.nonce()).toEqual(BigNumber.make("4660039994869"));
 			expect(result.sender()).toBe("GAHXEI3BVFOBDHWLC4TJKCGTLY6VMTKMRRWWPKNPPULUC7E3PD63ENKO");
 			expect(result.recipient()).toBe("GB2V4J7WTTKLIN5O3QPUAQCOLLIIULJM3FHHAQ7GEQ5EH53BXXQ47HU3");
 			expect(result.amount()).toEqual(BigNumber.make("100000000"));
@@ -64,7 +64,7 @@ describe("ClientService", function () {
 			// expect(data[0].typeGroup()).toBeUndefined();
 			expect(data[0].timestamp()).toBe(1554505662000);
 			// expect(data[0].confirmations()).toEqual(BigNumber.make(159414));
-			// expect(data[0].nonce()).toBe("4660039994869");
+			expect(data[0].nonce()).toEqual(BigNumber.ZERO);
 			expect(data[0].sender()).toBe("GAGLYFZJMN5HEULSTH5CIGPOPAVUYPG5YSWIYDJMAPIECYEBPM2TA3QR");
 			expect(data[0].recipient()).toBe("GBYUUJHG6F4EPJGNLERINATVQLNDOFRUD7SGJZ26YZLG5PAYLG7XUSGF");
 			expect(data[0].amount()).toEqual(BigNumber.make("100000000000000"));

--- a/packages/platform-sdk-xlm/src/dto/transaction.ts
+++ b/packages/platform-sdk-xlm/src/dto/transaction.ts
@@ -23,8 +23,8 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 	}
 
 	// todo: with the "transaction" method we get a nonce but with "transactions" it isn't available
-	public nonce(): string | undefined {
-		return this.data.source_account_sequence;
+	public nonce(): BigNumber {
+		return BigNumber.make(this.data.source_account_sequence);
 	}
 
 	public sender(): string {

--- a/packages/platform-sdk-xlm/src/dto/transaction.ts
+++ b/packages/platform-sdk-xlm/src/dto/transaction.ts
@@ -24,7 +24,11 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 
 	// todo: with the "transaction" method we get a nonce but with "transactions" it isn't available
 	public nonce(): BigNumber {
-		return BigNumber.make(this.data.source_account_sequence);
+		if (this.data.source_account_sequence) {
+			return BigNumber.make(this.data.source_account_sequence);
+		}
+
+		return BigNumber.ZERO;
 	}
 
 	public sender(): string {

--- a/packages/platform-sdk-xmr/src/dto/transaction.ts
+++ b/packages/platform-sdk-xmr/src/dto/transaction.ts
@@ -22,7 +22,7 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		throw new Exceptions.NotImplemented(this.constructor.name, "confirmations");
 	}
 
-	public nonce(): string | undefined {
+	public nonce(): BigNumber {
 		throw new Exceptions.NotImplemented(this.constructor.name, "nonce");
 	}
 

--- a/packages/platform-sdk-xrp/__tests__/dto/transaction.test.ts
+++ b/packages/platform-sdk-xrp/__tests__/dto/transaction.test.ts
@@ -15,7 +15,7 @@ describe("TransactionData", function () {
 		// expect(result.typeGroup()).toBeUndefined();
 		expect(result.timestamp()).toBe(1363132610000);
 		expect(result.confirmations()).toEqual(BigNumber.ZERO);
-		expect(result.nonce()).toBe(4);
+		expect(result.nonce()).toEqual(BigNumber.make(4));
 		expect(result.sender()).toBe("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59");
 		expect(result.recipient()).toBe("rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM");
 		expect(result.amount()).toEqual(BigNumber.make(100000));

--- a/packages/platform-sdk-xrp/__tests__/services/client.test.ts
+++ b/packages/platform-sdk-xrp/__tests__/services/client.test.ts
@@ -98,7 +98,7 @@ describe("ClientService", function () {
 			// expect(result.typeGroup()).toBeUndefined();
 			expect(result.timestamp()).toBe(1363132610000);
 			expect(result.confirmations()).toEqual(BigNumber.ZERO);
-			expect(result.nonce()).toBe(4);
+			expect(result.nonce()).toEqual(BigNumber.make(4));
 			expect(result.sender()).toBe("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59");
 			expect(result.recipient()).toBe("rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM");
 			expect(result.amount()).toEqual(BigNumber.make(100000));

--- a/packages/platform-sdk-xrp/src/dto/transaction.ts
+++ b/packages/platform-sdk-xrp/src/dto/transaction.ts
@@ -23,8 +23,8 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return BigNumber.ZERO;
 	}
 
-	public nonce(): string | undefined {
-		return this.data.sequence;
+	public nonce(): BigNumber {
+		return BigNumber.make(this.data.sequence);
 	}
 
 	public sender(): string {

--- a/packages/platform-sdk/src/contracts/coins/data.ts
+++ b/packages/platform-sdk/src/contracts/coins/data.ts
@@ -13,7 +13,7 @@ export interface TransactionData {
 
 	confirmations(): BigNumber;
 
-	nonce(): string | undefined;
+	nonce(): BigNumber;
 
 	sender(): string;
 

--- a/packages/platform-sdk/src/dto/transaction.ts
+++ b/packages/platform-sdk/src/dto/transaction.ts
@@ -15,7 +15,7 @@ export abstract class AbstractTransactionData {
 
 	abstract confirmations(): BigNumber;
 
-	abstract nonce(): string | undefined;
+	abstract nonce(): BigNumber;
 
 	abstract sender(): string;
 


### PR DESCRIPTION
> Resolves https://github.com/ArkEcosystem/platform-sdk/issues/195