### PR TITLE
fix(lsk): off by one error in api pagination offset

### DIFF
--- a/packages/platform-sdk-lsk/src/services/client.ts
+++ b/packages/platform-sdk-lsk/src/services/client.ts
@@ -155,7 +155,7 @@ export class ClientService implements Contracts.ClientService {
 
 		if (searchParams.cursor) {
 			// @ts-ignore
-			searchParams.offset = searchParams.cursor;
+			searchParams.offset = searchParams.cursor - 1;
 			delete searchParams.cursor;
 		}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

`offset === cursor - 1`

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
