### PR TITLE
refactor: fetch exchange rates only for live coins

### DIFF
--- a/packages/platform-sdk-profiles/src/environment/services/exchange-rate-service.test.ts
+++ b/packages/platform-sdk-profiles/src/environment/services/exchange-rate-service.test.ts
@@ -18,7 +18,8 @@ let profile: Profile;
 let wallet: ReadWriteWallet;
 let subject: ExchangeRateService;
 
-let networkSpy: jest.SpyInstance;
+let liveSpy: jest.SpyInstance;
+let testSpy: jest.SpyInstance;
 
 beforeEach(async () => {
 	nock.cleanAll();
@@ -50,12 +51,16 @@ beforeEach(async () => {
 	profile = profileRepository.create("John Doe");
 	wallet = await profile.wallets().importByMnemonic(identity.mnemonic, "ARK", "ark.devnet");
 
-	networkSpy = jest.spyOn(wallet.network(), "isTest").mockReturnValue(false);
+	liveSpy = jest.spyOn(wallet.network(), "isLive").mockReturnValue(true);
+	testSpy = jest.spyOn(wallet.network(), "isTest").mockReturnValue(false);
 
 	subject = new ExchangeRateService();
 });
 
-afterEach(() => networkSpy.mockRestore());
+afterEach(() => {
+	liveSpy.mockRestore();
+	testSpy.mockRestore();
+});
 
 beforeAll(() => nock.disableNetConnect());
 

--- a/packages/platform-sdk-profiles/src/environment/services/exchange-rate-service.test.ts
+++ b/packages/platform-sdk-profiles/src/environment/services/exchange-rate-service.test.ts
@@ -90,6 +90,8 @@ describe("#syncCoinByProfile", () => {
 	});
 
 	it("should sync a coin for specific profile without wallets argument", async () => {
+		const networkSpy = jest.spyOn(wallet.network(), "isLive").mockReturnValue(true);
+
 		profile.settings().set(ProfileSetting.MarketProvider, "cryptocompare");
 
 		nock(/.+/)
@@ -101,5 +103,7 @@ describe("#syncCoinByProfile", () => {
 		await subject.syncCoinByProfile(profile, "DARK");
 
 		expect(wallet.data().get(WalletData.ExchangeRate)).toBe(0.00002134);
+
+		networkSpy.mockRestore();
 	});
 });

--- a/packages/platform-sdk-profiles/src/environment/services/exchange-rate-service.ts
+++ b/packages/platform-sdk-profiles/src/environment/services/exchange-rate-service.ts
@@ -26,9 +26,9 @@ export class ExchangeRateService {
 			wallets = profile
 				.wallets()
 				.values()
-				.filter((wallet: ReadWriteWallet) => wallet.currency() === currency && !wallet.network().isTest());
+				.filter((wallet: ReadWriteWallet) => wallet.currency() === currency && wallet.network().isLive());
 		} else {
-			wallets = wallets.filter((wallet: ReadWriteWallet) => !wallet.network().isTest());
+			wallets = wallets.filter((wallet: ReadWriteWallet) => wallet.network().isLive());
 		}
 
 		if (!wallets.length) {

--- a/packages/platform-sdk-profiles/src/environment/services/exchange-rate-service.ts
+++ b/packages/platform-sdk-profiles/src/environment/services/exchange-rate-service.ts
@@ -29,6 +29,10 @@ export class ExchangeRateService {
 				.filter((wallet: ReadWriteWallet) => wallet.currency() === currency);
 		}
 
+		if (!wallets.length || !wallets[0].network().isLive()) {
+			return;
+		}
+
 		const marketService = MarketService.make(
 			profile.settings().get(ProfileSetting.MarketProvider) || "coingecko",
 			container.get(Identifiers.HttpClient),

--- a/packages/platform-sdk-profiles/src/environment/services/exchange-rate-service.ts
+++ b/packages/platform-sdk-profiles/src/environment/services/exchange-rate-service.ts
@@ -26,10 +26,12 @@ export class ExchangeRateService {
 			wallets = profile
 				.wallets()
 				.values()
-				.filter((wallet: ReadWriteWallet) => wallet.currency() === currency);
+				.filter((wallet: ReadWriteWallet) => wallet.currency() === currency && !wallet.network().isTest());
+		} else {
+			wallets = wallets.filter((wallet: ReadWriteWallet) => !wallet.network().isTest());
 		}
 
-		if (!wallets.length || !wallets[0].network().isLive()) {
+		if (!wallets.length) {
 			return;
 		}
 

--- a/packages/platform-sdk-profiles/src/wallets/wallet.ts
+++ b/packages/platform-sdk-profiles/src/wallets/wallet.ts
@@ -169,7 +169,7 @@ export class Wallet implements ReadWriteWallet {
 	}
 
 	public convertedBalance(): BigNumber {
-		if (!this.network().isLive()) {
+		if (this.network().isTest()) {
 			return BigNumber.ZERO;
 		}
 

--- a/packages/platform-sdk-profiles/src/wallets/wallet.ts
+++ b/packages/platform-sdk-profiles/src/wallets/wallet.ts
@@ -169,7 +169,7 @@ export class Wallet implements ReadWriteWallet {
 	}
 
 	public convertedBalance(): BigNumber {
-		if (this.network().isTest()) {
+		if (!this.network().isLive()) {
 			return BigNumber.ZERO;
 		}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Right now the wallet fetches the exchange rate for all coins, live or not. With these change the respective methods return early instead of fetching the rate for non-live coins.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
