### PR TITLE
refactor(notifications): extend `Notification` type

### DIFF
--- a/packages/platform-sdk-profiles/src/environment/env.test.ts
+++ b/packages/platform-sdk-profiles/src/environment/env.test.ts
@@ -79,6 +79,7 @@ it("should create a profile with data and persist it when instructed to do so", 
 		icon: "warning",
 		name: "Ledger Update Available",
 		body: "...",
+		type: "ledger",
 		action: "Read Changelog",
 	});
 

--- a/packages/platform-sdk-profiles/src/repositories/notification-repository.test.ts
+++ b/packages/platform-sdk-profiles/src/repositories/notification-repository.test.ts
@@ -8,14 +8,26 @@ const stubNotifications = [
 	{
 		icon: "warning",
 		name: "Ledger Update Available",
+		type: "ledger",
 		body: "...",
 		action: "Read Changelog",
 	},
 	{
 		icon: "warning",
 		name: "Ledger Update Available",
+		type: "plugin",
 		body: "...",
 		action: "Read Changelog",
+	},
+	{
+		icon: "info",
+		name: "Transaction Created",
+		body: "...",
+		type: "transaction",
+		action: "open",
+		meta: {
+			txId: "1",
+		},
 	},
 ];
 
@@ -27,7 +39,7 @@ test("#all", () => {
 	expect(subject.keys()).toHaveLength(0);
 
 	stubNotifications.forEach((n) => subject.push(n));
-	expect(Object.keys(subject.all())).toHaveLength(2);
+	expect(Object.keys(subject.all())).toHaveLength(stubNotifications.length);
 });
 
 test("#first", () => {
@@ -35,7 +47,7 @@ test("#first", () => {
 
 	stubNotifications.forEach((n) => subject.push(n));
 
-	expect(subject.keys()).toHaveLength(2);
+	expect(subject.keys()).toHaveLength(stubNotifications.length);
 	expect(subject.first().name).toEqual(stubNotification.name);
 });
 
@@ -44,8 +56,8 @@ test("#last", () => {
 
 	stubNotifications.forEach((n) => subject.push(n));
 
-	expect(subject.keys()).toHaveLength(2);
-	expect(subject.last().name).toEqual(stubNotifications[1].name);
+	expect(subject.keys()).toHaveLength(stubNotifications.length);
+	expect(subject.last().name).toEqual(stubNotifications[stubNotifications.length - 1].name);
 });
 
 test("#keys", () => {
@@ -149,7 +161,7 @@ test("#read", () => {
 	stubNotifications.forEach((n) => subject.push(n));
 	subject.markAsRead(subject.first().id);
 
-	expect(subject.unread()).toHaveLength(1);
+	expect(subject.unread()).toHaveLength(2);
 	expect(subject.first().read_at).toBeTruthy();
 });
 
@@ -159,8 +171,27 @@ test("#unread", () => {
 	stubNotifications.forEach((n) => subject.push(n));
 	subject.markAsRead(subject.first().id);
 
-	expect(subject.unread()).toHaveLength(1);
+	expect(subject.unread()).toHaveLength(2);
 	expect(subject.first().read_at).toBeTruthy();
 
 	expect(subject.last().read_at).toBeUndefined();
+});
+
+test("should have meta info", () => {
+	expect(subject.keys()).toHaveLength(0);
+
+	stubNotifications.forEach((n) => subject.push(n));
+
+	const last = stubNotifications[stubNotifications.length - 1];
+	expect(subject.last().meta).toBeObject();
+	expect(subject.last().meta).toEqual(last.meta);
+});
+
+test("should have type", () => {
+	expect(subject.keys()).toHaveLength(0);
+
+	stubNotifications.forEach((n) => subject.push(n));
+
+	const last = stubNotifications[stubNotifications.length - 1];
+	expect(subject.last().type).toEqual(last.type);
 });

--- a/packages/platform-sdk-profiles/src/repositories/notification-repository.test.ts
+++ b/packages/platform-sdk-profiles/src/repositories/notification-repository.test.ts
@@ -177,7 +177,7 @@ test("#unread", () => {
 	expect(subject.last().read_at).toBeUndefined();
 });
 
-test("should have meta info", () => {
+it("should have meta info", () => {
 	expect(subject.keys()).toHaveLength(0);
 
 	stubNotifications.forEach((n) => subject.push(n));
@@ -187,7 +187,7 @@ test("should have meta info", () => {
 	expect(subject.last().meta).toEqual(last.meta);
 });
 
-test("should have type", () => {
+it("should have a type", () => {
 	expect(subject.keys()).toHaveLength(0);
 
 	stubNotifications.forEach((n) => subject.push(n));

--- a/packages/platform-sdk-profiles/src/repositories/notification-repository.ts
+++ b/packages/platform-sdk-profiles/src/repositories/notification-repository.ts
@@ -8,8 +8,10 @@ interface Notification {
 	icon: string;
 	name: string;
 	body: string;
+	type: string;
 	action: string;
 	read_at?: number;
+	meta?: any;
 }
 
 export class NotificationRepository {

--- a/packages/platform-sdk-profiles/src/repositories/notification-repository.ts
+++ b/packages/platform-sdk-profiles/src/repositories/notification-repository.ts
@@ -11,7 +11,7 @@ interface Notification {
 	type: string;
 	action: string;
 	read_at?: number;
-	meta?: any;
+	meta?: Record<string, any>;
 }
 
 export class NotificationRepository {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist
* Add `type: string` field in `Notification` for categorization
* Add `meta: any` field in `Notification` to store additional required data.
* Add tests

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
