### PR TITLE
refactor: streamline profile repository methods

### DIFF
--- a/packages/platform-sdk-profiles/src/repositories/profile-repository.test.ts
+++ b/packages/platform-sdk-profiles/src/repositories/profile-repository.test.ts
@@ -9,21 +9,21 @@ beforeEach(() => (subject = new ProfileRepository()));
 
 describe("ProfileRepository", () => {
 	it("should push, get, list and forget any given profiles", async () => {
-		expect(subject.all()).toHaveLength(0);
+		expect(subject.values()).toHaveLength(0);
 
 		const john = subject.create("John");
 
-		expect(subject.all()).toHaveLength(1);
+		expect(subject.values()).toHaveLength(1);
 		expect(subject.findById(john.id())).toBeInstanceOf(Profile);
 
 		const jane = subject.create("Jane");
 
-		expect(subject.all()).toHaveLength(2);
+		expect(subject.values()).toHaveLength(2);
 		expect(subject.findById(jane.id())).toBeInstanceOf(Profile);
 
 		subject.forget(jane.id());
 
-		expect(subject.all()).toHaveLength(1);
+		expect(subject.values()).toHaveLength(1);
 		expect(() => subject.findById(jane.id())).toThrow("No profile found for");
 	});
 });

--- a/packages/platform-sdk-profiles/src/repositories/profile-repository.ts
+++ b/packages/platform-sdk-profiles/src/repositories/profile-repository.ts
@@ -33,8 +33,16 @@ export class ProfileRepository {
 		}
 	}
 
-	public all(): Profile[] {
-		return Object.values(this.#data.all());
+	public all(): Record<string, Profile> {
+		return this.#data.all() as Record<string, Profile>;
+	}
+
+	public keys(): string[] {
+		return this.#data.keys();
+	}
+
+	public values(): Profile[] {
+		return this.#data.values();
 	}
 
 	public findById(id: string): Profile {
@@ -46,7 +54,7 @@ export class ProfileRepository {
 	}
 
 	public create(name: string): Profile {
-		const profiles: Profile[] = this.all();
+		const profiles: Profile[] = this.values();
 
 		for (const profile of profiles) {
 			if (profile.name() === name) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adjusts the `all()` method and adds a `keys()` and `values()` method to the profile repository to be in line with the other repositories.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
