### PR TITLE
feat(profiles): implement `TransactionData#convertedAmount|fee` 

### DIFF
--- a/packages/platform-sdk-profiles/src/dto/transaction.test.ts
+++ b/packages/platform-sdk-profiles/src/dto/transaction.test.ts
@@ -6,14 +6,16 @@ import { Request } from "@arkecosystem/platform-sdk-http-got";
 import { BigNumber } from "@arkecosystem/platform-sdk-support";
 import nock from "nock";
 
+import { DateTime } from "../../../platform-sdk-intl/dist";
 import { identity } from "../../test/fixtures/identity";
+import { StubStorage } from "../../test/stubs/storage";
 import { container } from "../environment/container";
 import { Identifiers } from "../environment/container.models";
 import { CoinService } from "../environment/services/coin-service";
+import { ExchangeRateService } from "../environment/services/exchange-rate-service";
 import { Profile } from "../profiles/profile";
 import { ProfileSetting } from "../profiles/profile.models";
 import { Wallet } from "../wallets/wallet";
-import { StubStorage } from "../../test/stubs/storage";
 import { ReadWriteWallet, WalletData } from "../wallets/wallet.models";
 import {
 	BridgechainRegistrationData,
@@ -38,8 +40,6 @@ import {
 	TransferData,
 	VoteData,
 } from "./transaction";
-import { ExchangeRateService } from "../environment/services/exchange-rate-service";
-import { DateTime } from "../../../platform-sdk-intl/dist";
 
 const createSubject = (wallet, properties, klass) => {
 	let meta: Contracts.TransactionDataMeta = "some meta";
@@ -184,10 +184,14 @@ describe("Transaction", () => {
 	});
 
 	it("should have a converted amount", async () => {
-		subject = createSubject(wallet, {
-			timestamp: () => DateTime.make(),
-			amount: () => BigNumber.make(10e8),
-		}, TransferData);
+		subject = createSubject(
+			wallet,
+			{
+				timestamp: () => DateTime.make(),
+				amount: () => BigNumber.make(10e8),
+			},
+			TransferData,
+		);
 
 		await container.get<ExchangeRateService>(Identifiers.ExchangeRateService).syncAll(profile, "DARK");
 
@@ -203,10 +207,14 @@ describe("Transaction", () => {
 	});
 
 	it("should have a converted fee", async () => {
-		subject = createSubject(wallet, {
-			timestamp: () => DateTime.make(),
-			fee: () => BigNumber.make(10e8),
-		}, TransferData);
+		subject = createSubject(
+			wallet,
+			{
+				timestamp: () => DateTime.make(),
+				fee: () => BigNumber.make(10e8),
+			},
+			TransferData,
+		);
 
 		await container.get<ExchangeRateService>(Identifiers.ExchangeRateService).syncAll(profile, "DARK");
 
@@ -307,11 +315,15 @@ describe("Transaction", () => {
 	});
 
 	it("should have a converted total", async () => {
-		subject = createSubject(wallet, {
-			timestamp: () => DateTime.make(),
-			amount: () => BigNumber.make(10e8),
-			fee: () => BigNumber.make(5e8),
-		}, TransferData);
+		subject = createSubject(
+			wallet,
+			{
+				timestamp: () => DateTime.make(),
+				amount: () => BigNumber.make(10e8),
+				fee: () => BigNumber.make(5e8),
+			},
+			TransferData,
+		);
 
 		await container.get<ExchangeRateService>(Identifiers.ExchangeRateService).syncAll(profile, "DARK");
 

--- a/packages/platform-sdk-profiles/src/wallets/wallet.models.ts
+++ b/packages/platform-sdk-profiles/src/wallets/wallet.models.ts
@@ -41,8 +41,6 @@ export enum WalletData {
 	BroadcastedTransactions = "BROADCASTED_TRANSACTIONS",
 	Delegates = "DELEGATES",
 	ExchangeCurrency = "EXCHANGE_CURRENCY",
-	ExchangeRate = "EXCHANGE_RATE",
-	ExchangeRates = "EXCHANGE_RATES",
 	MultiSignatureParticipants = "MULTI_SIGNATURE_PARTICIPANTS",
 	Sequence = "SEQUENCE",
 	SignedTransactions = "SIGNED_TRANSACTIONS",

--- a/packages/platform-sdk-profiles/src/wallets/wallet.ts
+++ b/packages/platform-sdk-profiles/src/wallets/wallet.ts
@@ -1,4 +1,5 @@
 import { Coins, Contracts } from "@arkecosystem/platform-sdk";
+import { DateTime } from "@arkecosystem/platform-sdk-intl";
 import { BigNumber } from "@arkecosystem/platform-sdk-support";
 import { decrypt } from "bip38";
 import { encode } from "wif";
@@ -202,15 +203,9 @@ export class Wallet implements ReadWriteWallet {
 			return BigNumber.ZERO;
 		}
 
-		const value = container
+		return container
 			.get<ExchangeRateService>(Identifiers.ExchangeRateService)
-			.ratesByDate(this.currency(), this.exchangeCurrency());
-
-		if (value.isZero()) {
-			return value;
-		}
-
-		return this.balance().divide(1e8).times(value);
+			.exchange(this.currency(), this.exchangeCurrency(), DateTime.make(), this.balance().divide(1e8));
 	}
 
 	public nonce(): BigNumber {


### PR DESCRIPTION
Also resolves an inconsistency where satoshis were returned as `v / 1e8` even if they weren't converted. Converted values are returned as `v / 1e8` and the original values will be returned as `v` without modifications.