### PR TITLE
refactor: adjust return types in notifications repo

### DIFF
--- a/packages/platform-sdk-profiles/src/repositories/notification-repository.test.ts
+++ b/packages/platform-sdk-profiles/src/repositories/notification-repository.test.ts
@@ -26,13 +26,8 @@ beforeEach(() => (subject = new NotificationRepository()));
 test("#all", () => {
 	expect(subject.keys()).toHaveLength(0);
 
-	subject.push(stubNotification);
-
-	expect(subject.keys()).toHaveLength(1);
-
-	subject.push(stubNotification);
-
-	expect(subject.keys()).toHaveLength(2);
+	stubNotifications.forEach((n) => subject.push(n));
+	expect(Object.keys(subject.all())).toHaveLength(2);
 });
 
 test("#first", () => {

--- a/packages/platform-sdk-profiles/src/repositories/notification-repository.test.ts
+++ b/packages/platform-sdk-profiles/src/repositories/notification-repository.test.ts
@@ -4,14 +4,80 @@ import { NotificationRepository } from "./notification-repository";
 
 let subject: NotificationRepository;
 
-const stubNotification = {
-	icon: "warning",
-	name: "Ledger Update Available",
-	body: "...",
-	action: "Read Changelog",
-};
+const stubNotifications = [
+	{
+		icon: "warning",
+		name: "Ledger Update Available",
+		body: "...",
+		action: "Read Changelog",
+	},
+	{
+		icon: "warning",
+		name: "Ledger Update Available",
+		body: "...",
+		action: "Read Changelog",
+	},
+];
+
+const stubNotification = stubNotifications[0];
 
 beforeEach(() => (subject = new NotificationRepository()));
+
+test("#all", () => {
+	expect(subject.keys()).toHaveLength(0);
+
+	subject.push(stubNotification);
+
+	expect(subject.keys()).toHaveLength(1);
+
+	subject.push(stubNotification);
+
+	expect(subject.keys()).toHaveLength(2);
+});
+
+test("#first", () => {
+	expect(subject.keys()).toHaveLength(0);
+
+	stubNotifications.forEach((n) => subject.push(n));
+
+	expect(subject.keys()).toHaveLength(2);
+	expect(subject.first().name).toEqual(stubNotification.name);
+});
+
+test("#last", () => {
+	expect(subject.keys()).toHaveLength(0);
+
+	stubNotifications.forEach((n) => subject.push(n));
+
+	expect(subject.keys()).toHaveLength(2);
+	expect(subject.last().name).toEqual(stubNotifications[1].name);
+});
+
+test("#keys", () => {
+	expect(subject.keys()).toHaveLength(0);
+
+	stubNotifications.forEach((n) => subject.push(n));
+	const keys = Object.keys(subject.all());
+
+	expect(subject.keys()).toEqual(keys);
+});
+
+test("#values", () => {
+	expect(subject.keys()).toHaveLength(0);
+
+	stubNotifications.forEach((n) => subject.push(n));
+	const values = Object.keys(subject.all()).map((id) => subject.get(id));
+
+	expect(subject.values()).toEqual(values);
+});
+
+test("#get", () => {
+	expect(() => subject.get("invalid")).toThrowError("Failed to find");
+
+	const notification = subject.push(stubNotification);
+
+	expect(subject.get(notification.id)).toBeObject();
+});
 
 test("#push", () => {
 	expect(subject.keys()).toHaveLength(0);
@@ -25,12 +91,14 @@ test("#push", () => {
 	expect(subject.keys()).toHaveLength(2);
 });
 
-test("#get", () => {
-	expect(() => subject.get("invalid")).toThrowError("Failed to find");
+test("#fill", () => {
+	expect(subject.keys()).toHaveLength(0);
 
-	const notification = subject.push(stubNotification);
+	stubNotifications.forEach((n) => subject.push(n));
+	const first = subject.first();
+	subject.fill(Object.assign(first, { name: "updated name" }));
 
-	expect(subject.get(notification.id)).toBeObject();
+	expect(subject.first().name).toEqual("updated name");
 });
 
 test("#has", () => {
@@ -64,10 +132,40 @@ test("#flush", () => {
 	expect(subject.keys()).toHaveLength(0);
 });
 
+test("#count", () => {
+	expect(subject.keys()).toHaveLength(0);
+
+	stubNotifications.forEach((n) => subject.push(n));
+
+	expect(subject.count()).toEqual(stubNotifications.length);
+});
+
 test("marks notifications as read and filters them", () => {
 	subject.push(stubNotification);
 	subject.markAsRead(subject.push(stubNotification).id);
 
 	expect(subject.read()).toHaveLength(1);
 	expect(subject.unread()).toHaveLength(1);
+});
+
+test("#read", () => {
+	expect(subject.keys()).toHaveLength(0);
+
+	stubNotifications.forEach((n) => subject.push(n));
+	subject.markAsRead(subject.first().id);
+
+	expect(subject.unread()).toHaveLength(1);
+	expect(subject.first().read_at).toBeTruthy();
+});
+
+test("#unread", () => {
+	expect(subject.keys()).toHaveLength(0);
+
+	stubNotifications.forEach((n) => subject.push(n));
+	subject.markAsRead(subject.first().id);
+
+	expect(subject.unread()).toHaveLength(1);
+	expect(subject.first().read_at).toBeTruthy();
+
+	expect(subject.last().read_at).toBeUndefined();
 });

--- a/packages/platform-sdk-profiles/src/repositories/notification-repository.ts
+++ b/packages/platform-sdk-profiles/src/repositories/notification-repository.ts
@@ -1,8 +1,10 @@
 import { v4 as uuidv4 } from "uuid";
+import { Except } from "type-fest";
 
 import { DataRepository } from "./data-repository";
 
 interface Notification {
+	id: string;
 	icon: string;
 	name: string;
 	body: string;
@@ -10,22 +12,18 @@ interface Notification {
 	read_at?: number;
 }
 
-interface NotificationWithId extends Notification {
-	id: string;
-}
-
 export class NotificationRepository {
 	#data: DataRepository = new DataRepository();
 
-	public all(): Record<string, NotificationWithId> {
-		return this.#data.all() as Record<string, NotificationWithId>;
+	public all(): Record<string, Notification> {
+		return this.#data.all() as Record<string, Notification>;
 	}
 
-	public first(): NotificationWithId {
+	public first(): Notification {
 		return this.#data.first();
 	}
 
-	public last(): NotificationWithId {
+	public last(): Notification {
 		return this.#data.last();
 	}
 
@@ -33,12 +31,12 @@ export class NotificationRepository {
 		return this.#data.keys();
 	}
 
-	public values(): NotificationWithId[] {
+	public values(): Notification[] {
 		return this.#data.values();
 	}
 
-	public get(key: string): NotificationWithId {
-		const notification: NotificationWithId | undefined = this.#data.get(key);
+	public get(key: string): Notification {
+		const notification: Notification | undefined = this.#data.get(key);
 
 		if (!notification) {
 			throw new Error(`Failed to find a notification that matches [${key}].`);
@@ -47,7 +45,7 @@ export class NotificationRepository {
 		return notification;
 	}
 
-	public push(value: Notification): NotificationWithId {
+	public push(value: Except<Notification, "id">): Notification {
 		const id: string = uuidv4();
 
 		this.#data.set(id, { id, ...value });
@@ -81,11 +79,11 @@ export class NotificationRepository {
 	 * Convenience methods to interact with notifications states.
 	 */
 
-	public read(): NotificationWithId[] {
+	public read(): Notification[] {
 		return this.values().filter((notification: Notification) => notification.read_at !== undefined);
 	}
 
-	public unread(): NotificationWithId[] {
+	public unread(): Notification[] {
 		return this.values().filter((notification: Notification) => notification.read_at === undefined);
 	}
 

--- a/packages/platform-sdk-profiles/src/repositories/notification-repository.ts
+++ b/packages/platform-sdk-profiles/src/repositories/notification-repository.ts
@@ -81,11 +81,11 @@ export class NotificationRepository {
 	 * Convenience methods to interact with notifications states.
 	 */
 
-	public read(): object {
+	public read(): NotificationWithId[] {
 		return this.values().filter((notification: Notification) => notification.read_at !== undefined);
 	}
 
-	public unread(): object {
+	public unread(): NotificationWithId[] {
 		return this.values().filter((notification: Notification) => notification.read_at === undefined);
 	}
 

--- a/packages/platform-sdk-profiles/src/repositories/notification-repository.ts
+++ b/packages/platform-sdk-profiles/src/repositories/notification-repository.ts
@@ -17,15 +17,15 @@ interface NotificationWithId extends Notification {
 export class NotificationRepository {
 	#data: DataRepository = new DataRepository();
 
-	public all(): Record<string, Notification> {
-		return this.#data.all() as Record<string, Notification>;
+	public all(): Record<string, NotificationWithId> {
+		return this.#data.all() as Record<string, NotificationWithId>;
 	}
 
-	public first(): Notification {
+	public first(): NotificationWithId {
 		return this.#data.first();
 	}
 
-	public last(): Notification {
+	public last(): NotificationWithId {
 		return this.#data.last();
 	}
 
@@ -33,7 +33,7 @@ export class NotificationRepository {
 		return this.#data.keys();
 	}
 
-	public values(): Notification[] {
+	public values(): NotificationWithId[] {
 		return this.#data.values();
 	}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
- Return array of `NotificationsWithId` from read/unread methods instead of object
- Use `NotificationsWithId` as return type instead of `Notification`
- Add coverage

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
