### PR TITLE
feat(support): implement `BigNumber#isNegative` and `BigNumber#isZero`

### DIFF
--- a/packages/platform-sdk-support/src/bignumber.test.ts
+++ b/packages/platform-sdk-support/src/bignumber.test.ts
@@ -38,9 +38,19 @@ test("#isPositive", () => {
 	expect(subject.minus(10).isPositive()).toBeFalse();
 });
 
+test("#isNegative", () => {
+	expect(subject.isNegative()).toBeFalse();
+	expect(subject.minus(10).isNegative()).toBeTrue();
+});
+
 test("#isFinite", () => {
 	expect(subject.isFinite()).toBeTrue();
 	expect(BigNumber.make(Infinity).isFinite()).toBeFalse();
+});
+
+test("#isZero", () => {
+	expect(subject.isZero()).toBeFalse();
+	expect(BigNumber.make(0).isZero()).toBeTrue();
 });
 
 test("#comparedTo", () => {

--- a/packages/platform-sdk-support/src/bignumber.ts
+++ b/packages/platform-sdk-support/src/bignumber.ts
@@ -53,8 +53,16 @@ export class BigNumber {
 		return this.#value.isPositive();
 	}
 
+	public isNegative(): boolean {
+		return this.#value.isNegative();
+	}
+
 	public isFinite(): boolean {
 		return this.#value.isFinite();
+	}
+
+	public isZero(): boolean {
+		return this.#value.isZero();
 	}
 
 	public comparedTo(value: NumberLike): number {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adds helper methods to expose the `isZero` and `isNegative` methods.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
