### PR TITLE
fix(profiles): call correct method in `Wallet#cannot`

### DIFF
--- a/packages/platform-sdk-profiles/src/wallets/wallet.ts
+++ b/packages/platform-sdk-profiles/src/wallets/wallet.ts
@@ -497,7 +497,7 @@ export class Wallet implements ReadWriteWallet {
 	}
 
 	public canAny(features: string[]): boolean {
-		for(const feature of features) {
+		for (const feature of features) {
 			if (this.can(feature)) {
 				return true;
 			}
@@ -507,8 +507,8 @@ export class Wallet implements ReadWriteWallet {
 	}
 
 	public canAll(features: string[]): boolean {
-		for(const feature of features) {
-			if (!this.can(feature)) {
+		for (const feature of features) {
+			if (this.cannot(feature)) {
 				return false;
 			}
 		}
@@ -517,7 +517,7 @@ export class Wallet implements ReadWriteWallet {
 	}
 
 	public cannot(feature: string): boolean {
-		return this.#coin.network().can(feature);
+		return this.#coin.network().cannot(feature);
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Calls the Networks `cannot` method in the Wallets `cannot` helper.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
