### PR TITLE
perf(sdk): use `Promise.all` to construct coin services

### DIFF
--- a/packages/platform-sdk/src/coins/coin-factory.ts
+++ b/packages/platform-sdk/src/coins/coin-factory.ts
@@ -13,20 +13,32 @@ export class CoinFactory {
 		const config: Config = new Config(options, coin.schema);
 		config.set("network", networks.get(config.get<string>("network")));
 
+		const [client, fee, identity, ledger, link, message, multiSignature, peer, transaction] = await Promise.all([
+			services.ClientService.construct(config),
+			services.FeeService.construct(config),
+			services.IdentityService.construct(config),
+			services.LedgerService.construct(config),
+			services.LinkService.construct(config),
+			services.MessageService.construct(config),
+			services.MultiSignatureService.construct(config),
+			services.PeerService.construct(config),
+			services.TransactionService.construct(config),
+		])
+
 		return new Coin({
 			networks,
 			manifest: new Manifest(manifest),
 			config,
 			services: {
-				client: await services.ClientService.construct(config),
-				fee: await services.FeeService.construct(config),
-				identity: await services.IdentityService.construct(config),
-				ledger: await services.LedgerService.construct(config),
-				link: await services.LinkService.construct(config),
-				message: await services.MessageService.construct(config),
-				multiSignature: await services.MultiSignatureService.construct(config),
-				peer: await services.PeerService.construct(config),
-				transaction: await services.TransactionService.construct(config),
+				client,
+				fee,
+				identity,
+				ledger,
+				link,
+				message,
+				multiSignature,
+				peer,
+				transaction,
 			},
 		});
 	}


### PR DESCRIPTION
This change is somewhat breaking for internals because it has to be kept in mind that the services are not bootstrapped sequentially. This means you can't create services that depend on each other if they are dependent on HTTP requests being completed.