### PR TITLE
fix(ark): use searchParams instead of body for Core 3.0

### DIFF
--- a/packages/platform-sdk-ark/src/services/client.test.ts
+++ b/packages/platform-sdk-ark/src/services/client.test.ts
@@ -56,6 +56,20 @@ describe("ClientService", function () {
 			expect(result).toBeObject();
 			expect(result.items()[0]).toBeInstanceOf(TransactionData);
 		});
+
+		it("should work with Core 3.0 for advanced search", async () => {
+			subject = await ClientService.construct(createConfig({ network: "ark.devnet" }));
+
+			nock(/.+/)
+				.get("/api/transactions")
+				.query({ address: "DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8", "asset.type": "4", "asset.action": "0", "type": "6", "typeGroup": 2 })
+				.reply(200, require(`${__dirname}/../../test/fixtures/client/transactions.json`));
+
+			const result = await subject.transactions({ addresses: ["DBk4cPYpqp7EBcvkstVDpyX7RQJNHxpMg8"], asset: { type: 4, action: 0 }, type: 6, typeGroup: 2 });
+
+			expect(result).toBeObject();
+			expect(result.items()[0]).toBeInstanceOf(TransactionData);
+		});
 	});
 
 	describe("#wallet", () => {

--- a/packages/platform-sdk-ark/src/services/client.ts
+++ b/packages/platform-sdk-ark/src/services/client.ts
@@ -242,7 +242,8 @@ export class ClientService implements Contracts.ClientService {
 				delete body.addresses;
 			}
 
-			result.searchParams = dotify(result.searchParams);
+			result.searchParams = dotify({ ...result.searchParams, ...result.body });
+			result.body = null;
 		}
 
 		return result;

--- a/packages/platform-sdk/src/contracts/coins/client.ts
+++ b/packages/platform-sdk/src/contracts/coins/client.ts
@@ -58,6 +58,9 @@ export interface ClientTransactionsInput extends ClientPagination {
 	entityAction?: string;
 	// Meta
 	asset?: Record<string, any>;
+	// Transaction Types
+	type?: number;
+	typeGroup?: number;
 }
 
 export interface ClientWalletsInput extends ClientPagination {


### PR DESCRIPTION
## Summary

Fixes query parameters used in the aggregate entity service.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
