### PR TITLE
chore: fix type inclusion errors

### DIFF
--- a/packages/platform-sdk-intl/src/datetime.ts
+++ b/packages/platform-sdk-intl/src/datetime.ts
@@ -1,11 +1,3 @@
-import "dayjs/plugin/advancedFormat";
-import "dayjs/plugin/dayOfYear";
-import "dayjs/plugin/localizedFormat";
-import "dayjs/plugin/quarterOfYear";
-import "dayjs/plugin/toObject";
-import "dayjs/plugin/utc";
-import "dayjs/plugin/weekOfYear";
-
 import dayjs from "dayjs";
 import advancedFormat from "dayjs/plugin/advancedFormat";
 import dayOfYear from "dayjs/plugin/dayOfYear";

--- a/packages/platform-sdk-intl/src/datetime.ts
+++ b/packages/platform-sdk-intl/src/datetime.ts
@@ -38,7 +38,7 @@ export class DateTime {
 		}
 
 		try {
-			require(`dayjs/locale/${locale}`);
+			require(`dayjs/locale/${locale}.js`);
 
 			this.#instance.locale(locale);
 		} catch {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Require `dayjs` locale files explicitly using full file paths (adding `.js` suffix).
Remove duplicate imports for `dayjs` and plugins.

<!-- Why are these changes necessary? -->
Prevents Typescript compilation errors on forcing type inclusion when platform-sdk is used as a third-party package (seen in `mobile-wallet` angular compilation).

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
