### PR TITLE
perf(profiles): restore wallets before contacts

### DIFF
--- a/packages/platform-sdk-profiles/src/repositories/profile-repository.ts
+++ b/packages/platform-sdk-profiles/src/repositories/profile-repository.ts
@@ -26,9 +26,9 @@ export class ProfileRepository {
 
 			result.settings().fill(profile.settings);
 
-			await result.contacts().fill(profile.contacts);
-
 			await this.restoreWallets(result, profile.wallets);
+
+			await result.contacts().fill(profile.contacts);
 
 			this.#data.set(id, result);
 		}


### PR DESCRIPTION
As a side-effect of https://github.com/ArkEcosystem/platform-sdk/commit/d14138c44bf28122e9f0635517d591901007535a we can now also restore contacts faster because they can reuse pre-synced coin instances.