### PR TITLE
fix(intl): use `day` instead of `date` for differences

### DIFF
--- a/packages/platform-sdk-intl/__tests__/datetime.test.ts
+++ b/packages/platform-sdk-intl/__tests__/datetime.test.ts
@@ -247,7 +247,7 @@ test("#diffInHours", () => {
 });
 
 test("#diffInDays", () => {
-	expect(subject.diffInDays(subject.addDay())).toBe(-86400000);
+	expect(subject.diffInDays(subject.addDay())).toBe(-1);
 });
 
 test("#diffInWeeks", () => {

--- a/packages/platform-sdk-intl/src/datetime.ts
+++ b/packages/platform-sdk-intl/src/datetime.ts
@@ -301,7 +301,7 @@ export class DateTime {
 	}
 
 	public diffInDays(value: DateTimeLike): number {
-		return this.#instance.diff(this.toUTC(value), "date");
+		return this.#instance.diff(this.toUTC(value), "day");
 	}
 
 	public diffInWeeks(value: DateTimeLike): number {


### PR DESCRIPTION
https://day.js.org/docs/en/display/difference