### PR TITLE
perf(ark): compare network tokens after retrieving the crypto configuration

### DIFF
--- a/packages/platform-sdk-ark/src/service-provider.ts
+++ b/packages/platform-sdk-ark/src/service-provider.ts
@@ -61,6 +61,10 @@ export class ServiceProvider {
 		const dataCrypto = crypto.json().data;
 		const dataStatus = status.json().data;
 
+		if (dataCrypto.network.client.token !== config.get("network.currency.ticker")) {
+			throw new Error(`Failed to connect to ${peer} because it is on another network.`);
+		}
+
 		Managers.configManager.setConfig(dataCrypto);
 		Managers.configManager.setHeight(dataStatus.height);
 

--- a/packages/platform-sdk-ark/src/services/peer.test.ts
+++ b/packages/platform-sdk-ark/src/services/peer.test.ts
@@ -16,17 +16,6 @@ beforeEach(() => {
 describe("PeerService", () => {
 	describe("#new", () => {
 		describe("host", () => {
-			it("should throw if the peer is on the wrong network", async () => {
-				await expect(
-					PeerService.construct(
-						createConfig({
-							network: "ark.mainnet",
-							peer: "http://127.0.0.1/api",
-						}),
-					),
-				).rejects.toThrowError("Failed to connect to http://127.0.0.1/api because it is on another network.");
-			});
-
 			it("should fetch peers", async () => {
 				nock("http://127.0.0.1").get("/api/peers").reply(200, {
 					data: dummyPeersWalletApi,

--- a/packages/platform-sdk-ark/src/services/peer.ts
+++ b/packages/platform-sdk-ark/src/services/peer.ts
@@ -25,21 +25,6 @@ export class PeerService implements Contracts.PeerService {
 
 		let seeds: string[] = [];
 
-		// Validation
-		let response;
-		try {
-			response = (await httpClient.get(`${peer}/node/configuration`)).json();
-		} catch {
-			// We don't know what went wrong so we continue.
-		}
-
-		if (response) {
-			if (response.data.token !== network.currency.ticker) {
-				throw new Error(`Failed to connect to ${peer} because it is on another network.`);
-			}
-		}
-
-		// Seeds
 		try {
 			if (peer && isUrl(peer)) {
 				const response = (await httpClient.get(`${peer}/peers`)).json();


### PR DESCRIPTION
Safe 1 unnecessary request because we can already compare the tokens earlier.