### PR TITLE
fix(profiles): export `NetworkData`

### DIFF
--- a/packages/platform-sdk-profiles/src/index.ts
+++ b/packages/platform-sdk-profiles/src/index.ts
@@ -2,6 +2,7 @@ export * from "./avatar";
 export * from "./contact";
 export * from "./env";
 export * from "./migrator";
+export * from "./network";
 export * from "./profile";
 export * from "./wallet";
 


### PR DESCRIPTION
## Summary

Export the network file in `platform-sdk-profiles` to use `NetworkData`.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
