### PR TITLE
fix(ark): validate address before checking neo network

### DIFF
--- a/packages/platform-sdk-ark/src/services/identity/address.ts
+++ b/packages/platform-sdk-ark/src/services/identity/address.ts
@@ -50,7 +50,9 @@ export class Address implements Contracts.Address {
 
 	public async validate(address: string): Promise<boolean> {
 		try {
-			if (this.#config.get("network.id") === "ark.mainnet") {
+			const isValid = BaseAddress.validate(address, this.#configCrypto);
+
+			if (isValid && this.#config.get("network.id") === "ark.mainnet") {
 				const response: any = (
 					await this.#config
 						.get<Contracts.HttpClient>("httpClient")
@@ -63,7 +65,7 @@ export class Address implements Contracts.Address {
 				}
 			}
 
-			return BaseAddress.validate(address, this.#configCrypto);
+			return isValid;
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Validates an ARK address before querying the NEO network for it to avoid any bad input.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
