### PR TITLE
fix(ark): get votes from attributes object

### DIFF
--- a/packages/platform-sdk-ark/src/services/client.ts
+++ b/packages/platform-sdk-ark/src/services/client.ts
@@ -89,12 +89,12 @@ export class ClientService implements Contracts.ClientService {
 	public async votes(id: string): Promise<Contracts.VoteReport> {
 		const { data } = await this.get(`wallets/${id}`);
 
-		const hasVoted = data.vote !== undefined;
+		const hasVoted = data.attributes?.vote !== undefined;
 
 		return {
 			used: hasVoted ? 1 : 0,
 			available: hasVoted ? 0 : 1,
-			publicKeys: hasVoted ? [data.vote] : [],
+			publicKeys: hasVoted ? [data.attributes?.vote] : [],
 		};
 	}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

In Core 3.0 the `vote` attribute is present only under the `attributes` object, while in 2.7 it is also available at the root level. This change therefore works for both 2.7 and 3.0.

```
// 2.7

{
  attributes: {
    vote: "...",
  },
  vote: "...",
}

// 3.0

{
  attributes: {
    vote: "...",
  },
}
```
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
