### PR TITLE
feat(intl): implement `Currency#fromString` to parse currency strings

### DIFF
--- a/packages/platform-sdk-intl/__tests__/currency.test.ts
+++ b/packages/platform-sdk-intl/__tests__/currency.test.ts
@@ -1,58 +1,13 @@
 import { Currency } from "../src/currency";
 
 test("#fromString", () => {
-	expect(
-		Currency.fromString(
-			{
-				name: "bitcoin",
-				code: "BTC",
-				magnitude: 8,
-			},
-			"Ѧ 0,0001",
-		),
-	).toEqual({ display: "0.0001", value: "10000" });
+	expect(Currency.fromString("Ѧ 0,0001")).toEqual({ display: "0.0001", value: "10000" });
 
-	expect(
-		Currency.fromString(
-			{
-				name: "bitcoin",
-				code: "BTC",
-				magnitude: 8,
-			},
-			"R$ 45,210.21",
-		),
-	).toEqual({ display: "45.21021", value: "4521021000" });
+	expect(Currency.fromString("R$ 45,210.21")).toEqual({ display: "45.21021", value: "4521021000" });
 
-	expect(
-		Currency.fromString(
-			{
-				name: "bitcoin",
-				code: "BTC",
-				magnitude: 8,
-			},
-			"$ 45.210,21",
-		),
-	).toEqual({ display: "45.21021", value: "4521021000" });
+	expect(Currency.fromString("$ 45.210,21")).toEqual({ display: "45.21021", value: "4521021000" });
 
-	expect(
-		Currency.fromString(
-			{
-				name: "bitcoin",
-				code: "BTC",
-				magnitude: 8,
-			},
-			"Ѧ 0.100000008123",
-		),
-	).toEqual({ display: "0.10000000", value: "10000000" });
+	expect(Currency.fromString("Ѧ 0.1000000081283")).toEqual({ display: "0.10000000", value: "10000000" });
 
-	expect(
-		Currency.fromString(
-			{
-				name: "bitcoin",
-				code: "BTC",
-				magnitude: 8,
-			},
-			"52,21579",
-		),
-	).toEqual({ display: "52.21579", value: "5221579000" });
+	expect(Currency.fromString("52,21579")).toEqual({ display: "52.21579", value: "5221579000" });
 });

--- a/packages/platform-sdk-intl/__tests__/currency.test.ts
+++ b/packages/platform-sdk-intl/__tests__/currency.test.ts
@@ -1,0 +1,58 @@
+import { Currency } from "../src/currency";
+
+test("#fromString", () => {
+	expect(
+		Currency.fromString(
+			{
+				name: "bitcoin",
+				code: "BTC",
+				magnitude: 8,
+			},
+			"Ѧ 0,0001",
+		),
+	).toEqual({ display: "0.0001", value: "10000" });
+
+	expect(
+		Currency.fromString(
+			{
+				name: "bitcoin",
+				code: "BTC",
+				magnitude: 8,
+			},
+			"R$ 45,210.21",
+		),
+	).toEqual({ display: "45.21021", value: "4521021000" });
+
+	expect(
+		Currency.fromString(
+			{
+				name: "bitcoin",
+				code: "BTC",
+				magnitude: 8,
+			},
+			"$ 45.210,21",
+		),
+	).toEqual({ display: "45.21021", value: "4521021000" });
+
+	expect(
+		Currency.fromString(
+			{
+				name: "bitcoin",
+				code: "BTC",
+				magnitude: 8,
+			},
+			"Ѧ 0.100000008123",
+		),
+	).toEqual({ display: "0.10000000", value: "10000000" });
+
+	expect(
+		Currency.fromString(
+			{
+				name: "bitcoin",
+				code: "BTC",
+				magnitude: 8,
+			},
+			"52,21579",
+		),
+	).toEqual({ display: "52.21579", value: "5221579000" });
+});

--- a/packages/platform-sdk-intl/src/currency.ts
+++ b/packages/platform-sdk-intl/src/currency.ts
@@ -1,0 +1,110 @@
+// Based on https://github.com/LedgerHQ/ledger-live-common/blob/master/src/currencies/sanitizeValueString.js
+
+export interface CurrencyUnit {
+	// display name of a given unit (example: satoshi)
+	name: string;
+	// string to use when formatting the unit. like 'BTC' or 'USD'
+	code: string;
+	// number of digits after the '.'
+	magnitude: number;
+	// should it always print all digits even if they are 0 (usually: true for fiats, false for cryptos)
+	showAllDigits?: boolean;
+}
+
+export class Currency {
+	public static fromString(
+		unit: CurrencyUnit,
+		valueString: string,
+		locale?: string,
+	): {
+		display: string;
+		value: string;
+	} {
+		const seperator = Currency.getSeparators(locale || "en-US");
+		const dot = seperator.decimal || ".";
+
+		let display = "";
+		let value = "";
+		let decimals = -1;
+		for (let i = 0; i < valueString.length; i++) {
+			const c = valueString[i];
+
+			if ("0123456789".indexOf(c) !== -1) {
+				if (decimals >= 0) {
+					decimals++;
+					if (decimals > unit.magnitude) break;
+					value = value === "0" ? c : value + c;
+					display += c;
+				} else if (value !== "0") {
+					value += c;
+					display += c;
+				} else {
+					value = c;
+					display = c;
+				}
+			} else if (decimals === -1 && (c === "," || c === ".")) {
+				if (unit.magnitude === 0) {
+					// in this specific case, we will never allow commas
+					return { display, value };
+				}
+
+				if (i === 0) {
+					display = "0";
+				}
+
+				decimals = 0;
+				display += dot;
+			}
+		}
+		for (let i = Math.max(0, decimals); i < unit.magnitude; ++i) {
+			value += "0";
+		}
+
+		if (!value) {
+			value = "0";
+		}
+
+		return { display, value };
+	}
+
+	private static getSeparators(locale: string): { decimal: number; thousands: number } {
+		const localeNotAvailable = (1.2).toLocaleString("en", { style: "currency", currency: "USD" }) !== "$1.20";
+
+		let result;
+
+		if (localeNotAvailable) {
+			const staticFallback = {
+				en: ["-$1.00", "10,000.2"],
+				es: ["-1,00 US$", "10.000,2"],
+				fr: ["-1,00 $US", "10 000,2"],
+				ja: ["-US$1.00", "10,000.2"],
+				ko: ["-US$1.00", "10,000.2"],
+				ru: ["-1,00 $", "10 000,2"],
+				zh: ["-US$1.00", "10,000.2"],
+			};
+
+			result = staticFallback[Object.keys(staticFallback).includes(locale) ? locale : "en"][1];
+		} else {
+			result = (10000.2).toLocaleString(locale);
+		}
+
+		let decimal;
+		let thousands;
+
+		for (let i = 0; i < result.length; i++) {
+			const c = result[i];
+
+			if (/[0-9]/.test(c)) {
+				continue;
+			}
+
+			if (!thousands) {
+				thousands = c;
+			} else {
+				decimal = c;
+			}
+		}
+
+		return { decimal, thousands };
+	}
+}

--- a/packages/platform-sdk-intl/src/index.ts
+++ b/packages/platform-sdk-intl/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./currency";
 export * from "./datetime";
 export * from "./money";
 export * from "./numeral";


### PR DESCRIPTION
Implements a way to parse currency strings to get the raw numbers from it. Requires to pass in a `magnitude` to limit the decimal numbers but defaults to 8 for the magnitude.