### PR TITLE
refactor: remove `TransactionData#nonce` method

### DIFF
--- a/packages/platform-sdk-ark/__tests__/dto/transaction.test.ts
+++ b/packages/platform-sdk-ark/__tests__/dto/transaction.test.ts
@@ -29,10 +29,6 @@ describe("TransactionData", function () {
 		expect(subject.confirmations()).toEqual(Utils.BigNumber.make(4636121));
 	});
 
-	test("#nonce", () => {
-		expect(subject.nonce()).toEqual(Utils.BigNumber.make(1));
-	});
-
 	test("#sender", () => {
 		expect(subject.sender()).toBe("0208e6835a8f020cfad439c059b89addc1ce21f8cab0af6e6957e22d3720bff8a4");
 	});

--- a/packages/platform-sdk-ark/src/dto/transaction.ts
+++ b/packages/platform-sdk-ark/src/dto/transaction.ts
@@ -22,10 +22,6 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return Utils.BigNumber.make(this.data.confirmations);
 	}
 
-	public nonce(): Utils.BigNumber {
-		return Utils.BigNumber.make(this.data.nonce);
-	}
-
 	public sender(): string {
 		return this.data.senderPublicKey;
 	}

--- a/packages/platform-sdk-atom/__tests__/dto/transaction.test.ts
+++ b/packages/platform-sdk-atom/__tests__/dto/transaction.test.ts
@@ -15,7 +15,6 @@ describe("TransactionData", function () {
 		expect(result.typeGroup()).toBeUndefined();
 		expect(result.timestamp()).toBe(1576957341000);
 		expect(result.confirmations()).toEqual(Utils.BigNumber.ZERO);
-		expect(result.nonce()).toEqual(Utils.BigNumber.ZERO);
 		expect(result.sender()).toBe("cosmos1de7pk372jkp9vrul0gv5j6r3l9mt3wa6m4h6h0");
 		expect(result.recipient()).toBe("cosmos14ddvyl5t0hzmknceuv3zzu5szuum4rkygpq5ln");
 		expect(result.amount()).toEqual(Utils.BigNumber.make(10680));

--- a/packages/platform-sdk-atom/__tests__/services/client.test.ts
+++ b/packages/platform-sdk-atom/__tests__/services/client.test.ts
@@ -29,7 +29,6 @@ describe("ClientService", function () {
 			expect(result.typeGroup()).toBeUndefined();
 			expect(result.timestamp()).toBe(1576957341000);
 			expect(result.confirmations()).toEqual(Utils.BigNumber.ZERO);
-			expect(result.nonce()).toEqual(Utils.BigNumber.ZERO);
 			expect(result.sender()).toBe("cosmos1de7pk372jkp9vrul0gv5j6r3l9mt3wa6m4h6h0");
 			expect(result.recipient()).toBe("cosmos14ddvyl5t0hzmknceuv3zzu5szuum4rkygpq5ln");
 			expect(result.amount()).toEqual(Utils.BigNumber.make(10680));
@@ -55,7 +54,6 @@ describe("ClientService", function () {
 			expect(result.data[0].typeGroup()).toBeUndefined();
 			expect(result.data[0].timestamp()).toBe(1576957341000);
 			expect(result.data[0].confirmations()).toEqual(Utils.BigNumber.ZERO);
-			expect(result.data[0].nonce()).toEqual(Utils.BigNumber.ZERO);
 			expect(result.data[0].sender()).toBe("cosmos1de7pk372jkp9vrul0gv5j6r3l9mt3wa6m4h6h0");
 			expect(result.data[0].recipient()).toBe("cosmos14ddvyl5t0hzmknceuv3zzu5szuum4rkygpq5ln");
 			expect(result.data[0].amount()).toEqual(Utils.BigNumber.make(10680));

--- a/packages/platform-sdk-atom/src/dto/transaction.ts
+++ b/packages/platform-sdk-atom/src/dto/transaction.ts
@@ -22,10 +22,6 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return Utils.BigNumber.ZERO;
 	}
 
-	public nonce(): Utils.BigNumber {
-		return Utils.BigNumber.ZERO;
-	}
-
 	public sender(): string {
 		const event = this.data.events.find((event) => event.type === "message");
 		const attribute = event.attributes.find((attribute) => attribute.key === "sender");

--- a/packages/platform-sdk-btc/__tests__/dto/transaction.test.ts
+++ b/packages/platform-sdk-btc/__tests__/dto/transaction.test.ts
@@ -15,7 +15,6 @@ describe("TransactionData", function () {
 		expect(result.typeGroup()).toBeUndefined();
 		expect(result.timestamp()).toBe(1561095453000);
 		expect(result.confirmations()).toEqual(Utils.BigNumber.make(159414));
-		expect(result.nonce()).toEqual(Utils.BigNumber.ZERO);
 		// expect(result.sender()).toBe("...");
 		// expect(result.recipient()).toBe("...");
 		expect(result.amount()).toEqual(Utils.BigNumber.make(3050000));

--- a/packages/platform-sdk-btc/__tests__/services/client.test.ts
+++ b/packages/platform-sdk-btc/__tests__/services/client.test.ts
@@ -30,7 +30,6 @@ describe("ClientService", function () {
 			expect(result.typeGroup()).toBeUndefined();
 			expect(result.timestamp()).toBe(1561095453000);
 			expect(result.confirmations()).toEqual(Utils.BigNumber.make(159414));
-			expect(result.nonce()).toEqual(Utils.BigNumber.ZERO);
 			// expect(result.sender()).toBe("...");
 			// expect(result.recipient()).toBe("...");
 			expect(result.amount()).toEqual(Utils.BigNumber.make(3050000));

--- a/packages/platform-sdk-btc/src/dto/transaction.ts
+++ b/packages/platform-sdk-btc/src/dto/transaction.ts
@@ -22,10 +22,6 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return Utils.BigNumber.make(this.data.confirmations);
 	}
 
-	public nonce(): Utils.BigNumber {
-		return Utils.BigNumber.ZERO;
-	}
-
 	public sender(): string {
 		throw new Exceptions.NotImplemented(this.constructor.name, "sender");
 	}

--- a/packages/platform-sdk-eos/src/dto/transaction.ts
+++ b/packages/platform-sdk-eos/src/dto/transaction.ts
@@ -22,10 +22,6 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return Utils.BigNumber.make(0);
 	}
 
-	public nonce(): Utils.BigNumber {
-		return Utils.BigNumber.make(this.data.nonce);
-	}
-
 	public sender(): string {
 		return this.data.from;
 	}

--- a/packages/platform-sdk-eth/__tests__/dto/transaction.test.ts
+++ b/packages/platform-sdk-eth/__tests__/dto/transaction.test.ts
@@ -29,10 +29,6 @@ describe("TransactionData", function () {
 		expect(subject.confirmations()).toEqual(Utils.BigNumber.ZERO);
 	});
 
-	test("#nonce", () => {
-		expect(subject.nonce()).toEqual(Utils.BigNumber.ZERO);
-	});
-
 	test("#sender", () => {
 		expect(subject.sender()).toBe("0x4581A610f96878266008993475F1476cA9997081");
 	});

--- a/packages/platform-sdk-eth/__tests__/services/client.test.ts
+++ b/packages/platform-sdk-eth/__tests__/services/client.test.ts
@@ -30,7 +30,6 @@ describe("ClientService", function () {
 			expect(result.typeGroup()).toBeUndefined();
 			expect(result.timestamp()).toBeUndefined();
 			expect(result.confirmations()).toEqual(Utils.BigNumber.ZERO);
-			expect(result.nonce()).toEqual(Utils.BigNumber.ZERO);
 			expect(result.sender()).toBe("0x4581A610f96878266008993475F1476cA9997081");
 			expect(result.recipient()).toBe("0x230b2A8C0CcE28fd6eFF491c47aeBa244b10A12c");
 			expect(result.amount()).toEqual(Utils.BigNumber.make("79000000000000"));

--- a/packages/platform-sdk-eth/src/dto/transaction.ts
+++ b/packages/platform-sdk-eth/src/dto/transaction.ts
@@ -22,10 +22,6 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return Utils.BigNumber.make(0);
 	}
 
-	public nonce(): Utils.BigNumber {
-		return Utils.BigNumber.make(parseInt(this.data.nonce, 16));
-	}
-
 	public sender(): string {
 		return this.data.from;
 	}

--- a/packages/platform-sdk-lsk/__tests__/dto/transaction.test.ts
+++ b/packages/platform-sdk-lsk/__tests__/dto/transaction.test.ts
@@ -29,10 +29,6 @@ describe("TransactionData", function () {
 		expect(subject.confirmations()).toEqual(Utils.BigNumber.make(35754));
 	});
 
-	test("#nonce", () => {
-		expect(subject.nonce()).toEqual(Utils.BigNumber.ZERO);
-	});
-
 	test("#sender", () => {
 		expect(subject.sender()).toBe("1a3aec07d0ff815c910d4c707a66b58a692dacb3de9d7d95a085bcee93738a07");
 	});

--- a/packages/platform-sdk-lsk/src/dto/transaction.ts
+++ b/packages/platform-sdk-lsk/src/dto/transaction.ts
@@ -22,10 +22,6 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return Utils.BigNumber.make(this.data.confirmations);
 	}
 
-	public nonce(): Utils.BigNumber {
-		return Utils.BigNumber.ZERO;
-	}
-
 	public sender(): string {
 		return this.data.senderPublicKey;
 	}

--- a/packages/platform-sdk-neo/__tests__/dto/transaction.test.ts
+++ b/packages/platform-sdk-neo/__tests__/dto/transaction.test.ts
@@ -22,7 +22,6 @@ describe("TransactionData", function () {
 		// expect(result.typeGroup()).toBeUndefined();
 		expect(result.timestamp()).toBe(1588930966);
 		expect(result.confirmations()).toEqual(Utils.BigNumber.ZERO);
-		expect(result.nonce()).toEqual(Utils.BigNumber.ZERO);
 		expect(result.sender()).toBe("AStJyBXGGBK6bwrRfRUHSjp993PB5C9QgF");
 		expect(result.recipient()).toBe("Ab9QkPeMzx7ehptvjbjHviAXUfdhAmEAUF");
 		expect(result.amount()).toEqual(Utils.BigNumber.make(1));

--- a/packages/platform-sdk-neo/__tests__/services/client.test.ts
+++ b/packages/platform-sdk-neo/__tests__/services/client.test.ts
@@ -29,7 +29,6 @@ describe("ClientService", function () {
 			// expect(result.data[0].typeGroup()).toBeUndefined();
 			expect(result.data[0].timestamp()).toBe(1588930966);
 			expect(result.data[0].confirmations()).toEqual(Utils.BigNumber.ZERO);
-			expect(result.data[0].nonce()).toEqual(Utils.BigNumber.ZERO);
 			expect(result.data[0].sender()).toBe("AStJyBXGGBK6bwrRfRUHSjp993PB5C9QgF");
 			expect(result.data[0].recipient()).toBe("Ab9QkPeMzx7ehptvjbjHviAXUfdhAmEAUF");
 			expect(result.data[0].amount()).toEqual(Utils.BigNumber.make(1));

--- a/packages/platform-sdk-neo/src/dto/transaction.ts
+++ b/packages/platform-sdk-neo/src/dto/transaction.ts
@@ -22,10 +22,6 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return Utils.BigNumber.ZERO;
 	}
 
-	public nonce(): Utils.BigNumber {
-		return Utils.BigNumber.ZERO;
-	}
-
 	public sender(): string {
 		return this.data.address_from;
 	}

--- a/packages/platform-sdk-trx/src/dto/transaction.ts
+++ b/packages/platform-sdk-trx/src/dto/transaction.ts
@@ -22,10 +22,6 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		throw new Exceptions.NotImplemented(this.constructor.name, "confirmations");
 	}
 
-	public nonce(): Utils.BigNumber {
-		throw new Exceptions.NotImplemented(this.constructor.name, "nonce");
-	}
-
 	public sender(): string {
 		throw new Exceptions.NotImplemented(this.constructor.name, "sender");
 	}

--- a/packages/platform-sdk-xlm/__tests__/services/client.test.ts
+++ b/packages/platform-sdk-xlm/__tests__/services/client.test.ts
@@ -36,7 +36,6 @@ describe("ClientService", function () {
 			// expect(result.typeGroup()).toBeUndefined();
 			expect(result.timestamp()).toBe(1554840865000);
 			// expect(result.confirmations()).toEqual(Utils.BigNumber.make(159414));
-			expect(result.nonce()).toEqual(Utils.BigNumber.make("4660039994869"));
 			expect(result.sender()).toBe("GAHXEI3BVFOBDHWLC4TJKCGTLY6VMTKMRRWWPKNPPULUC7E3PD63ENKO");
 			expect(result.recipient()).toBe("GB2V4J7WTTKLIN5O3QPUAQCOLLIIULJM3FHHAQ7GEQ5EH53BXXQ47HU3");
 			expect(result.amount()).toEqual(Utils.BigNumber.make("100000000"));
@@ -63,7 +62,6 @@ describe("ClientService", function () {
 			// expect(data[0].typeGroup()).toBeUndefined();
 			expect(data[0].timestamp()).toBe(1554505662000);
 			// expect(data[0].confirmations()).toEqual(Utils.BigNumber.make(159414));
-			expect(data[0].nonce()).toEqual(Utils.BigNumber.ZERO);
 			expect(data[0].sender()).toBe("GAGLYFZJMN5HEULSTH5CIGPOPAVUYPG5YSWIYDJMAPIECYEBPM2TA3QR");
 			expect(data[0].recipient()).toBe("GBYUUJHG6F4EPJGNLERINATVQLNDOFRUD7SGJZ26YZLG5PAYLG7XUSGF");
 			expect(data[0].amount()).toEqual(Utils.BigNumber.make("100000000000000"));

--- a/packages/platform-sdk-xlm/src/dto/transaction.ts
+++ b/packages/platform-sdk-xlm/src/dto/transaction.ts
@@ -22,15 +22,6 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		throw new Exceptions.NotImplemented(this.constructor.name, "confirmations");
 	}
 
-	// todo: with the "transaction" method we get a nonce but with "transactions" it isn't available
-	public nonce(): Utils.BigNumber {
-		if (this.data.source_account_sequence) {
-			return Utils.BigNumber.make(this.data.source_account_sequence);
-		}
-
-		return Utils.BigNumber.ZERO;
-	}
-
 	public sender(): string {
 		return this.data.from || this.data.operation.from;
 	}

--- a/packages/platform-sdk-xmr/src/dto/transaction.ts
+++ b/packages/platform-sdk-xmr/src/dto/transaction.ts
@@ -22,10 +22,6 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		throw new Exceptions.NotImplemented(this.constructor.name, "confirmations");
 	}
 
-	public nonce(): Utils.BigNumber {
-		throw new Exceptions.NotImplemented(this.constructor.name, "nonce");
-	}
-
 	public sender(): string {
 		throw new Exceptions.NotImplemented(this.constructor.name, "sender");
 	}

--- a/packages/platform-sdk-xrp/__tests__/dto/transaction.test.ts
+++ b/packages/platform-sdk-xrp/__tests__/dto/transaction.test.ts
@@ -15,7 +15,6 @@ describe("TransactionData", function () {
 		// expect(result.typeGroup()).toBeUndefined();
 		expect(result.timestamp()).toBe(1363132610000);
 		expect(result.confirmations()).toEqual(Utils.BigNumber.ZERO);
-		expect(result.nonce()).toEqual(Utils.BigNumber.make(4));
 		expect(result.sender()).toBe("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59");
 		expect(result.recipient()).toBe("rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM");
 		expect(result.amount()).toEqual(Utils.BigNumber.make(100000));

--- a/packages/platform-sdk-xrp/__tests__/services/client.test.ts
+++ b/packages/platform-sdk-xrp/__tests__/services/client.test.ts
@@ -98,7 +98,6 @@ describe("ClientService", function () {
 			// expect(result.typeGroup()).toBeUndefined();
 			expect(result.timestamp()).toBe(1363132610000);
 			expect(result.confirmations()).toEqual(Utils.BigNumber.ZERO);
-			expect(result.nonce()).toEqual(Utils.BigNumber.make(4));
 			expect(result.sender()).toBe("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59");
 			expect(result.recipient()).toBe("rMH4UxPrbuMa1spCBR98hLLyNJp4d8p4tM");
 			expect(result.amount()).toEqual(Utils.BigNumber.make(100000));

--- a/packages/platform-sdk-xrp/src/dto/transaction.ts
+++ b/packages/platform-sdk-xrp/src/dto/transaction.ts
@@ -23,10 +23,6 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return Utils.BigNumber.ZERO;
 	}
 
-	public nonce(): Utils.BigNumber {
-		return Utils.BigNumber.make(this.data.sequence);
-	}
-
 	public sender(): string {
 		return this.data.specification.source.address;
 	}

--- a/packages/platform-sdk/src/contracts/coins/data.ts
+++ b/packages/platform-sdk/src/contracts/coins/data.ts
@@ -12,8 +12,6 @@ export interface TransactionData {
 
 	confirmations(): BigNumber;
 
-	nonce(): BigNumber;
-
 	sender(): string;
 
 	recipient(): string;

--- a/packages/platform-sdk/src/dto/transaction.ts
+++ b/packages/platform-sdk/src/dto/transaction.ts
@@ -14,8 +14,6 @@ export abstract class AbstractTransactionData {
 
 	abstract confirmations(): BigNumber;
 
-	abstract nonce(): BigNumber;
-
 	abstract sender(): string;
 
 	abstract recipient(): string;
@@ -35,7 +33,6 @@ export abstract class AbstractTransactionData {
 			typeGroup: this.typeGroup(),
 			timestamp: this.timestamp(),
 			confirmations: this.confirmations(),
-			nonce: this.nonce(),
 			sender: this.sender(),
 			recipient: this.recipient(),
 			amount: this.amount(),


### PR DESCRIPTION
The `nonce` isn't relevant outside of signing transactions.