### PR TITLE
refactor(sdk): implement `Coin` to slim down `CoinFactory`

### DIFF
--- a/packages/platform-sdk-coincap/__tests__/tracker.test.ts
+++ b/packages/platform-sdk-coincap/__tests__/tracker.test.ts
@@ -36,10 +36,7 @@ beforeEach(() => {
 
 	nock(BASE_URL_COINCAP).get("/rates").reply(200, require("./__fixtures__/rates.json"));
 
-	nock(BASE_URL_COINCAP)
-		.get("/assets/ark/history")
-		.query(true)
-		.reply(200, require("./__fixtures__/historical.json"));
+	nock(BASE_URL_COINCAP).get("/assets/ark/history").query(true).reply(200, require("./__fixtures__/historical.json"));
 });
 
 describe("PriceTracker", () => {

--- a/packages/platform-sdk-lsk/src/services/ledger.ts
+++ b/packages/platform-sdk-lsk/src/services/ledger.ts
@@ -52,6 +52,7 @@ export class LedgerService implements Contracts.LedgerService {
 		throw new Exceptions.NotImplemented(this.constructor.name, "signMessageWithSchnorr");
 	}
 
-	getLedgerAccount = (path: string): LedgerAccount =>
-		new LedgerAccount().coinIndex(SupportedCoin.LISK).account(Utils.BIP44.parse(path).account);
+	private getLedgerAccount(path: string): LedgerAccount {
+		return new LedgerAccount().coinIndex(SupportedCoin.LISK).account(Utils.BIP44.parse(path).account);
+	}
 }

--- a/packages/platform-sdk/src/coins/coin.ts
+++ b/packages/platform-sdk/src/coins/coin.ts
@@ -1,0 +1,84 @@
+import {
+	ClientService,
+	FeeService,
+	IdentityService,
+	LedgerService,
+	LinkService,
+	MessageService,
+	PeerService,
+	TransactionService,
+} from "../contracts/coins";
+import { Manifest } from "./manifest";
+import { NetworkRepository } from "./network-repository";
+import { CoinServices } from "./contracts";
+
+export class Coin {
+	readonly #network: NetworkRepository;
+	readonly #manifest: Manifest;
+	readonly #services: CoinServices;
+
+	public constructor({
+		network,
+		manifest,
+		services,
+	}: {
+		network: NetworkRepository;
+		manifest: Manifest;
+		services: CoinServices;
+	}) {
+		this.#network = network;
+		this.#manifest = manifest;
+		this.#services = services;
+	}
+
+	public async destruct(): Promise<void> {
+		await this.#services.client.destruct();
+		await this.#services.fee.destruct();
+		await this.#services.identity.destruct();
+		await this.#services.ledger.destruct();
+		await this.#services.link.destruct();
+		await this.#services.message.destruct();
+		await this.#services.peer.destruct();
+		await this.#services.transaction.destruct();
+	}
+
+	public network(): NetworkRepository {
+		return this.#network;
+	}
+
+	public manifest(): Manifest {
+		return this.#manifest;
+	}
+
+	public clientService(): ClientService {
+		return this.#services.client;
+	}
+
+	public feeService(): FeeService {
+		return this.#services.fee;
+	}
+
+	public identityService(): IdentityService {
+		return this.#services.identity;
+	}
+
+	public ledgerService(): LedgerService {
+		return this.#services.ledger;
+	}
+
+	public linkService(): LinkService {
+		return this.#services.link;
+	}
+
+	public messageService(): MessageService {
+		return this.#services.message;
+	}
+
+	public peerService(): PeerService {
+		return this.#services.peer;
+	}
+
+	public transactionService(): TransactionService {
+		return this.#services.transaction;
+	}
+}

--- a/packages/platform-sdk/src/coins/coin.ts
+++ b/packages/platform-sdk/src/coins/coin.ts
@@ -11,11 +11,13 @@ import {
 import { Manifest } from "./manifest";
 import { NetworkRepository } from "./network-repository";
 import { CoinServices } from "./contracts";
+import { Guard } from "./guard";
 
 export class Coin {
 	readonly #network: NetworkRepository;
 	readonly #manifest: Manifest;
 	readonly #services: CoinServices;
+	readonly #guard: Guard;
 
 	public constructor({
 		network,
@@ -29,6 +31,7 @@ export class Coin {
 		this.#network = network;
 		this.#manifest = manifest;
 		this.#services = services;
+		this.#guard = new Guard(manifest.get("abilities"));
 	}
 
 	public async destruct(): Promise<void> {
@@ -50,35 +53,39 @@ export class Coin {
 		return this.#manifest;
 	}
 
-	public clientService(): ClientService {
+	public guard(): Guard {
+		return this.#guard;
+	}
+
+	public client(): ClientService {
 		return this.#services.client;
 	}
 
-	public feeService(): FeeService {
+	public fee(): FeeService {
 		return this.#services.fee;
 	}
 
-	public identityService(): IdentityService {
+	public identity(): IdentityService {
 		return this.#services.identity;
 	}
 
-	public ledgerService(): LedgerService {
+	public ledger(): LedgerService {
 		return this.#services.ledger;
 	}
 
-	public linkService(): LinkService {
+	public link(): LinkService {
 		return this.#services.link;
 	}
 
-	public messageService(): MessageService {
+	public message(): MessageService {
 		return this.#services.message;
 	}
 
-	public peerService(): PeerService {
+	public peer(): PeerService {
 		return this.#services.peer;
 	}
 
-	public transactionService(): TransactionService {
+	public transaction(): TransactionService {
 		return this.#services.transaction;
 	}
 }

--- a/packages/platform-sdk/src/coins/coin.ts
+++ b/packages/platform-sdk/src/coins/coin.ts
@@ -8,10 +8,10 @@ import {
 	PeerService,
 	TransactionService,
 } from "../contracts/coins";
-import { Manifest } from "./manifest";
-import { NetworkRepository } from "./network-repository";
 import { CoinServices } from "./contracts";
 import { Guard } from "./guard";
+import { Manifest } from "./manifest";
+import { NetworkRepository } from "./network-repository";
 
 export class Coin {
 	readonly #network: NetworkRepository;

--- a/packages/platform-sdk/src/coins/contracts.ts
+++ b/packages/platform-sdk/src/coins/contracts.ts
@@ -9,31 +9,18 @@ import {
 	TransactionService,
 } from "../contracts/coins";
 
-export interface FactoryServices {
-	client: ClientService;
-	fee: FeeService;
-	identity: IdentityService;
-	ledger: LedgerService;
-	link: LinkService;
-	message: MessageService;
-	peer: PeerService;
-	transaction: TransactionService;
-}
-
-export interface CoinServices {
-	client: any;
-	fee: any;
-	identity: any;
-	ledger: any;
-	link: any;
-	message: any;
-	peer: any;
-	transaction: any;
-}
-
-export interface Coin {
+export interface CoinSpecs {
 	manifest: any;
-	services: CoinServices;
+	services: {
+		client: any;
+		fee: any;
+		identity: any;
+		ledger: any;
+		link: any;
+		message: any;
+		peer: any;
+		transaction: any;
+	};
 }
 
 export interface CoinOptions {
@@ -49,4 +36,15 @@ export interface CoinOptions {
 		peer: {};
 		transaction: {};
 	};
+}
+
+export interface CoinServices {
+	client: ClientService;
+	fee: FeeService;
+	identity: IdentityService;
+	ledger: LedgerService;
+	link: LinkService;
+	message: MessageService;
+	peer: PeerService;
+	transaction: TransactionService;
 }

--- a/packages/platform-sdk/src/coins/contracts.ts
+++ b/packages/platform-sdk/src/coins/contracts.ts
@@ -9,7 +9,7 @@ import {
 	TransactionService,
 } from "../contracts/coins";
 
-export interface CoinSpecs {
+export interface CoinSpec {
 	manifest: any;
 	services: {
 		client: any;

--- a/packages/platform-sdk/src/coins/factory.ts
+++ b/packages/platform-sdk/src/coins/factory.ts
@@ -1,85 +1,31 @@
-import {
-	ClientService,
-	FeeService,
-	IdentityService,
-	LedgerService,
-	LinkService,
-	MessageService,
-	PeerService,
-	TransactionService,
-} from "../contracts/coins";
-import { Coin, CoinOptions, FactoryServices } from "./contracts";
+import { Coin } from "./coin";
+import { CoinOptions, CoinSpecs } from "./contracts";
+import { Manifest } from "./manifest";
+import { NetworkRepository } from "./network-repository";
 
 export class CoinFactory {
-	readonly #services: FactoryServices;
-
-	public constructor(services: FactoryServices) {
-		this.#services = services;
-	}
-
-	public static async construct(coin: Coin, options: CoinOptions): Promise<CoinFactory> {
+	public static async make(coin: CoinSpecs, options: CoinOptions): Promise<Coin> {
 		const merge = (options: CoinOptions, service: string) => ({
 			network: options.network,
 			peer: options.peer,
 			...(options.services ? options.services[service] || {} : {}),
 		});
 
-		const { services } = coin;
+		const { manifest, services } = coin;
 
-		// todo: create NetworkRepository instance
-
-		return new CoinFactory({
-			client: await services.client.construct(merge(options, "client")),
-			fee: await services.fee.construct(merge(options, "fee")),
-			identity: await services.identity.construct(merge(options, "identity")),
-			ledger: await services.ledger.construct(merge(options, "ledger")),
-			link: await services.link.construct(merge(options, "link")),
-			message: await services.message.construct(merge(options, "message")),
-			peer: await services.peer.construct(merge(options, "peer")),
-			transaction: await services.transaction.construct(merge(options, "transaction")),
+		return new Coin({
+			network: new NetworkRepository(manifest.networks),
+			manifest: new Manifest(manifest),
+			services: {
+				client: await services.client.construct(merge(options, "client")),
+				fee: await services.fee.construct(merge(options, "fee")),
+				identity: await services.identity.construct(merge(options, "identity")),
+				ledger: await services.ledger.construct(merge(options, "ledger")),
+				link: await services.link.construct(merge(options, "link")),
+				message: await services.message.construct(merge(options, "message")),
+				peer: await services.peer.construct(merge(options, "peer")),
+				transaction: await services.transaction.construct(merge(options, "transaction")),
+			},
 		});
-	}
-
-	public async destruct(): Promise<void> {
-		await this.#services.client.destruct();
-		await this.#services.fee.destruct();
-		await this.#services.identity.destruct();
-		await this.#services.ledger.destruct();
-		await this.#services.link.destruct();
-		await this.#services.message.destruct();
-		await this.#services.peer.destruct();
-		await this.#services.transaction.destruct();
-	}
-
-	public clientService(): ClientService {
-		return this.#services.client;
-	}
-
-	public feeService(): FeeService {
-		return this.#services.fee;
-	}
-
-	public identityService(): IdentityService {
-		return this.#services.identity;
-	}
-
-	public ledgerService(): LedgerService {
-		return this.#services.ledger;
-	}
-
-	public linkService(): LinkService {
-		return this.#services.link;
-	}
-
-	public messageService(): MessageService {
-		return this.#services.message;
-	}
-
-	public peerService(): PeerService {
-		return this.#services.peer;
-	}
-
-	public transactionService(): TransactionService {
-		return this.#services.transaction;
 	}
 }

--- a/packages/platform-sdk/src/coins/factory.ts
+++ b/packages/platform-sdk/src/coins/factory.ts
@@ -1,10 +1,10 @@
 import { Coin } from "./coin";
-import { CoinOptions, CoinSpecs } from "./contracts";
+import { CoinOptions, CoinSpec } from "./contracts";
 import { Manifest } from "./manifest";
 import { NetworkRepository } from "./network-repository";
 
 export class CoinFactory {
-	public static async make(coin: CoinSpecs, options: CoinOptions): Promise<Coin> {
+	public static async make(coin: CoinSpec, options: CoinOptions): Promise<Coin> {
 		const merge = (options: CoinOptions, service: string) => ({
 			network: options.network,
 			peer: options.peer,

--- a/packages/platform-sdk/src/coins/guard.ts
+++ b/packages/platform-sdk/src/coins/guard.ts
@@ -1,6 +1,6 @@
 import delve from "dlv";
 
-class Guard {
+export class Guard {
 	readonly #abilities: object;
 
 	public constructor(abilities: object) {


### PR DESCRIPTION
The `CoinFactory` now creates a `Coin` instance that exposes all services and data of a concrete coin implementation. This makes the `CoinFactory` a real factory and things easier to test.