### PR TITLE
fix(profiles): do not set avatar during initialization

### DIFF
--- a/packages/platform-sdk-profiles/src/environment/env.test.ts
+++ b/packages/platform-sdk-profiles/src/environment/env.test.ts
@@ -112,7 +112,6 @@ it("should create a profile with data and persist it when instructed to do so", 
 	expect(newProfile.settings().all()).toEqual({
 		ADVANCED_MODE: "value",
 		AUTOMATIC_SIGN_OUT_PERIOD: 15,
-		AVATAR: "<svg version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100\" height=\"100\" viewBox=\"0 0 100 100\"><style>circle{mix-blend-mode:soft-light;}</style><rect fill=\"rgb(233, 30, 99)\" width=\"100\" height=\"100\"/><circle r=\"45\" cx=\"80\" cy=\"30\" fill=\"rgb(76, 175, 80)\"/><circle r=\"55\" cx=\"0\" cy=\"60\" fill=\"rgb(255, 152, 0)\"/><circle r=\"40\" cx=\"50\" cy=\"50\" fill=\"rgb(3, 169, 244)\"/></svg>",
 		BIP39_LOCALE: "english",
 		EXCHANGE_CURRENCY: "BTC",
 		LEDGER_UPDATE_METHOD: false,

--- a/packages/platform-sdk-profiles/src/profiles/profile.test.ts
+++ b/packages/platform-sdk-profiles/src/profiles/profile.test.ts
@@ -91,7 +91,7 @@ it("should flush all data", () => {
 
 	subject.flush();
 
-	expect(subject.settings().keys()).toHaveLength(12);
+	expect(subject.settings().keys()).toHaveLength(11);
 });
 
 it("should fail to flush all data if the name is missing", () => {

--- a/packages/platform-sdk-profiles/src/profiles/profile.ts
+++ b/packages/platform-sdk-profiles/src/profiles/profile.ts
@@ -170,7 +170,6 @@ export class Profile implements ProfileContract {
 
 	public initializeSettings(): void {
 		this.settings().set(ProfileSetting.AdvancedMode, false);
-		this.settings().set(ProfileSetting.Avatar, Avatar.make(this.name()));
 		this.settings().set(ProfileSetting.AutomaticSignOutPeriod, 15);
 		this.settings().set(ProfileSetting.Bip39Locale, "english");
 		this.settings().set(ProfileSetting.ExchangeCurrency, "BTC");


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The default avatar should not be stored.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
