### PR TITLE
refactor: use `Coins.Config` by reference

### DIFF
--- a/packages/platform-sdk-atom/src/services/identity/address.ts
+++ b/packages/platform-sdk-atom/src/services/identity/address.ts
@@ -1,21 +1,22 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
 import { BIP44 } from "@arkecosystem/platform-sdk-crypto";
 import bech32 from "bech32";
 
 export class Address implements Contracts.Address {
-	readonly #slip44;
-	readonly #bech32;
+	readonly #config: Coins.Config;
 
-	public constructor(slip44: number, bech32: string) {
-		this.#slip44 = slip44;
-		this.#bech32 = bech32;
+	public constructor(config: Coins.Config) {
+		this.#config = config;
 	}
 
 	public async fromMnemonic(mnemonic: string): Promise<string> {
-		const child = BIP44.deriveChild(mnemonic, { coinType: this.#slip44, index: 0 });
+		const child = BIP44.deriveChild(mnemonic, {
+			coinType: this.#config.get("network.crypto.slip44"),
+			index: 0,
+		});
 		const words = bech32.toWords(child.identifier);
 
-		return bech32.encode(this.#bech32, words);
+		return bech32.encode(this.#config.get("network.crypto.bech32"), words);
 	}
 
 	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<string> {

--- a/packages/platform-sdk-atom/src/services/identity/index.ts
+++ b/packages/platform-sdk-atom/src/services/identity/index.ts
@@ -7,16 +7,14 @@ import { PublicKey } from "./public-key";
 import { WIF } from "./wif";
 
 export class IdentityService implements Contracts.IdentityService {
-	readonly #slip44;
-	readonly #bech32;
+	readonly #config: Coins.Config;
 
-	public constructor(network: Coins.CoinNetwork) {
-		this.#slip44 = network.crypto.slip44;
-		this.#bech32 = network.crypto.bech32;
+	public constructor(config: Coins.Config) {
+		this.#config = config;
 	}
 
 	public static async construct(config: Coins.Config): Promise<IdentityService> {
-		return new IdentityService(config.get<Coins.CoinNetwork>("network"));
+		return new IdentityService(config);
 	}
 
 	public async destruct(): Promise<void> {
@@ -24,15 +22,15 @@ export class IdentityService implements Contracts.IdentityService {
 	}
 
 	public address(): Address {
-		return new Address(this.#slip44, this.#bech32);
+		return new Address(this.#config);
 	}
 
 	public publicKey(): PublicKey {
-		return new PublicKey(this.#slip44);
+		return new PublicKey(this.#config);
 	}
 
 	public privateKey(): PrivateKey {
-		return new PrivateKey(this.#slip44);
+		return new PrivateKey(this.#config);
 	}
 
 	public wif(): WIF {
@@ -40,6 +38,6 @@ export class IdentityService implements Contracts.IdentityService {
 	}
 
 	public keys(): Keys {
-		return new Keys(this.#slip44);
+		return new Keys(this.#config);
 	}
 }

--- a/packages/platform-sdk-atom/src/services/identity/keys.ts
+++ b/packages/platform-sdk-atom/src/services/identity/keys.ts
@@ -1,17 +1,17 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
 import { BIP44 } from "@arkecosystem/platform-sdk-crypto";
 import { secp256k1 } from "bcrypto";
 
 export class Keys implements Contracts.Keys {
-	readonly #slip44;
+	readonly #config: Coins.Config;
 
-	public constructor(slip44: number) {
-		this.#slip44 = slip44;
+	public constructor(config: Coins.Config) {
+		this.#config = config;
 	}
 
 	public async fromMnemonic(mnemonic: string): Promise<Contracts.KeyPair> {
 		const privateKey: Buffer | undefined = BIP44.deriveChild(mnemonic, {
-			coinType: this.#slip44,
+			coinType: this.#config.get("network.crypto.slip44"),
 			index: 0,
 		}).privateKey;
 

--- a/packages/platform-sdk-atom/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-atom/src/services/identity/private-key.ts
@@ -1,16 +1,17 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
 
 import { Keys } from "./keys";
 
 export class PrivateKey implements Contracts.PrivateKey {
-	readonly #keys: Keys;
+	readonly #config: Coins.Config;
 
-	public constructor(slip44: number) {
-		this.#keys = new Keys(slip44);
+	public constructor(config: Coins.Config) {
+		this.#config = config;
 	}
 
 	public async fromMnemonic(mnemonic: string): Promise<string> {
-		const { privateKey } = await this.#keys.fromMnemonic(mnemonic);
+		const keys = new Keys(this.#config.get("network.crypto.slip44"));
+		const { privateKey } = await keys.fromMnemonic(mnemonic);
 
 		if (!privateKey) {
 			throw new Error("Failed to derive the private key.");

--- a/packages/platform-sdk-atom/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-atom/src/services/identity/private-key.ts
@@ -10,7 +10,7 @@ export class PrivateKey implements Contracts.PrivateKey {
 	}
 
 	public async fromMnemonic(mnemonic: string): Promise<string> {
-		const keys = new Keys(this.#config.get("network.crypto.slip44"));
+		const keys = new Keys(this.#config);
 		const { privateKey } = await keys.fromMnemonic(mnemonic);
 
 		if (!privateKey) {

--- a/packages/platform-sdk-atom/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-atom/src/services/identity/public-key.ts
@@ -1,16 +1,17 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
 
 import { Keys } from "./keys";
 
 export class PublicKey implements Contracts.PublicKey {
-	readonly #keys: Keys;
+	readonly #config: Coins.Config;
 
-	public constructor(slip44: number) {
-		this.#keys = new Keys(slip44);
+	public constructor(config: Coins.Config) {
+		this.#config = config;
 	}
 
 	public async fromMnemonic(mnemonic: string): Promise<string> {
-		const { publicKey } = await this.#keys.fromMnemonic(mnemonic);
+		const keys = new Keys(this.#config.get("network.crypto.slip44"));
+		const { publicKey } = await keys.fromMnemonic(mnemonic);
 
 		if (!publicKey) {
 			throw new Error("Failed to derive the public key.");

--- a/packages/platform-sdk-atom/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-atom/src/services/identity/public-key.ts
@@ -10,7 +10,7 @@ export class PublicKey implements Contracts.PublicKey {
 	}
 
 	public async fromMnemonic(mnemonic: string): Promise<string> {
-		const keys = new Keys(this.#config.get("network.crypto.slip44"));
+		const keys = new Keys(this.#config);
 		const { publicKey } = await keys.fromMnemonic(mnemonic);
 
 		if (!publicKey) {

--- a/packages/platform-sdk-eth/src/services/identity/address.ts
+++ b/packages/platform-sdk-eth/src/services/identity/address.ts
@@ -1,18 +1,18 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
 import { Buffoon } from "@arkecosystem/platform-sdk-crypto";
 import Wallet from "ethereumjs-wallet";
 
 import { createWallet, getAddress } from "./utils";
 
 export class Address implements Contracts.Address {
-	readonly #slip44;
+	readonly #config: Coins.Config;
 
-	public constructor(slip44: number) {
-		this.#slip44 = slip44;
+	public constructor(config: Coins.Config) {
+		this.#config = config;
 	}
 
 	public async fromMnemonic(mnemonic: string): Promise<string> {
-		return getAddress(createWallet(mnemonic, this.#slip44));
+		return getAddress(createWallet(mnemonic, this.#config.get("network.crypto.slip44")));
 	}
 
 	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<string> {

--- a/packages/platform-sdk-eth/src/services/identity/index.ts
+++ b/packages/platform-sdk-eth/src/services/identity/index.ts
@@ -8,14 +8,14 @@ import { PublicKey } from "./public-key";
 import { WIF } from "./wif";
 
 export class IdentityService implements Contracts.IdentityService {
-	readonly #slip44;
+	readonly #config: Coins.Config;
 
-	public constructor(network: Coins.CoinNetwork) {
-		this.#slip44 = network.crypto.slip44;
+	public constructor(config: Coins.Config) {
+		this.#config = config;
 	}
 
 	public static async construct(config: Coins.Config): Promise<IdentityService> {
-		return new IdentityService(config.get<Coins.CoinNetwork>("network"));
+		return new IdentityService(config);
 	}
 
 	public async destruct(): Promise<void> {
@@ -23,15 +23,15 @@ export class IdentityService implements Contracts.IdentityService {
 	}
 
 	public address(): Address {
-		return new Address(this.#slip44);
+		return new Address(this.#config);
 	}
 
 	public publicKey(): PublicKey {
-		return new PublicKey(this.#slip44);
+		return new PublicKey(this.#config);
 	}
 
 	public privateKey(): PrivateKey {
-		return new PrivateKey(this.#slip44);
+		return new PrivateKey(this.#config);
 	}
 
 	public wif(): WIF {
@@ -39,6 +39,6 @@ export class IdentityService implements Contracts.IdentityService {
 	}
 
 	public keys(): Keys {
-		return new Keys(this.#slip44);
+		return new Keys(this.#config);
 	}
 }

--- a/packages/platform-sdk-eth/src/services/identity/keys.ts
+++ b/packages/platform-sdk-eth/src/services/identity/keys.ts
@@ -1,18 +1,18 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
 import { Buffoon } from "@arkecosystem/platform-sdk-crypto";
 import Wallet from "ethereumjs-wallet";
 
 import { createWallet } from "./utils";
 
 export class Keys implements Contracts.Keys {
-	readonly #slip44;
+	readonly #config: Coins.Config;
 
-	public constructor(slip44: number) {
-		this.#slip44 = slip44;
+	public constructor(config: Coins.Config) {
+		this.#config = config;
 	}
 
 	public async fromMnemonic(mnemonic: string): Promise<Contracts.KeyPair> {
-		const wallet: Wallet = createWallet(mnemonic, this.#slip44);
+		const wallet: Wallet = createWallet(mnemonic, this.#config.get("network.crypto.slip44"));
 
 		return {
 			publicKey: wallet.getPublicKey().toString("hex"),

--- a/packages/platform-sdk-eth/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-eth/src/services/identity/private-key.ts
@@ -1,16 +1,16 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
 
 import { createWallet } from "./utils";
 
 export class PrivateKey implements Contracts.PrivateKey {
-	readonly #slip44;
+	readonly #config: Coins.Config;
 
-	public constructor(slip44: number) {
-		this.#slip44 = slip44;
+	public constructor(config: Coins.Config) {
+		this.#config = config;
 	}
 
 	public async fromMnemonic(mnemonic: string): Promise<string> {
-		return createWallet(mnemonic, this.#slip44)
+		return createWallet(mnemonic, this.#config.get("network.crypto.slip44"))
 			.getPrivateKey()
 			.toString("hex");
 	}

--- a/packages/platform-sdk-eth/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-eth/src/services/identity/public-key.ts
@@ -12,7 +12,7 @@ export class PublicKey implements Contracts.PublicKey {
 	}
 
 	public async fromMnemonic(mnemonic: string): Promise<string> {
-		const privateKey = new PrivateKey(this.#config.get("network.crypto.slip44"));
+		const privateKey = new PrivateKey(this.#config);
 		const keyPair = Wallet.fromPrivateKey(Buffoon.fromHex(await privateKey.fromMnemonic(mnemonic)));
 
 		return keyPair.getPublicKey().toString("hex");

--- a/packages/platform-sdk-eth/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-eth/src/services/identity/public-key.ts
@@ -1,19 +1,19 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
 import { Buffoon } from "@arkecosystem/platform-sdk-crypto";
 import Wallet from "ethereumjs-wallet";
 
 import { PrivateKey } from "./private-key";
 
 export class PublicKey implements Contracts.PublicKey {
-	readonly #privateKey: PrivateKey;
+	readonly #config: Coins.Config;
 
-	public constructor(slip44: number) {
-		this.#privateKey = new PrivateKey(slip44);
+	public constructor(config: Coins.Config) {
+		this.#config = config;
 	}
 
 	public async fromMnemonic(mnemonic: string): Promise<string> {
-		const privateKey = Buffoon.fromHex(await this.#privateKey.fromMnemonic(mnemonic));
-		const keyPair = Wallet.fromPrivateKey(privateKey);
+		const privateKey = new PrivateKey(this.#config.get("network.crypto.slip44"));
+		const keyPair = Wallet.fromPrivateKey(Buffoon.fromHex(await privateKey.fromMnemonic(mnemonic)));
 
 		return keyPair.getPublicKey().toString("hex");
 	}

--- a/packages/platform-sdk-xrp/src/services/client.ts
+++ b/packages/platform-sdk-xrp/src/services/client.ts
@@ -147,7 +147,7 @@ export class ClientService implements Contracts.ClientService {
 		return new ClientService(connection);
 	}
 
-	public async destruct() {
+	public async destruct(): Promise<void> {
 		await this.#connection.disconnect();
 	}
 

--- a/packages/platform-sdk-xrp/src/services/ledger.ts
+++ b/packages/platform-sdk-xrp/src/services/ledger.ts
@@ -2,16 +2,11 @@ import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
 import Ripple from "@ledgerhq/hw-app-xrp";
 
 export class LedgerService implements Contracts.LedgerService {
-	#config: Coins.Config;
 	#ledger: Contracts.LedgerTransport;
 	#transport!: Ripple;
 
-	private constructor(config: Coins.Config) {
-		this.#config = config;
-	}
-
 	public static async construct(config: Coins.Config): Promise<LedgerService> {
-		return new LedgerService(config);
+		return new LedgerService();
 	}
 
 	public async destruct(): Promise<void> {


### PR DESCRIPTION
> Resolves https://github.com/ArkEcosystem/platform-sdk/issues/458

Only peers will not be used by reference because some coins use WebSockets or require peers in several places which would lead to having to implement some kind of watchers to recreate all of those instances. In those cases, it is advised to simply recreate the whole coin instance to ensure that all previous instances are destroyed and won't interfere with the new one.