### PR TITLE
feat: implement `WalletData#secondPublicKey`

### DIFF
--- a/packages/platform-sdk-ark/src/dto/wallet.ts
+++ b/packages/platform-sdk-ark/src/dto/wallet.ts
@@ -19,6 +19,10 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 		return BigNumber.make(this.data.nonce);
 	}
 
+	public secondPublicKey(): string | undefined {
+		return this.getProperty(['secondPublicKey', 'attributes.secondPublicKey']);
+	}
+
 	public username(): string | undefined {
 		return this.getProperty(['username', 'attributes.delegate.username']);
 	}

--- a/packages/platform-sdk-atom/src/dto/wallet.ts
+++ b/packages/platform-sdk-atom/src/dto/wallet.ts
@@ -18,6 +18,10 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 		return BigNumber.make(this.data.sequence);
 	}
 
+	public secondPublicKey(): string | undefined {
+		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+	}
+
 	public username(): string | undefined {
 		throw new Exceptions.NotImplemented(this.constructor.name, "username");
 	}

--- a/packages/platform-sdk-btc/src/dto/wallet.ts
+++ b/packages/platform-sdk-btc/src/dto/wallet.ts
@@ -18,6 +18,10 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 		return BigNumber.ZERO;
 	}
 
+	public secondPublicKey(): string | undefined {
+		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+	}
+
 	public username(): string | undefined {
 		throw new Exceptions.NotImplemented(this.constructor.name, "username");
 	}

--- a/packages/platform-sdk-eos/src/dto/wallet.ts
+++ b/packages/platform-sdk-eos/src/dto/wallet.ts
@@ -18,6 +18,10 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 		return BigNumber.ZERO;
 	}
 
+	public secondPublicKey(): string | undefined {
+		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+	}
+
 	public username(): string | undefined {
 		throw new Exceptions.NotImplemented(this.constructor.name, "username");
 	}

--- a/packages/platform-sdk-eth/src/dto/wallet.ts
+++ b/packages/platform-sdk-eth/src/dto/wallet.ts
@@ -19,6 +19,10 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 		return BigNumber.make(Web3.utils.toBN(this.data.nonce).toString());
 	}
 
+	public secondPublicKey(): string | undefined {
+		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+	}
+
 	public username(): string | undefined {
 		throw new Exceptions.NotImplemented(this.constructor.name, "username");
 	}

--- a/packages/platform-sdk-lsk/src/dto/wallet.ts
+++ b/packages/platform-sdk-lsk/src/dto/wallet.ts
@@ -19,7 +19,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public secondPublicKey(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+		return this.data.secondPublicKey;
 	}
 
 	public username(): string | undefined {

--- a/packages/platform-sdk-lsk/src/dto/wallet.ts
+++ b/packages/platform-sdk-lsk/src/dto/wallet.ts
@@ -18,6 +18,10 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 		return BigNumber.ZERO;
 	}
 
+	public secondPublicKey(): string | undefined {
+		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+	}
+
 	public username(): string | undefined {
 		return this.data.username || this.data.delegate?.username;
 	}

--- a/packages/platform-sdk-neo/src/dto/wallet.ts
+++ b/packages/platform-sdk-neo/src/dto/wallet.ts
@@ -18,6 +18,10 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 		return BigNumber.ZERO;
 	}
 
+	public secondPublicKey(): string | undefined {
+		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+	}
+
 	public username(): string | undefined {
 		throw new Exceptions.NotImplemented(this.constructor.name, "username");
 	}

--- a/packages/platform-sdk-trx/src/dto/wallet.ts
+++ b/packages/platform-sdk-trx/src/dto/wallet.ts
@@ -18,6 +18,10 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 		return BigNumber.ZERO;
 	}
 
+	public secondPublicKey(): string | undefined {
+		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+	}
+
 	public username(): string | undefined {
 		throw new Exceptions.NotImplemented(this.constructor.name, "username");
 	}

--- a/packages/platform-sdk-xlm/src/dto/wallet.ts
+++ b/packages/platform-sdk-xlm/src/dto/wallet.ts
@@ -18,6 +18,10 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 		return BigNumber.make(this.data.sequence);
 	}
 
+	public secondPublicKey(): string | undefined {
+		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+	}
+
 	public username(): string | undefined {
 		throw new Exceptions.NotImplemented(this.constructor.name, "username");
 	}

--- a/packages/platform-sdk-xmr/src/dto/wallet.ts
+++ b/packages/platform-sdk-xmr/src/dto/wallet.ts
@@ -18,6 +18,10 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 		return BigNumber.ZERO;
 	}
 
+	public secondPublicKey(): string | undefined {
+		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+	}
+
 	public username(): string | undefined {
 		throw new Exceptions.NotImplemented(this.constructor.name, "username");
 	}

--- a/packages/platform-sdk-xrp/src/dto/wallet.ts
+++ b/packages/platform-sdk-xrp/src/dto/wallet.ts
@@ -18,6 +18,10 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 		return BigNumber.ZERO;
 	}
 
+	public secondPublicKey(): string | undefined {
+		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+	}
+
 	public username(): string | undefined {
 		throw new Exceptions.NotImplemented(this.constructor.name, "username");
 	}

--- a/packages/platform-sdk/src/contracts/coins/data.ts
+++ b/packages/platform-sdk/src/contracts/coins/data.ts
@@ -20,6 +20,10 @@ export interface WalletData {
 
 	nonce(): BigNumber;
 
+	// Second Signature
+
+	secondPublicKey(): string | undefined;
+
 	// Delegate
 	username(): string | undefined;
 

--- a/packages/platform-sdk/src/contracts/coins/data.ts
+++ b/packages/platform-sdk/src/contracts/coins/data.ts
@@ -21,7 +21,6 @@ export interface WalletData {
 	nonce(): BigNumber;
 
 	// Second Signature
-
 	secondPublicKey(): string | undefined;
 
 	// Delegate

--- a/packages/platform-sdk/src/dto/wallet.ts
+++ b/packages/platform-sdk/src/dto/wallet.ts
@@ -16,7 +16,6 @@ export abstract class AbstractWalletData {
 	abstract nonce(): BigNumber;
 
 	// Second Signature
-
 	abstract secondPublicKey(): string | undefined;
 
 	// Delegate

--- a/packages/platform-sdk/src/dto/wallet.ts
+++ b/packages/platform-sdk/src/dto/wallet.ts
@@ -15,6 +15,10 @@ export abstract class AbstractWalletData {
 
 	abstract nonce(): BigNumber;
 
+	// Second Signature
+
+	abstract secondPublicKey(): string | undefined;
+
 	// Delegate
 	abstract username(): string | undefined;
 


### PR DESCRIPTION
## Summary

Required to verify that a mnemonic matches the second signature.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
