### PR TITLE
refactor(lsk): don't enforce api limit and sort tx by timestamp

### DIFF
--- a/packages/platform-sdk-lsk/src/services/client.ts
+++ b/packages/platform-sdk-lsk/src/services/client.ts
@@ -46,7 +46,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async transactions(query: Contracts.ClientTransactionsInput): Promise<Coins.TransactionDataCollection> {
-		const result = await this.get("transactions", this.createSearchParams(query));
+		const result = await this.get("transactions", this.createSearchParams({ sort: "timestamp:desc", ...query }));
 
 		return Helpers.createTransactionDataCollectionWithType(
 			result.data,
@@ -77,7 +77,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async delegates(query?: any): Promise<Coins.WalletDataCollection> {
-		const result = await this.get("delegates", this.createSearchParams(query));
+		const result = await this.get("delegates", this.createSearchParams({ limit: 101, ...query }));
 
 		return new Coins.WalletDataCollection(
 			result.data.map((wallet) => new WalletData(wallet)),
@@ -152,8 +152,6 @@ export class ClientService implements Contracts.ClientService {
 			searchParams = {};
 		}
 
-		searchParams.limit = 101; // Enforce 101 for consistent pagination.
-
 		if (searchParams.cursor) {
 			// @ts-ignore
 			searchParams.offset = searchParams.cursor;
@@ -178,13 +176,13 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	private createPagination(data, meta): Contracts.MetaPagination {
-		const hasPreviousPage: boolean = data && data.length === 101 && meta.offset !== 0;
-		const hasNextPage: boolean = data && data.length === 101;
+		const hasPreviousPage: boolean = data && data.length === meta.limit && meta.offset !== 0;
+		const hasNextPage: boolean = data && data.length === meta.limit;
 
 		return {
-			prev: hasPreviousPage ? Number(meta.offset) - 101 : undefined,
+			prev: hasPreviousPage ? Number(meta.offset) - Number(meta.limit) : undefined,
 			self: meta.offset,
-			next: hasNextPage ? Number(meta.offset) + 101 : undefined,
+			next: hasNextPage ? Number(meta.offset) + Number(meta.limit) : undefined,
 		};
 	}
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Removes the hardcoded API limit and sorts the transactions by timestamp by default.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
