### PR TITLE
refactor(sdk): store network object in `Config.network` instead of string

### DIFF
--- a/packages/platform-sdk-ada/src/manifest.ts
+++ b/packages/platform-sdk-ada/src/manifest.ts
@@ -2,6 +2,8 @@ export const manifest = {
 	name: "Cardano",
 	networks: {
 		mainnet: {
+			id: "mainnet",
+			name: "Mainnet",
 			explorer: "https://explorer.cardano.org/",
 			currency: {
 				ticker: "ADA",
@@ -13,6 +15,8 @@ export const manifest = {
 			hosts: [],
 		},
 		testnet: {
+			id: "testnet",
+			name: "Testnet",
 			explorer: "https://shelleyexplorer.cardano.org/",
 			currency: {
 				ticker: "ADA",

--- a/packages/platform-sdk-ada/src/services/link.ts
+++ b/packages/platform-sdk-ada/src/services/link.ts
@@ -1,16 +1,14 @@
 import { Coins, Contracts } from "@arkecosystem/platform-sdk";
 
-import { manifest } from "../manifest";
-
 export class LinkService implements Contracts.LinkService {
 	readonly #baseUrl: string;
 
-	private constructor(network: string) {
-		this.#baseUrl = manifest.networks[network].explorer;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#baseUrl = network.explorer;
 	}
 
 	public static async construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(config.get("network"));
+		return new LinkService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-ark/__tests__/helpers.ts
+++ b/packages/platform-sdk-ark/__tests__/helpers.ts
@@ -1,6 +1,12 @@
 import { Coins } from "@arkecosystem/platform-sdk";
 
 import { schema } from "../src/schema";
+import { manifest } from "../src/manifest";
 
-export const createConfig = (options?: object) =>
-	new Coins.Config(options || { network: "devnet", peer: "https://dexplorer.ark.io/api" }, schema);
+export const createConfig = (options?: object) => {
+	const config = new Coins.Config(options || { network: "devnet", peer: "https://dexplorer.ark.io/api" }, schema)
+
+	config.set('network', manifest.networks.devnet)
+
+	return config
+};

--- a/packages/platform-sdk-ark/src/manifest.ts
+++ b/packages/platform-sdk-ark/src/manifest.ts
@@ -2,6 +2,8 @@ export const manifest = {
 	name: "ARK",
 	networks: {
 		mainnet: {
+			id: "mainnet",
+			name: "Mainnet",
 			explorer: "https://explorer.ark.io/",
 			currency: {
 				ticker: "ARK",
@@ -79,6 +81,8 @@ export const manifest = {
 			],
 		},
 		devnet: {
+			id: "devnet",
+			name: "Devnet",
 			explorer: "https://dexplorer.ark.io/",
 			currency: {
 				ticker: "DARK",

--- a/packages/platform-sdk-ark/src/services/identity/index.ts
+++ b/packages/platform-sdk-ark/src/services/identity/index.ts
@@ -9,7 +9,8 @@ import { WIF } from "./wif";
 
 export class IdentityService implements Contracts.IdentityService {
 	public static async construct(config: Coins.Config): Promise<IdentityService> {
-		Managers.configManager.setFromPreset(config.get("network"));
+		// @ts-ignore
+		Managers.configManager.setFromPreset(config.get<Coins.CoinNetwork>("network").id);
 
 		return new IdentityService();
 	}

--- a/packages/platform-sdk-ark/src/services/link.ts
+++ b/packages/platform-sdk-ark/src/services/link.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class LinkService implements Contracts.LinkService {
 	readonly #baseUrl: string;
 
-	private constructor(network: string) {
-		this.#baseUrl = manifest.networks[network].explorer;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#baseUrl = network.explorer;
 	}
 
 	public static async construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(config.get("network"));
+		return new LinkService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-ark/src/services/peer.ts
+++ b/packages/platform-sdk-ark/src/services/peer.ts
@@ -35,7 +35,7 @@ export class PeerService implements Contracts.PeerService {
 					seeds.push(`http://${seed.ip}:${port}`);
 				}
 			} else {
-				seeds = manifest.networks[config.get<string>("network")].hosts;
+				seeds = config.get<Coins.CoinNetwork>("network").hosts;
 			}
 		} catch {
 			throw new Error("Failed to discovery any peers.");

--- a/packages/platform-sdk-atom/__tests__/helpers.ts
+++ b/packages/platform-sdk-atom/__tests__/helpers.ts
@@ -1,6 +1,12 @@
 import { Coins } from "@arkecosystem/platform-sdk";
 
 import { schema } from "../src/schema";
+import { manifest } from "../src/manifest";
 
-export const createConfig = (options?: object) =>
-	new Coins.Config(options || { network: "cosmos.testnet", peer: "https://stargate.cosmos.network" }, schema);
+export const createConfig = (options?: object) => {
+	const config = new Coins.Config(options || { network: "cosmos.testnet", peer: "https://stargate.cosmos.network" }, schema)
+
+	config.set('network', manifest.networks['cosmos.testnet'])
+
+	return config
+};

--- a/packages/platform-sdk-atom/src/manifest.ts
+++ b/packages/platform-sdk-atom/src/manifest.ts
@@ -2,6 +2,8 @@ export const manifest = {
 	name: "Cosmos",
 	networks: {
 		"cosmos.mainnet": {
+			id: "cosmos.mainnet",
+			name: "Cosmos Mainnet",
 			explorer: "https://stake.id/",
 			currency: {
 				ticker: "ATOM",
@@ -15,6 +17,8 @@ export const manifest = {
 			hosts: [],
 		},
 		"cosmos.testnet": {
+			id: "cosmos.testnet",
+			name: "Cosmos Testnet",
 			explorer: "https://gaia.stake.id/",
 			currency: {
 				ticker: "MUON",
@@ -28,6 +32,8 @@ export const manifest = {
 			hosts: [],
 		},
 		"terra.mainnet": {
+			id: "terra.mainnet",
+			name: "Terra Mainnet",
 			explorer: "https://terra.stake.id/",
 			currency: {
 				ticker: "LUNA",
@@ -41,6 +47,8 @@ export const manifest = {
 			hosts: [],
 		},
 		"terra.testnet": {
+			id: "terra.testnet",
+			name: "Terra Testnet",
 			explorer: "https://soju.stake.id/",
 			currency: {
 				ticker: "LUNA",

--- a/packages/platform-sdk-atom/src/services/identity/index.ts
+++ b/packages/platform-sdk-atom/src/services/identity/index.ts
@@ -11,13 +11,13 @@ export class IdentityService implements Contracts.IdentityService {
 	readonly #slip44;
 	readonly #bech32;
 
-	public constructor(network: string) {
-		this.#slip44 = manifest.networks[network].crypto.slip44;
-		this.#bech32 = manifest.networks[network].crypto.bech32;
+	public constructor(network: Coins.CoinNetwork) {
+		this.#slip44 = network.crypto.slip44;
+		this.#bech32 = network.crypto.bech32;
 	}
 
 	public static async construct(config: Coins.Config): Promise<IdentityService> {
-		return new IdentityService(config.get("network"));
+		return new IdentityService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-atom/src/services/link.ts
+++ b/packages/platform-sdk-atom/src/services/link.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class LinkService implements Contracts.LinkService {
 	readonly #baseUrl: string;
 
-	private constructor(network: string) {
-		this.#baseUrl = manifest.networks[network].explorer;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#baseUrl = network.explorer;
 	}
 
 	public static async construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(config.get("network"));
+		return new LinkService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-atom/src/services/peer.ts
+++ b/packages/platform-sdk-atom/src/services/peer.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class PeerService implements Contracts.PeerService {
 	readonly #seeds: string[];
 
-	private constructor(network: string) {
-		this.#seeds = manifest.networks[network].hosts;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#seeds = network.hosts;
 	}
 
 	public static async construct(config: Coins.Config): Promise<PeerService> {
-		return new PeerService(config.get<string>("network"));
+		return new PeerService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-atom/src/services/transaction.ts
+++ b/packages/platform-sdk-atom/src/services/transaction.ts
@@ -13,7 +13,7 @@ export class TransactionService implements Contracts.TransactionService {
 	private constructor(opts: Contracts.KeyValuePair) {
 		this.#client = opts.client;
 		this.#identity = opts.identity;
-		this.#networkId = manifest.networks[opts.network].crypto.networkId;
+		this.#networkId = opts.network.crypto.networkId;
 	}
 
 	public static async construct(config: Coins.Config): Promise<TransactionService> {

--- a/packages/platform-sdk-btc/__tests__/helpers.ts
+++ b/packages/platform-sdk-btc/__tests__/helpers.ts
@@ -1,6 +1,12 @@
 import { Coins } from "@arkecosystem/platform-sdk";
 
 import { schema } from "../src/schema";
+import { manifest } from "../src/manifest";
 
-export const createConfig = (options?: object) =>
-	new Coins.Config(options || { network: "mainnet", peer: "https://coins.com/api/btc" }, schema);
+export const createConfig = (options?: object) => {
+	const config = new Coins.Config(options || { network: "livenet", peer: "https://coins.com/api/btc" }, schema)
+
+	config.set('network', manifest.networks.livenet)
+
+	return config
+};

--- a/packages/platform-sdk-btc/src/manifest.ts
+++ b/packages/platform-sdk-btc/src/manifest.ts
@@ -2,6 +2,8 @@ export const manifest = {
 	name: "Bitcoin",
 	networks: {
 		livenet: {
+			id: "livenet",
+			name: "Livenet",
 			explorer: "https://blockstream.info/",
 			currency: {
 				ticker: "BTC",
@@ -13,6 +15,8 @@ export const manifest = {
 			hosts: [],
 		},
 		testnet: {
+			id: "testnet",
+			name: "Testnet",
 			explorer: "https://blockstream.info/testnet/",
 			currency: {
 				ticker: "BTC",

--- a/packages/platform-sdk-btc/src/services/identity/index.ts
+++ b/packages/platform-sdk-btc/src/services/identity/index.ts
@@ -9,12 +9,12 @@ import { WIF } from "./wif";
 export class IdentityService implements Contracts.IdentityService {
 	readonly #network: string;
 
-	private constructor(network: string) {
-		this.#network = network;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#network = network.id;
 	}
 
 	public static async construct(config: Coins.Config): Promise<IdentityService> {
-		return new IdentityService(config.get("network"));
+		return new IdentityService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-btc/src/services/link.ts
+++ b/packages/platform-sdk-btc/src/services/link.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class LinkService implements Contracts.LinkService {
 	readonly #baseUrl: string;
 
-	private constructor(network: string) {
-		this.#baseUrl = manifest.networks[network].explorer;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#baseUrl = network.explorer;
 	}
 
 	public static async construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(config.get("network"));
+		return new LinkService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-btc/src/services/peer.ts
+++ b/packages/platform-sdk-btc/src/services/peer.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class PeerService implements Contracts.PeerService {
 	readonly #seeds: string[];
 
-	private constructor(network: string) {
-		this.#seeds = manifest.networks[network].hosts;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#seeds = network.hosts;
 	}
 
 	public static async construct(config: Coins.Config): Promise<PeerService> {
-		return new PeerService(config.get<string>("network"));
+		return new PeerService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-eos/__tests__/helpers.ts
+++ b/packages/platform-sdk-eos/__tests__/helpers.ts
@@ -1,6 +1,12 @@
 import { Coins } from "@arkecosystem/platform-sdk";
 
 import { schema } from "../src/schema";
+import { manifest } from "../src/manifest";
 
-export const createConfig = (options?: object) =>
-	new Coins.Config(options || { network: "testnet", peer: "https://api.testnet.eos.io" }, schema);
+export const createConfig = (options?: object) => {
+	const config = new Coins.Config(options || { network: "testnet", peer: "https://api.testnet.eos.io" }, schema)
+
+	config.set('network', manifest.networks['eos.testnet'])
+
+	return config
+};

--- a/packages/platform-sdk-eos/src/manifest.ts
+++ b/packages/platform-sdk-eos/src/manifest.ts
@@ -2,6 +2,8 @@ export const manifest = {
 	name: "EOS",
 	networks: {
 		"eos.mainnet": {
+			id: "eos.mainnet",
+			name: "EOS Mainnet",
 			explorer: "https://eos.bloks.io/",
 			currency: {
 				ticker: "EOS",
@@ -15,6 +17,8 @@ export const manifest = {
 			hosts: ["https://eos.greymass.com", "https://api.eosn.io", "https://mainnet.genereos.io"],
 		},
 		"eos.testnet": {
+			id: "eos.testnet",
+			name: "EOS Testnet",
 			explorer: "https://eos-test.bloks.io/",
 			currency: {
 				ticker: "EOS",
@@ -28,6 +32,8 @@ export const manifest = {
 			hosts: ["https://jungle2.cryptolions.io"],
 		},
 		"telos.mainnet": {
+			id: "telos.mainnet",
+			name: "TELOS Mainnet",
 			explorer: "https://telos.bloks.io/",
 			currency: {
 				ticker: "TLOS",
@@ -46,6 +52,8 @@ export const manifest = {
 			],
 		},
 		"telos.testnet": {
+			id: "telos.testnet",
+			name: "TELOS Testnet",
 			explorer: "https://telos-test.bloks.io/",
 			currency: {
 				ticker: "TLOS",
@@ -64,6 +72,8 @@ export const manifest = {
 			],
 		},
 		"wax.mainnet": {
+			id: "wax.mainnet",
+			name: "WAX Mainnet",
 			explorer: "https://wax.bloks.io/",
 			currency: {
 				ticker: "WAX",
@@ -77,6 +87,8 @@ export const manifest = {
 			hosts: ["https://wax.eosphere.io"],
 		},
 		"worbli.mainnet": {
+			id: "worbli.mainnet",
+			name: "WORBLI Mainnet",
 			explorer: "https://worbli.bloks.io/",
 			currency: {
 				ticker: "WBI",
@@ -90,6 +102,8 @@ export const manifest = {
 			hosts: ["https://api.worbli.io", "https://worbli-mainnet.eosblocksmith.io"],
 		},
 		"worbli.testnet": {
+			id: "worbli.testnet",
+			name: "WORBLI Testnet",
 			explorer: "https://worbli-test.bloks.io/",
 			currency: {
 				ticker: "WBI",
@@ -103,6 +117,8 @@ export const manifest = {
 			hosts: ["https://worbli-testnet.eosblocksmith.io", "https://worbli-testnet.eosphere.io"],
 		},
 		"meetone.mainnet": {
+			id: "meetone.mainnet",
+			name: "MEETONE Mainnet",
 			explorer: "https://meetone.bloks.io/",
 			currency: {
 				ticker: "MEETONE",
@@ -116,6 +132,8 @@ export const manifest = {
 			hosts: ["https://fullnode.meet.one"],
 		},
 		"bos.mainnet": {
+			id: "bos.mainnet",
+			name: "BOS Mainnet",
 			explorer: "https://bos.bloks.io/",
 			currency: {
 				ticker: "BOS",

--- a/packages/platform-sdk-eos/src/services/link.ts
+++ b/packages/platform-sdk-eos/src/services/link.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class LinkService implements Contracts.LinkService {
 	readonly #baseUrl: string;
 
-	private constructor(network: string) {
-		this.#baseUrl = manifest.networks[network].explorer;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#baseUrl = network.explorer;
 	}
 
 	public static async construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(config.get("network"));
+		return new LinkService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-eos/src/services/peer.ts
+++ b/packages/platform-sdk-eos/src/services/peer.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class PeerService implements Contracts.PeerService {
 	readonly #seeds: string[];
 
-	private constructor(network: string) {
-		this.#seeds = manifest.networks[network].hosts;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#seeds = network.hosts;
 	}
 
 	public static async construct(config: Coins.Config): Promise<PeerService> {
-		return new PeerService(config.get<string>("network"));
+		return new PeerService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-eth/__tests__/helpers.ts
+++ b/packages/platform-sdk-eth/__tests__/helpers.ts
@@ -1,6 +1,12 @@
 import { Coins } from "@arkecosystem/platform-sdk";
 
 import { schema } from "../src/schema";
+import { manifest } from "../src/manifest";
 
-export const createConfig = (options?: object) =>
-	new Coins.Config(options || { network: "ropsten", peer: "https://coins.com/api/eth" }, schema);
+export const createConfig = (options?: object) => {
+	const config = new Coins.Config(options || { network: "ropsten", peer: "https://coins.com/api/eth" }, schema)
+
+	config.set('network', manifest.networks.ropsten)
+
+	return config
+};

--- a/packages/platform-sdk-eth/src/manifest.ts
+++ b/packages/platform-sdk-eth/src/manifest.ts
@@ -2,6 +2,8 @@ export const manifest = {
 	name: "Ethereum",
 	networks: {
 		mainnet: {
+			id: "mainnet",
+			name: "Mainnet",
 			explorer: "https://etherscan.io/",
 			currency: {
 				ticker: "ETH",
@@ -14,6 +16,8 @@ export const manifest = {
 			hosts: [],
 		},
 		ropsten: {
+			id: "ropsten",
+			name: "Ropsten",
 			explorer: "https://ropsten.etherscan.io/",
 			currency: {
 				ticker: "ETH",
@@ -26,7 +30,8 @@ export const manifest = {
 			hosts: [],
 		},
 		rinkeby: {
-			rinkeby: "ETH",
+			id: "rinkeby",
+			name: "Rinkeby",
 			explorer: "https://rinkeby.etherscan.io/",
 			crypto: {
 				networkId: 4,
@@ -35,6 +40,8 @@ export const manifest = {
 			hosts: [],
 		},
 		goerli: {
+			id: "goerli",
+			name: "Goerli",
 			explorer: "https://goerli.etherscan.io/",
 			currency: {
 				ticker: "ETH",
@@ -47,6 +54,8 @@ export const manifest = {
 			hosts: [],
 		},
 		kovan: {
+			id: "kovan",
+			name: "Kovan",
 			explorer: "https://kovan.etherscan.io/",
 			currency: {
 				ticker: "ETH",

--- a/packages/platform-sdk-eth/src/services/identity/index.ts
+++ b/packages/platform-sdk-eth/src/services/identity/index.ts
@@ -10,12 +10,12 @@ import { WIF } from "./wif";
 export class IdentityService implements Contracts.IdentityService {
 	readonly #slip44;
 
-	public constructor(network: string) {
-		this.#slip44 = manifest.networks[network].crypto.slip44;
+	public constructor(network: Coins.CoinNetwork) {
+		this.#slip44 = network.crypto.slip44;
 	}
 
 	public static async construct(config: Coins.Config): Promise<IdentityService> {
-		return new IdentityService(config.get("network"));
+		return new IdentityService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-eth/src/services/link.ts
+++ b/packages/platform-sdk-eth/src/services/link.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class LinkService implements Contracts.LinkService {
 	readonly #baseUrl: string;
 
-	private constructor(network: string) {
-		this.#baseUrl = manifest.networks[network].explorer;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#baseUrl = network.explorer;
 	}
 
 	public static async construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(config.get("network"));
+		return new LinkService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-eth/src/services/peer.ts
+++ b/packages/platform-sdk-eth/src/services/peer.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class PeerService implements Contracts.PeerService {
 	readonly #seeds: string[];
 
-	private constructor(network: string) {
-		this.#seeds = manifest.networks[network].hosts;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#seeds = network.hosts;
 	}
 
 	public static async construct(config: Coins.Config): Promise<PeerService> {
-		return new PeerService(config.get<string>("network"));
+		return new PeerService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-lsk/__tests__/helpers.ts
+++ b/packages/platform-sdk-lsk/__tests__/helpers.ts
@@ -1,6 +1,12 @@
 import { Coins } from "@arkecosystem/platform-sdk";
 
 import { schema } from "../src/schema";
+import { manifest } from "../src/manifest";
 
-export const createConfig = (options?: object) =>
-	new Coins.Config(options || { network: "testnet", peer: "https://betanet.lisk.io:443" }, schema);
+export const createConfig = (options?: object) => {
+	const config = new Coins.Config(options || { network: "testnet", peer: "https://betanet.lisk.io:443" }, schema)
+
+	config.set('network', manifest.networks.testnet)
+
+	return config
+};

--- a/packages/platform-sdk-lsk/src/manifest.ts
+++ b/packages/platform-sdk-lsk/src/manifest.ts
@@ -2,6 +2,8 @@ export const manifest = {
 	name: "Lisk",
 	networks: {
 		mainnet: {
+			id: "mainnet",
+			name: "Mainnet",
 			explorer: "https://explorer.lisk.io/",
 			currency: {
 				ticker: "LSK",
@@ -31,6 +33,8 @@ export const manifest = {
 			],
 		},
 		testnet: {
+			id: "testnet",
+			name: "Testnet",
 			explorer: "https://testnet-explorer.lisk.io/",
 			currency: {
 				ticker: "LSK",
@@ -43,6 +47,8 @@ export const manifest = {
 			hosts: ["https://testnet.lisk.io"],
 		},
 		betanet: {
+			id: "betanet",
+			name: "Betanet",
 			explorer: "https://betanet-explorer.lisk.io/",
 			currency: {
 				ticker: "LSK",

--- a/packages/platform-sdk-lsk/src/services/fee.ts
+++ b/packages/platform-sdk-lsk/src/services/fee.ts
@@ -7,12 +7,12 @@ import { manifest } from "../manifest";
 export class FeeService implements Contracts.FeeService {
 	readonly #network;
 
-	private constructor(network: string) {
-		this.#network = network;
+	private constructor (network: Coins.CoinNetwork) {
+		this.#network = network.crypto.networkId;
 	}
 
 	public static async construct(config: Coins.Config): Promise<FeeService> {
-		return new FeeService(manifest.networks[config.get<string>("network")].crypto.networkId);
+		return new FeeService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-lsk/src/services/link.ts
+++ b/packages/platform-sdk-lsk/src/services/link.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class LinkService implements Contracts.LinkService {
 	readonly #baseUrl: string;
 
-	private constructor(network: string) {
-		this.#baseUrl = manifest.networks[network].explorer;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#baseUrl = network.explorer;
 	}
 
 	public static async construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(config.get("network"));
+		return new LinkService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-lsk/src/services/peer.ts
+++ b/packages/platform-sdk-lsk/src/services/peer.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class PeerService implements Contracts.PeerService {
 	readonly #seeds: string[];
 
-	private constructor(network: string) {
-		this.#seeds = manifest.networks[network].hosts;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#seeds = network.hosts;
 	}
 
 	public static async construct(config: Coins.Config): Promise<PeerService> {
-		return new PeerService(config.get<string>("network"));
+		return new PeerService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-lsk/src/services/transaction.ts
+++ b/packages/platform-sdk-lsk/src/services/transaction.ts
@@ -7,12 +7,12 @@ import { manifest } from "../manifest";
 export class TransactionService implements Contracts.TransactionService {
 	readonly #network;
 
-	private constructor(network: string) {
-		this.#network = network;
+	private constructor (network: Coins.CoinNetwork) {
+		this.#network = network.crypto.networkId;
 	}
 
 	public static async construct(config: Coins.Config): Promise<TransactionService> {
-		return new TransactionService(manifest.networks[config.get<string>("network")].crypto.networkId);
+		return new TransactionService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-neo/__tests__/helpers.ts
+++ b/packages/platform-sdk-neo/__tests__/helpers.ts
@@ -1,5 +1,12 @@
 import { Coins } from "@arkecosystem/platform-sdk";
 
 import { schema } from "../src/schema";
+import { manifest } from "../src/manifest";
 
-export const createConfig = (options?: object) => new Coins.Config(options || { network: "testnet" }, schema);
+export const createConfig = (options?: object) => {
+	const config = new Coins.Config(options || { network: "testnet" }, schema)
+
+	config.set('network', manifest.networks.testnet)
+
+	return config
+};

--- a/packages/platform-sdk-neo/src/manifest.ts
+++ b/packages/platform-sdk-neo/src/manifest.ts
@@ -2,6 +2,8 @@ export const manifest = {
 	name: "NEO",
 	networks: {
 		mainnet: {
+			id: "mainnet",
+			name: "Mainnet",
 			explorer: "https://neotracker.io/",
 			currency: {
 				ticker: "NEO",
@@ -34,6 +36,8 @@ export const manifest = {
 			],
 		},
 		testnet: {
+			id: "testnet",
+			name: "Testnet",
 			explorer: "https://neoscan-testnet.io/",
 			currency: {
 				ticker: "NEO",

--- a/packages/platform-sdk-neo/src/services/client.ts
+++ b/packages/platform-sdk-neo/src/services/client.ts
@@ -27,7 +27,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public static async construct(config: Coins.Config): Promise<ClientService> {
-		return new ClientService(config.get("network"));
+		return new ClientService(config.get<Coins.CoinNetwork>("network").id);
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-neo/src/services/identity/index.ts
+++ b/packages/platform-sdk-neo/src/services/identity/index.ts
@@ -10,12 +10,12 @@ import { WIF } from "./wif";
 export class IdentityService implements Contracts.IdentityService {
 	readonly #slip44;
 
-	public constructor(network: string) {
-		this.#slip44 = manifest.networks[network].crypto.slip44;
+	public constructor(network: Coins.CoinNetwork) {
+		this.#slip44 = network.crypto.slip44;
 	}
 
 	public static async construct(config: Coins.Config): Promise<IdentityService> {
-		return new IdentityService(config.get("network"));
+		return new IdentityService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-neo/src/services/link.ts
+++ b/packages/platform-sdk-neo/src/services/link.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class LinkService implements Contracts.LinkService {
 	readonly #baseUrl: string;
 
-	private constructor(network: string) {
-		this.#baseUrl = manifest.networks[network].explorer;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#baseUrl = network.explorer;
 	}
 
 	public static async construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(config.get("network"));
+		return new LinkService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-neo/src/services/peer.ts
+++ b/packages/platform-sdk-neo/src/services/peer.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class PeerService implements Contracts.PeerService {
 	readonly #seeds: string[];
 
-	private constructor(network: string) {
-		this.#seeds = manifest.networks[network].hosts;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#seeds = network.hosts;
 	}
 
 	public static async construct(config: Coins.Config): Promise<PeerService> {
-		return new PeerService(config.get<string>("network"));
+		return new PeerService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-trx/__tests__/helpers.ts
+++ b/packages/platform-sdk-trx/__tests__/helpers.ts
@@ -1,6 +1,12 @@
 import { Coins } from "@arkecosystem/platform-sdk";
 
 import { schema } from "../src/schema";
+import { manifest } from "../src/manifest";
 
-export const createConfig = (options?: object) =>
-	new Coins.Config(options || { network: "testnet", peer: "https://api.shasta.trongrid.io" }, schema);
+export const createConfig = (options?: object) => {
+	const config = new Coins.Config(options || { network: "testnet", peer: "https://api.shasta.trongrid.io" }, schema)
+
+	config.set('network', manifest.networks.testnet)
+
+	return config
+};

--- a/packages/platform-sdk-trx/src/manifest.ts
+++ b/packages/platform-sdk-trx/src/manifest.ts
@@ -2,6 +2,8 @@ export const manifest = {
 	name: "Tron",
 	networks: {
 		mainnet: {
+			id: "mainnet",
+			name: "Mainnet",
 			explorer: "https://tronscan.org/#/",
 			currency: {
 				ticker: "TRX",
@@ -13,6 +15,8 @@ export const manifest = {
 			hosts: ["https://api.trongrid.io"],
 		},
 		testnet: {
+			id: "testnet",
+			name: "Testnet",
 			explorer: "https://shasta.tronscan.org/#/",
 			currency: {
 				ticker: "TRX",

--- a/packages/platform-sdk-trx/src/services/link.ts
+++ b/packages/platform-sdk-trx/src/services/link.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class LinkService implements Contracts.LinkService {
 	readonly #baseUrl: string;
 
-	private constructor(network: string) {
-		this.#baseUrl = manifest.networks[network].explorer;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#baseUrl = network.explorer;
 	}
 
 	public static async construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(config.get("network"));
+		return new LinkService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-trx/src/services/peer.ts
+++ b/packages/platform-sdk-trx/src/services/peer.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class PeerService implements Contracts.PeerService {
 	readonly #seeds: string[];
 
-	private constructor(network: string) {
-		this.#seeds = manifest.networks[network].hosts;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#seeds = network.hosts;
 	}
 
 	public static async construct(config: Coins.Config): Promise<PeerService> {
-		return new PeerService(config.get<string>("network"));
+		return new PeerService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-xlm/__tests__/helpers.ts
+++ b/packages/platform-sdk-xlm/__tests__/helpers.ts
@@ -1,6 +1,12 @@
 import { Coins } from "@arkecosystem/platform-sdk";
 
 import { schema } from "../src/schema";
+import { manifest } from "../src/manifest";
 
-export const createConfig = (options?: object) =>
-	new Coins.Config(options || { network: "testnet", peer: "https://dexplorer.ark.io/api" }, schema);
+export const createConfig = (options?: object) => {
+	const config = new Coins.Config(options || { network: "testnet" }, schema)
+
+	config.set('network', manifest.networks.testnet)
+
+	return config
+};

--- a/packages/platform-sdk-xlm/src/manifest.ts
+++ b/packages/platform-sdk-xlm/src/manifest.ts
@@ -2,6 +2,8 @@ export const manifest = {
 	name: "Stellar",
 	networks: {
 		mainnet: {
+			id: "mainnet",
+			name: "Mainnet",
 			explorer: "https://steexp.com/",
 			currency: {
 				ticker: "XLM",
@@ -13,6 +15,8 @@ export const manifest = {
 			hosts: ["https://horizon.stellar.org"],
 		},
 		testnet: {
+			id: "testnet",
+			name: "Testnet",
 			explorer: "https://testnet.steexp.com/",
 			currency: {
 				ticker: "XLM",

--- a/packages/platform-sdk-xlm/src/services/client.ts
+++ b/packages/platform-sdk-xlm/src/services/client.ts
@@ -21,7 +21,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public static async construct(config: Coins.Config): Promise<ClientService> {
-		return new ClientService(config.get("network"));
+		return new ClientService(config.get<Coins.CoinNetwork>("network").id);
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-xlm/src/services/link.ts
+++ b/packages/platform-sdk-xlm/src/services/link.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class LinkService implements Contracts.LinkService {
 	readonly #baseUrl: string;
 
-	private constructor(network: string) {
-		this.#baseUrl = manifest.networks[network].explorer;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#baseUrl = network.explorer;
 	}
 
 	public static async construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(config.get("network"));
+		return new LinkService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-xlm/src/services/peer.ts
+++ b/packages/platform-sdk-xlm/src/services/peer.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class PeerService implements Contracts.PeerService {
 	readonly #seeds: string[];
 
-	private constructor(network: string) {
-		this.#seeds = manifest.networks[network].hosts;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#seeds = network.hosts;
 	}
 
 	public static async construct(config: Coins.Config): Promise<PeerService> {
-		return new PeerService(config.get<string>("network"));
+		return new PeerService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-xlm/src/services/transaction.ts
+++ b/packages/platform-sdk-xlm/src/services/transaction.ts
@@ -20,14 +20,16 @@ export class TransactionService implements Contracts.TransactionService {
 	};
 
 	private constructor(options) {
-		this.#client = new Stellar.Server(this.#networks[options.network].host);
-		this.#networkPassphrase = this.#networks[options.network].networkPassphrase;
+		const network = this.#networks[options.network.id];
+
+		this.#client = new Stellar.Server(network.host);
+		this.#networkPassphrase = network.networkPassphrase;
 		this.#identity = options.identity;
 	}
 
 	public static async construct(config: Coins.Config): Promise<TransactionService> {
 		return new TransactionService({
-			network: config.get("network"),
+			network: config.get<Coins.CoinNetwork>("network"),
 			identity: await IdentityService.construct(config),
 		});
 	}

--- a/packages/platform-sdk-xmr/src/manifest.ts
+++ b/packages/platform-sdk-xmr/src/manifest.ts
@@ -2,6 +2,8 @@ export const manifest = {
 	name: "Monero",
 	networks: {
 		mainnet: {
+			id: "mainnet",
+			name: "Mainnet",
 			explorer: "https://moneroblocks.info/",
 			currency: {
 				ticker: "XMR",
@@ -13,6 +15,8 @@ export const manifest = {
 			hosts: [],
 		},
 		testnet: {
+			id: "testnet",
+			name: "Testnet",
 			explorer: "https://dexplorer.ark.io/",
 			currency: {
 				ticker: "XMR",

--- a/packages/platform-sdk-xmr/src/services/link.ts
+++ b/packages/platform-sdk-xmr/src/services/link.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class LinkService implements Contracts.LinkService {
 	readonly #baseUrl: string;
 
-	private constructor(network: string) {
-		this.#baseUrl = manifest.networks[network].explorer;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#baseUrl = network.explorer;
 	}
 
 	public static async construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(config.get("network"));
+		return new LinkService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-xmr/src/services/peer.ts
+++ b/packages/platform-sdk-xmr/src/services/peer.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class PeerService implements Contracts.PeerService {
 	readonly #seeds: string[];
 
-	private constructor(network: string) {
-		this.#seeds = manifest.networks[network].hosts;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#seeds = network.hosts;
 	}
 
 	public static async construct(config: Coins.Config): Promise<PeerService> {
-		return new PeerService(config.get<string>("network"));
+		return new PeerService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-xrp/__tests__/helpers.ts
+++ b/packages/platform-sdk-xrp/__tests__/helpers.ts
@@ -1,12 +1,15 @@
 import { Coins } from "@arkecosystem/platform-sdk";
 
 import { schema } from "../src/schema";
+import { manifest } from "../src/manifest";
 
-export const createConfig = (options?: object) =>
-	new Coins.Config(
-		options || {
-			network: "testnet", // peer: "wss://s.altnet.rippletest.net:51233",
-			peer: "ws://localhost:51233",
-		},
-		schema,
-	);
+export const createConfig = (options?: object) => {
+	const config = new Coins.Config(options || {
+		network: "testnet", // peer: "wss://s.altnet.rippletest.net:51233",
+		peer: "ws://localhost:51233",
+	}, schema)
+
+	config.set('network', manifest.networks.testnet)
+
+	return config
+};

--- a/packages/platform-sdk-xrp/src/manifest.ts
+++ b/packages/platform-sdk-xrp/src/manifest.ts
@@ -2,6 +2,8 @@ export const manifest = {
 	name: "Ripple",
 	networks: {
 		mainnet: {
+			id: "mainnet",
+			name: "Mainnet",
 			explorer: "https://livenet.xrpl.org/",
 			currency: {
 				ticker: "XRP",
@@ -13,6 +15,8 @@ export const manifest = {
 			hosts: ["wss://s2.ripple.com/"],
 		},
 		testnet: {
+			id: "testnet",
+			name: "Testnet",
 			explorer: "https://testnet.xrpl.org/",
 			currency: {
 				ticker: "XRP",

--- a/packages/platform-sdk-xrp/src/services/link.ts
+++ b/packages/platform-sdk-xrp/src/services/link.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class LinkService implements Contracts.LinkService {
 	readonly #baseUrl: string;
 
-	private constructor(network: string) {
-		this.#baseUrl = manifest.networks[network].explorer;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#baseUrl = network.explorer;
 	}
 
 	public static async construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(config.get("network"));
+		return new LinkService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk-xrp/src/services/peer.ts
+++ b/packages/platform-sdk-xrp/src/services/peer.ts
@@ -5,12 +5,12 @@ import { manifest } from "../manifest";
 export class PeerService implements Contracts.PeerService {
 	readonly #seeds: string[];
 
-	private constructor(network: string) {
-		this.#seeds = manifest.networks[network].hosts;
+	private constructor(network: Coins.CoinNetwork) {
+		this.#seeds = network.hosts;
 	}
 
 	public static async construct(config: Coins.Config): Promise<PeerService> {
-		return new PeerService(config.get<string>("network"));
+		return new PeerService(config.get<Coins.CoinNetwork>("network"));
 	}
 
 	public async destruct(): Promise<void> {

--- a/packages/platform-sdk/src/coins/coin-factory.ts
+++ b/packages/platform-sdk/src/coins/coin-factory.ts
@@ -1,6 +1,6 @@
 import { Coin } from "./coin";
 import { Config } from "./config";
-import { CoinOptions, CoinSpec } from "./contracts";
+import { CoinNetwork, CoinOptions, CoinSpec } from "./contracts";
 import { Manifest } from "./manifest";
 import { NetworkRepository } from "./network-repository";
 
@@ -8,10 +8,13 @@ export class CoinFactory {
 	public static async make(coin: CoinSpec, options: CoinOptions): Promise<Coin> {
 		const { manifest, services } = coin;
 
+		const networks: NetworkRepository = new NetworkRepository(manifest.networks);
+
 		const config: Config = new Config(options, coin.schema);
+		config.set("network", networks.get(config.get<string>("network")));
 
 		return new Coin({
-			network: new NetworkRepository(manifest.networks),
+			networks,
 			manifest: new Manifest(manifest),
 			config,
 			services: {

--- a/packages/platform-sdk/src/coins/coin.ts
+++ b/packages/platform-sdk/src/coins/coin.ts
@@ -9,30 +9,30 @@ import {
 	TransactionService,
 } from "../contracts/coins";
 import { Config } from "./config";
-import { CoinServices } from "./contracts";
+import { CoinNetwork, CoinServices } from "./contracts";
 import { Guard } from "./guard";
 import { Manifest } from "./manifest";
 import { NetworkRepository } from "./network-repository";
 
 export class Coin {
-	readonly #network: NetworkRepository;
+	readonly #networks: NetworkRepository;
 	readonly #manifest: Manifest;
 	readonly #config: Config;
 	readonly #services: CoinServices;
 	readonly #guard: Guard;
 
 	public constructor({
-		network,
+		networks,
 		manifest,
 		config,
 		services,
 	}: {
-		network: NetworkRepository;
+		networks: NetworkRepository;
 		manifest: Manifest;
 		config: Config;
 		services: CoinServices;
 	}) {
-		this.#network = network;
+		this.#networks = networks;
 		this.#manifest = manifest;
 		this.#config = config;
 		this.#services = services;
@@ -50,8 +50,12 @@ export class Coin {
 		await this.#services.transaction.destruct();
 	}
 
-	public network(): NetworkRepository {
-		return this.#network;
+	public network(): CoinNetwork {
+		return this.#config.get("network");
+	}
+
+	public networks(): NetworkRepository {
+		return this.#networks;
 	}
 
 	public manifest(): Manifest {

--- a/packages/platform-sdk/src/coins/contracts.ts
+++ b/packages/platform-sdk/src/coins/contracts.ts
@@ -39,3 +39,19 @@ export interface CoinServices {
 	peer: PeerService;
 	transaction: TransactionService;
 }
+
+export interface CoinNetwork {
+	id: string;
+	name: string;
+	explorer: string;
+	currency: {
+		ticker: string;
+		symbol: string;
+	};
+	crypto: {
+		networkId?: string;
+		slip44: number;
+		bech32?: string;
+	};
+	hosts: string[];
+}

--- a/packages/platform-sdk/src/coins/index.ts
+++ b/packages/platform-sdk/src/coins/index.ts
@@ -1,6 +1,6 @@
 export * from "./coin";
 export * from "./config";
 export * from "./contracts";
-export * from "./factory";
+export * from "./coin-factory";
 export * from "./manifest";
 export * from "./network-repository";

--- a/packages/platform-sdk/src/coins/network-repository.ts
+++ b/packages/platform-sdk/src/coins/network-repository.ts
@@ -1,30 +1,18 @@
-interface Network {
-	explorer: string;
-	currency: {
-		ticker: string;
-		symbol: string;
-	};
-	crypto: {
-		networkId?: string;
-		slip44: number;
-		bech32?: string;
-	};
-	hosts: string[];
-}
+import { CoinNetwork } from "./contracts";
 
 export class NetworkRepository {
-	readonly #networks: Record<string, Network>;
+	readonly #networks: Record<string, CoinNetwork>;
 
-	public constructor(networks: Record<string, Network>) {
+	public constructor(networks: Record<string, CoinNetwork>) {
 		this.#networks = networks;
 	}
 
-	public all(): Record<string, Network> {
+	public all(): Record<string, CoinNetwork> {
 		return this.#networks;
 	}
 
-	public get(name: string): Network {
-		const result: Network | undefined = this.#networks[name];
+	public get(name: string): CoinNetwork {
+		const result: CoinNetwork | undefined = this.#networks[name];
 
 		if (!result) {
 			throw new Error(`The [${name}] network is not supported.`);
@@ -33,7 +21,7 @@ export class NetworkRepository {
 		return result;
 	}
 
-	public push(name: string, data: Network): void {
+	public push(name: string, data: CoinNetwork): void {
 		this.#networks[name] = data;
 	}
 

--- a/packages/platform-sdk/src/contracts/coins/identity.ts
+++ b/packages/platform-sdk/src/contracts/coins/identity.ts
@@ -1,5 +1,3 @@
-import { KeyValuePair } from "../types";
-
 export interface IdentityService {
 	destruct(): Promise<void>;
 


### PR DESCRIPTION
> Resolves https://github.com/ArkEcosystem/platform-sdk/issues/266

A lot of times the concrete implementations need to do `manifest.networks[config.get('network')]` because the string identifier itself is rather useless. This PR changes it so that the `Config` instance overwrites the string identifier with the object so that all information is easily accessible.