### PR TITLE
fix: replace post per get requests

### DIFF
--- a/packages/platform-sdk-ark/src/services/client.ts
+++ b/packages/platform-sdk-ark/src/services/client.ts
@@ -38,7 +38,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async transactions(query: Contracts.ClientTransactionsInput): Promise<Coins.TransactionDataCollection> {
-		const response = await this.post("transactions/search", this.createSearchParams(query));
+		const response = await this.get("transactions/search", this.createSearchParams(query));
 
 		return Helpers.createTransactionDataCollectionWithType(
 			response.data,
@@ -54,7 +54,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	public async wallets(query: Contracts.ClientWalletsInput): Promise<Coins.WalletDataCollection> {
-		const response = await this.post("wallets/search", this.createSearchParams(query));
+		const response = await this.get("wallets/search", this.createSearchParams(query));
 
 		return new Coins.WalletDataCollection(
 			response.data.map((wallet) => new WalletData(wallet)),

--- a/packages/platform-sdk-profiles/src/profiles/aggregates/entity-aggregate.test.ts
+++ b/packages/platform-sdk-profiles/src/profiles/aggregates/entity-aggregate.test.ts
@@ -55,7 +55,7 @@ afterAll(() => nock.enableNetConnect());
 it("should aggregate registrations for the given type and sub-type", async () => {
 	nock.cleanAll();
 	nock(/.+/)
-		.post("/api/transactions/search")
+		.get("/api/transactions/search")
 		.reply(200, require("../../../test/fixtures/client/registrations/business.json"));
 
 	const registrations = await profile.entityAggregate().registrations(EntityType.Business, EntitySubType.None);

--- a/packages/platform-sdk-profiles/src/profiles/aggregates/transaction-aggregate.test.ts
+++ b/packages/platform-sdk-profiles/src/profiles/aggregates/transaction-aggregate.test.ts
@@ -48,7 +48,7 @@ afterAll(() => nock.enableNetConnect());
 describe.each(["transactions", "sentTransactions", "receivedTransactions"])("%s", (method: string) => {
 	it("should have more transactions", async () => {
 		nock(/.+/)
-			.post("/api/transactions/search")
+			.get("/api/transactions/search")
 			.reply(200, require("../../../test/fixtures/client/transactions.json"));
 
 		const result = await subject[method]();
@@ -59,7 +59,7 @@ describe.each(["transactions", "sentTransactions", "receivedTransactions"])("%s"
 
 	it("should not have more transactions", async () => {
 		nock(/.+/)
-			.post("/api/transactions/search")
+			.get("/api/transactions/search")
 			.reply(200, require("../../../test/fixtures/client/transactions-no-more.json"));
 
 		const result = await subject[method]();
@@ -70,7 +70,7 @@ describe.each(["transactions", "sentTransactions", "receivedTransactions"])("%s"
 	});
 
 	it("should skip error responses for processing", async () => {
-		nock(/.+/).post("/api/transactions/search").reply(404);
+		nock(/.+/).get("/api/transactions/search").reply(404);
 
 		const result = await subject[method]();
 
@@ -81,7 +81,7 @@ describe.each(["transactions", "sentTransactions", "receivedTransactions"])("%s"
 
 	it("should skip empty responses for processing", async () => {
 		nock(/.+/)
-			.post("/api/transactions/search")
+			.get("/api/transactions/search")
 			.reply(200, require("../../../test/fixtures/client/transactions-empty.json"));
 
 		const result = await subject[method]();
@@ -93,9 +93,9 @@ describe.each(["transactions", "sentTransactions", "receivedTransactions"])("%s"
 
 	it("should fetch transactions twice and then stop because no more are available", async () => {
 		nock(/.+/)
-			.post("/api/transactions/search")
+			.get("/api/transactions/search")
 			.reply(200, require("../../../test/fixtures/client/transactions.json"))
-			.post("/api/transactions/search?page=2")
+			.get("/api/transactions/search?page=2")
 			.reply(200, require("../../../test/fixtures/client/transactions-no-more.json"));
 
 		// We receive a response that does contain a "next" cursor
@@ -122,7 +122,7 @@ describe.each(["transactions", "sentTransactions", "receivedTransactions"])("%s"
 
 	it("should determine if it has more transactions to be requested", async () => {
 		nock(/.+/)
-			.post("/api/transactions/search")
+			.get("/api/transactions/search")
 			.reply(200, require("../../../test/fixtures/client/transactions.json"));
 
 		expect(subject.hasMore(method)).toBeFalse();
@@ -134,7 +134,7 @@ describe.each(["transactions", "sentTransactions", "receivedTransactions"])("%s"
 });
 
 it("should flush the history", async () => {
-	nock(/.+/).post("/api/transactions/search").reply(200, require("../../../test/fixtures/client/transactions.json"));
+	nock(/.+/).get("/api/transactions/search").reply(200, require("../../../test/fixtures/client/transactions.json"));
 
 	expect(subject.hasMore("transactions")).toBeFalse();
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
- Due to core v3 release all POST `/search` endpoints were removed. This aims to replace them for `GET` requests.
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
