### PR TITLE
feat(profiles): store exchange currency in wallet data

### DIFF
--- a/packages/platform-sdk-profiles/src/environment/services/exchange-rate-service.ts
+++ b/packages/platform-sdk-profiles/src/environment/services/exchange-rate-service.ts
@@ -7,41 +7,36 @@ import { ReadWriteWallet, WalletData } from "../../wallets/wallet.models";
 import { container } from "../container";
 import { Identifiers } from "../container.models";
 
-// TODO: remove duplicate syncing of exchange rates.
-// A profile could have 100 ARK Wallets and we would send 100 requests at the moment.
 export class ExchangeRateService {
 	public async syncAll(): Promise<void> {
 		const profiles: Profile[] = container.get<ProfileRepository>(Identifiers.ProfileRepository).values();
 
 		const promises: Promise<void>[] = [];
 		for (const profile of profiles) {
-			for (const wallet of profile.wallets().values()) {
-				promises.push(this.getExchangeRate(profile, wallet));
+			for (const [currency, wallets] of Object.entries(profile.wallets().allByCoin())) {
+				promises.push(this.getExchangeRate(profile, currency, Object.values(wallets)));
 			}
 		}
 
 		await Promise.allSettled(promises);
 	}
 
-	private async getExchangeRate(profile: Profile, wallet: ReadWriteWallet): Promise<void> {
+	private async getExchangeRate(profile: Profile, currency: string, wallets: ReadWriteWallet[]): Promise<void> {
 		const marketService = MarketService.make(
 			profile.settings().get(ProfileSetting.MarketProvider) || "coingecko",
 			container.get(Identifiers.HttpClient),
 		);
 
 		const exchangeCurrency: string = profile.settings().get(ProfileSetting.ExchangeCurrency) || "BTC";
+		const exchangeRate = await marketService.dailyAverage(
+			currency,
+			exchangeCurrency,
+			+Date.now(),
+		);
 
-		wallet
-			.data()
-			.set(
-				WalletData.ExchangeRate,
-				await marketService.dailyAverage(
-					wallet.currency(),
-					exchangeCurrency,
-					+Date.now(),
-				),
-			);
-
-		wallet.data().set(WalletData.ExchangeCurrency, exchangeCurrency);
+		for (const wallet of wallets) {
+			wallet.data().set(WalletData.ExchangeCurrency, exchangeCurrency);
+			wallet.data().set(WalletData.ExchangeRate, exchangeRate);
+		}
 	}
 }

--- a/packages/platform-sdk-profiles/src/environment/services/exchange-rate-service.ts
+++ b/packages/platform-sdk-profiles/src/environment/services/exchange-rate-service.ts
@@ -29,15 +29,19 @@ export class ExchangeRateService {
 			container.get(Identifiers.HttpClient),
 		);
 
+		const exchangeCurrency: string = profile.settings().get(ProfileSetting.ExchangeCurrency) || "BTC";
+
 		wallet
 			.data()
 			.set(
 				WalletData.ExchangeRate,
 				await marketService.dailyAverage(
 					wallet.currency(),
-					profile.settings().get(ProfileSetting.ExchangeCurrency) || "BTC",
+					exchangeCurrency,
 					+Date.now(),
 				),
 			);
+
+		wallet.data().set(WalletData.ExchangeCurrency, exchangeCurrency);
 	}
 }

--- a/packages/platform-sdk-profiles/src/wallets/wallet.models.ts
+++ b/packages/platform-sdk-profiles/src/wallets/wallet.models.ts
@@ -46,6 +46,7 @@ export enum WalletData {
 	Balance = "BALANCE",
 	BroadcastedTransactions = "BROADCASTED_TRANSACTIONS",
 	Delegates = "DELEGATES",
+	ExchangeCurrency = "EXCHANGE_CURRENCY",
 	ExchangeRate = "EXCHANGE_RATE",
 	MultiSignatureParticipants = "MULTI_SIGNATURE_PARTICIPANTS",
 	Sequence = "SEQUENCE",
@@ -72,6 +73,7 @@ export interface ReadWriteWallet {
 	coin(): Coins.Coin;
 	network(): NetworkData;
 	currency(): string;
+	exchangeCurrency(): string;
 	alias(): string | undefined;
 	address(): string;
 	publicKey(): string | undefined;

--- a/packages/platform-sdk-profiles/src/wallets/wallet.test.ts
+++ b/packages/platform-sdk-profiles/src/wallets/wallet.test.ts
@@ -187,7 +187,7 @@ describe.each([123, 456, 789])("%s", (slip44) => {
 		expect(actual.data).toEqual({
 			BALANCE: "55827093444556",
 			BROADCASTED_TRANSACTIONS: {},
-			EXCHANGE_CURRENCY: "",
+			EXCHANGE_CURRENCY: "BTC",
 			EXCHANGE_RATE: 0,
 			SEQUENCE: "111932",
 			SIGNED_TRANSACTIONS: {},

--- a/packages/platform-sdk-profiles/src/wallets/wallet.test.ts
+++ b/packages/platform-sdk-profiles/src/wallets/wallet.test.ts
@@ -187,6 +187,7 @@ describe.each([123, 456, 789])("%s", (slip44) => {
 		expect(actual.data).toEqual({
 			BALANCE: "55827093444556",
 			BROADCASTED_TRANSACTIONS: {},
+			EXCHANGE_CURRENCY: "",
 			EXCHANGE_RATE: 0,
 			SEQUENCE: "111932",
 			SIGNED_TRANSACTIONS: {},

--- a/packages/platform-sdk-profiles/src/wallets/wallet.ts
+++ b/packages/platform-sdk-profiles/src/wallets/wallet.ts
@@ -131,6 +131,10 @@ export class Wallet implements ReadWriteWallet {
 		return this.network().ticker();
 	}
 
+	public exchangeCurrency(): string {
+		return this.data().get(WalletData.ExchangeCurrency) as string;
+	}
+
 	public alias(): string | undefined {
 		return this.settings().get(WalletSetting.Alias);
 	}
@@ -207,6 +211,7 @@ export class Wallet implements ReadWriteWallet {
 			data: {
 				[WalletData.Balance]: this.balance().toFixed(),
 				[WalletData.BroadcastedTransactions]: this.data().get(WalletData.BroadcastedTransactions, []),
+				[WalletData.ExchangeCurrency]: this.data().get(WalletData.ExchangeCurrency, ""),
 				[WalletData.ExchangeRate]: this.data().get(WalletData.ExchangeRate, 0),
 				[WalletData.Sequence]: this.nonce().toFixed(),
 				[WalletData.SignedTransactions]: this.data().get(WalletData.SignedTransactions, []),

--- a/packages/platform-sdk-profiles/src/wallets/wallet.ts
+++ b/packages/platform-sdk-profiles/src/wallets/wallet.ts
@@ -211,7 +211,7 @@ export class Wallet implements ReadWriteWallet {
 			data: {
 				[WalletData.Balance]: this.balance().toFixed(),
 				[WalletData.BroadcastedTransactions]: this.data().get(WalletData.BroadcastedTransactions, []),
-				[WalletData.ExchangeCurrency]: this.data().get(WalletData.ExchangeCurrency, ""),
+				[WalletData.ExchangeCurrency]: this.data().get(WalletData.ExchangeCurrency, "BTC"),
 				[WalletData.ExchangeRate]: this.data().get(WalletData.ExchangeRate, 0),
 				[WalletData.Sequence]: this.nonce().toFixed(),
 				[WalletData.SignedTransactions]: this.data().get(WalletData.SignedTransactions, []),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

- Stores the exchange currency in addition to the exchange rate on a wallet.

- Updates the market service to fetch each coins exchange rate only once per profile.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
