### PR TITLE
fix(profiles): fix profile registration aggregate query params

### DIFF
--- a/packages/platform-sdk-profiles/src/profiles/aggregates/registration-aggregate.test.ts
+++ b/packages/platform-sdk-profiles/src/profiles/aggregates/registration-aggregate.test.ts
@@ -1,0 +1,86 @@
+import "jest-extended";
+
+import { ARK } from "@arkecosystem/platform-sdk-ark";
+import { Request } from "@arkecosystem/platform-sdk-http-got";
+import nock from "nock";
+
+import { container } from "../../environment/container";
+import { Identifiers } from "../../environment/container.models";
+import { Profile } from "../profile";
+
+let profile: Profile;
+
+beforeEach(async () => {
+	nock.disableNetConnect();
+
+	nock(/.+/)
+		.get("/api/node/configuration/crypto")
+		.reply(200, require("../../../test/fixtures/client/cryptoConfiguration.json"))
+		.get("/api/node/configuration")
+		.reply(200, require("../../../test/fixtures/client/configuration.json"))
+		.get("/api/peers")
+		.reply(200, require("../../../test/fixtures/client/peers.json"))
+		.get("/api/node/syncing")
+		.reply(200, require("../../../test/fixtures/client/syncing.json"))
+		.get("/api/wallets/D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb")
+		.reply(200, require("../../../test/fixtures/wallets/D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb.json"))
+		.persist();
+
+	container.set(Identifiers.HttpClient, new Request());
+	container.set(Identifiers.Coins, { ARK });
+	profile = new Profile("uuid");
+	const address = "D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb";
+
+	await profile.wallets().importByAddress(address, "ARK", "devnet");
+});
+
+afterAll(() => nock.enableNetConnect());
+
+it("should aggregate all registrations", async () => {
+	nock(/.+/)
+		.post("/api/transactions/search")
+		.reply(200, require("../../../test/fixtures/client/registrations/all.json"));
+
+	const allRegistrations = await profile.registrationAggregate().all();
+
+	expect(allRegistrations.items()).toHaveLength(3);
+	expect(allRegistrations.findById("03e44853b26f450d5aba78e3fad390faa8ae9aa6995b1fa80b8d191516b52f1e")).toBeTruthy();
+	expect(allRegistrations.findById("9d25ddf8e59d8595a74d7fe74fdee3380660d60333c453b1a352326d80ba4b43")).toBeTruthy();
+	expect(allRegistrations.findById("df520b0a278314e998dc93be1e20c72b8313950c19da23967a9db60eb4e990da")).toBeTruthy();
+});
+
+it("should aggregate business registrations", async () => {
+	nock.cleanAll();
+	nock(/.+/)
+		.post("/api/transactions/search")
+		.reply(200, require("../../../test/fixtures/client/registrations/business.json"));
+
+	const registrations = await profile.registrationAggregate().businesses();
+
+	expect(registrations.items()).toHaveLength(1);
+	expect(registrations.findById("df520b0a278314e998dc93be1e20c72b8313950c19da23967a9db60eb4e990da")).toBeTruthy();
+});
+
+it("should aggregate core plugin registrations", async () => {
+	nock.cleanAll();
+	nock(/.+/)
+		.post("/api/transactions/search")
+		.reply(200, require("../../../test/fixtures/client/registrations/core-plugins.json"));
+
+	const registrations = await profile.registrationAggregate().corePlugins();
+
+	expect(registrations.items()).toHaveLength(1);
+	expect(registrations.findById("9d25ddf8e59d8595a74d7fe74fdee3380660d60333c453b1a352326d80ba4b43")).toBeTruthy();
+});
+
+it("should aggregate desktop wallet plugin registrations", async () => {
+	nock.cleanAll();
+	nock(/.+/)
+		.post("/api/transactions/search")
+		.reply(200, require("../../../test/fixtures/client/registrations/desktop-plugins.json"));
+
+	const registrations = await profile.registrationAggregate().desktopWalletPlugins();
+
+	expect(registrations.items()).toHaveLength(1);
+	expect(registrations.findById("03e44853b26f450d5aba78e3fad390faa8ae9aa6995b1fa80b8d191516b52f1e")).toBeTruthy();
+});

--- a/packages/platform-sdk-profiles/src/profiles/aggregates/registration-aggregate.ts
+++ b/packages/platform-sdk-profiles/src/profiles/aggregates/registration-aggregate.ts
@@ -87,10 +87,10 @@ export class RegistrationAggregate {
 				};
 
 				if (lastResponse && lastResponse.hasMorePages()) {
-					return resolve(syncedWallet.transactions({ cursor: lastResponse.nextPage(), ...query }));
+					return resolve(syncedWallet.client().transactions({ cursor: lastResponse.nextPage(), ...query }));
 				}
 
-				return resolve(syncedWallet.transactions(query));
+				return resolve(syncedWallet.client().transactions(query));
 			});
 		}
 

--- a/packages/platform-sdk-profiles/test/fixtures/client/registrations/all.json
+++ b/packages/platform-sdk-profiles/test/fixtures/client/registrations/all.json
@@ -1,0 +1,102 @@
+{
+	"meta": {
+		"totalCountIsEstimate": false,
+		"count": 3,
+		"pageCount": 1,
+		"totalCount": 3,
+		"next": null,
+		"previous": null,
+		"self": "/transactions/search?transform=true&page=1&limit=100",
+		"first": "/transactions/search?transform=true&page=1&limit=100",
+		"last": "/transactions/search?transform=true&page=1&limit=100"
+	},
+	"data": [
+		{
+			"id": "03e44853b26f450d5aba78e3fad390faa8ae9aa6995b1fa80b8d191516b52f1e",
+			"blockId": "6df1acf95b8ca678d8291617c3fd053b322ef85688558383520215f9ec73c250",
+			"version": 2,
+			"type": 6,
+			"typeGroup": 2,
+			"amount": "0",
+			"fee": "5000000000",
+			"sender": "D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb",
+			"senderPublicKey": "03af2feb4fc97301e16d6a877d5b135417e8f284d40fac0f84c09ca37f82886c51",
+			"recipient": "D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb",
+			"signature": "c76598d67b064f0dfdc24641bc6e5c3cf0d41d137005cd1416c8473aed657a2e0976a71a21345259b094616936a79622dfbe889fe76c5bf0f6c657f02ece3787",
+			"asset": {
+				"type": 3,
+				"subType": 2,
+				"action": 0,
+				"data": {
+					"name": "desktopplugin2",
+					"ipfsData": "QmNgvK9AAh7XVHubzJE3F33K4GJubFcQm9AUPBy1vFCEsV"
+				}
+			},
+			"confirmations": 138688,
+			"timestamp": {
+				"epoch": 106691600,
+				"unix": 1596792800,
+				"human": "2020-08-07T09:33:20.000Z"
+			},
+			"nonce": "10"
+		},
+		{
+			"id": "9d25ddf8e59d8595a74d7fe74fdee3380660d60333c453b1a352326d80ba4b43",
+			"blockId": "d2a58f4e3943643cca6c11628524ddfca0874b0c7ce8bf942c7875b5a70085a3",
+			"version": 2,
+			"type": 6,
+			"typeGroup": 2,
+			"amount": "0",
+			"fee": "5000000000",
+			"sender": "D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb",
+			"senderPublicKey": "03af2feb4fc97301e16d6a877d5b135417e8f284d40fac0f84c09ca37f82886c51",
+			"recipient": "D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb",
+			"signature": "182c5d52539d57eab8aca0dc33d54572fb46d20175406003d3607f89437ebcd2e30b76b693d46c383b72214fb7cef98b635db0298a98412430219f8e99c667a5",
+			"asset": {
+				"type": 3,
+				"subType": 1,
+				"action": 0,
+				"data": {
+					"name": "coreplugin2",
+					"ipfsData": "QmXCuXaBuWZGqES7tDW6AHFCGj8zEzFG48P1BHWSU1fqq3"
+				}
+			},
+			"confirmations": 138690,
+			"timestamp": {
+				"epoch": 106691584,
+				"unix": 1596792784,
+				"human": "2020-08-07T09:33:04.000Z"
+			},
+			"nonce": "9"
+		},
+		{
+			"id": "df520b0a278314e998dc93be1e20c72b8313950c19da23967a9db60eb4e990da",
+			"blockId": "3a6156804fd49caaec44d6cd1aa9b99b2c24204c14aa2ca966739a2063828f58",
+			"version": 2,
+			"type": 6,
+			"typeGroup": 2,
+			"amount": "0",
+			"fee": "5000000000",
+			"sender": "D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb",
+			"senderPublicKey": "03af2feb4fc97301e16d6a877d5b135417e8f284d40fac0f84c09ca37f82886c51",
+			"recipient": "D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb",
+			"signature": "68e006bf3133bf582aa3ce9fa0722225940a5fa797fb59f02333e89c2c7909681ad988db5baebdb7152010db15713069dde0755a23bf8b797f626d09b0cb7ad4",
+			"asset": {
+				"type": 0,
+				"subType": 0,
+				"action": 0,
+				"data": {
+					"name": "business2reg",
+					"ipfsData": "QmRwgWaaEyYgGqp55196TsFDQLW4NZkyTnPwiSVhJ7NPRV"
+				}
+			},
+			"confirmations": 138693,
+			"timestamp": {
+				"epoch": 106691560,
+				"unix": 1596792760,
+				"human": "2020-08-07T09:32:40.000Z"
+			},
+			"nonce": "8"
+		}
+	]
+}

--- a/packages/platform-sdk-profiles/test/fixtures/client/registrations/business.json
+++ b/packages/platform-sdk-profiles/test/fixtures/client/registrations/business.json
@@ -1,0 +1,44 @@
+{
+	"meta": {
+		"totalCountIsEstimate": false,
+		"count": 1,
+		"pageCount": 1,
+		"totalCount": 1,
+		"next": null,
+		"previous": null,
+		"self": "/transactions/search?transform=true&page=1&limit=100",
+		"first": "/transactions/search?transform=true&page=1&limit=100",
+		"last": "/transactions/search?transform=true&page=1&limit=100"
+	},
+	"data": [
+		{
+			"id": "df520b0a278314e998dc93be1e20c72b8313950c19da23967a9db60eb4e990da",
+			"blockId": "3a6156804fd49caaec44d6cd1aa9b99b2c24204c14aa2ca966739a2063828f58",
+			"version": 2,
+			"type": 6,
+			"typeGroup": 2,
+			"amount": "0",
+			"fee": "5000000000",
+			"sender": "D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb",
+			"senderPublicKey": "03af2feb4fc97301e16d6a877d5b135417e8f284d40fac0f84c09ca37f82886c51",
+			"recipient": "D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb",
+			"signature": "68e006bf3133bf582aa3ce9fa0722225940a5fa797fb59f02333e89c2c7909681ad988db5baebdb7152010db15713069dde0755a23bf8b797f626d09b0cb7ad4",
+			"asset": {
+				"type": 0,
+				"subType": 0,
+				"action": 0,
+				"data": {
+					"name": "business2reg",
+					"ipfsData": "QmRwgWaaEyYgGqp55196TsFDQLW4NZkyTnPwiSVhJ7NPRV"
+				}
+			},
+			"confirmations": 138693,
+			"timestamp": {
+				"epoch": 106691560,
+				"unix": 1596792760,
+				"human": "2020-08-07T09:32:40.000Z"
+			},
+			"nonce": "8"
+		}
+	]
+}

--- a/packages/platform-sdk-profiles/test/fixtures/client/registrations/core-plugins.json
+++ b/packages/platform-sdk-profiles/test/fixtures/client/registrations/core-plugins.json
@@ -1,0 +1,44 @@
+{
+	"meta": {
+		"totalCountIsEstimate": false,
+		"count": 1,
+		"pageCount": 1,
+		"totalCount": 1,
+		"next": null,
+		"previous": null,
+		"self": "/transactions/search?transform=true&page=1&limit=100",
+		"first": "/transactions/search?transform=true&page=1&limit=100",
+		"last": "/transactions/search?transform=true&page=1&limit=100"
+	},
+	"data": [
+		{
+			"id": "9d25ddf8e59d8595a74d7fe74fdee3380660d60333c453b1a352326d80ba4b43",
+			"blockId": "d2a58f4e3943643cca6c11628524ddfca0874b0c7ce8bf942c7875b5a70085a3",
+			"version": 2,
+			"type": 6,
+			"typeGroup": 2,
+			"amount": "0",
+			"fee": "5000000000",
+			"sender": "D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb",
+			"senderPublicKey": "03af2feb4fc97301e16d6a877d5b135417e8f284d40fac0f84c09ca37f82886c51",
+			"recipient": "D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb",
+			"signature": "182c5d52539d57eab8aca0dc33d54572fb46d20175406003d3607f89437ebcd2e30b76b693d46c383b72214fb7cef98b635db0298a98412430219f8e99c667a5",
+			"asset": {
+				"type": 3,
+				"subType": 1,
+				"action": 0,
+				"data": {
+					"name": "coreplugin2",
+					"ipfsData": "QmXCuXaBuWZGqES7tDW6AHFCGj8zEzFG48P1BHWSU1fqq3"
+				}
+			},
+			"confirmations": 138690,
+			"timestamp": {
+				"epoch": 106691584,
+				"unix": 1596792784,
+				"human": "2020-08-07T09:33:04.000Z"
+			},
+			"nonce": "9"
+		}
+	]
+}

--- a/packages/platform-sdk-profiles/test/fixtures/client/registrations/desktop-plugins.json
+++ b/packages/platform-sdk-profiles/test/fixtures/client/registrations/desktop-plugins.json
@@ -1,0 +1,44 @@
+{
+	"meta": {
+		"totalCountIsEstimate": false,
+		"count": 1,
+		"pageCount": 1,
+		"totalCount": 1,
+		"next": null,
+		"previous": null,
+		"self": "/transactions/search?transform=true&page=1&limit=100",
+		"first": "/transactions/search?transform=true&page=1&limit=100",
+		"last": "/transactions/search?transform=true&page=1&limit=100"
+	},
+	"data": [
+		{
+			"id": "03e44853b26f450d5aba78e3fad390faa8ae9aa6995b1fa80b8d191516b52f1e",
+			"blockId": "6df1acf95b8ca678d8291617c3fd053b322ef85688558383520215f9ec73c250",
+			"version": 2,
+			"type": 6,
+			"typeGroup": 2,
+			"amount": "0",
+			"fee": "5000000000",
+			"sender": "D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb",
+			"senderPublicKey": "03af2feb4fc97301e16d6a877d5b135417e8f284d40fac0f84c09ca37f82886c51",
+			"recipient": "D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb",
+			"signature": "c76598d67b064f0dfdc24641bc6e5c3cf0d41d137005cd1416c8473aed657a2e0976a71a21345259b094616936a79622dfbe889fe76c5bf0f6c657f02ece3787",
+			"asset": {
+				"type": 3,
+				"subType": 2,
+				"action": 0,
+				"data": {
+					"name": "desktopplugin2",
+					"ipfsData": "QmNgvK9AAh7XVHubzJE3F33K4GJubFcQm9AUPBy1vFCEsV"
+				}
+			},
+			"confirmations": 138688,
+			"timestamp": {
+				"epoch": 106691600,
+				"unix": 1596792800,
+				"human": "2020-08-07T09:33:20.000Z"
+			},
+			"nonce": "10"
+		}
+	]
+}

--- a/packages/platform-sdk-profiles/test/fixtures/wallets/D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb.json
+++ b/packages/platform-sdk-profiles/test/fixtures/wallets/D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb.json
@@ -1,0 +1,54 @@
+{
+	"data": {
+		"address": "D5sRKWckH4rE1hQ9eeMeHAepgyC3cvJtwb",
+		"publicKey": "03af2feb4fc97301e16d6a877d5b135417e8f284d40fac0f84c09ca37f82886c51",
+		"nonce": "12",
+		"balance": "5768000000",
+		"attributes": {
+			"secondPublicKey": "03c05c3520f4a459143779b97e8081798f550fcc20c1e02600845cea92bb15947b",
+			"delegate": {
+				"username": "testwallet2",
+				"voteBalance": "0",
+				"forgedFees": "0",
+				"forgedRewards": "0",
+				"producedBlocks": 0,
+				"resigned": true
+			},
+			"ipfs": {
+				"hashes": {
+					"QmPRqPTEEwx95WNcSsk6YQk7aGW9hoZbTF9zE92dBj9H68": true
+				}
+			},
+			"entities": {
+				"df520b0a278314e998dc93be1e20c72b8313950c19da23967a9db60eb4e990da": {
+					"type": 0,
+					"subType": 0,
+					"data": {
+						"name": "business2reg",
+						"ipfsData": "QmRwgWaaEyYgGqp55196TsFDQLW4NZkyTnPwiSVhJ7NPRV"
+					}
+				},
+				"9d25ddf8e59d8595a74d7fe74fdee3380660d60333c453b1a352326d80ba4b43": {
+					"type": 3,
+					"subType": 1,
+					"data": {
+						"name": "coreplugin2",
+						"ipfsData": "QmXCuXaBuWZGqES7tDW6AHFCGj8zEzFG48P1BHWSU1fqq3"
+					}
+				},
+				"03e44853b26f450d5aba78e3fad390faa8ae9aa6995b1fa80b8d191516b52f1e": {
+					"type": 3,
+					"subType": 2,
+					"data": {
+						"name": "desktopplugin2",
+						"ipfsData": "QmNgvK9AAh7XVHubzJE3F33K4GJubFcQm9AUPBy1vFCEsV"
+					}
+				}
+			}
+		},
+		"isDelegate": true,
+		"isResigned": true,
+		"username": "testwallet2",
+		"secondPublicKey": "03c05c3520f4a459143779b97e8081798f550fcc20c1e02600845cea92bb15947b"
+	}
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
* Use `syncedWallet.client().transactions()` instead of `syncedWallet.transactions()` to fetch registration txs, omitting the `addresses` request param, that was returning empty data.
* Add fixtures and registration aggregate tests

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
