### PR TITLE
fix(profiles): Transaction#memo return undefined for types that don't support memo

### DIFF
--- a/packages/platform-sdk-profiles/src/dto/transaction.test.ts
+++ b/packages/platform-sdk-profiles/src/dto/transaction.test.ts
@@ -255,6 +255,19 @@ describe("Transaction", () => {
 		expect(subject.memo()).toBe("memo");
 	});
 
+	test("should not throw if transaction type does not have memo", () => {
+		const subject = createSubject(
+			wallet,
+			{
+				memo: undefined,
+			},
+			TransactionData,
+		);
+
+		expect(() => subject.memo()).not.toThrow();
+		expect(subject.memo()).toBeUndefined();
+	});
+
 	test("#hasPassed", () => {
 		subject = createSubject(
 			wallet,

--- a/packages/platform-sdk-profiles/src/dto/transaction.ts
+++ b/packages/platform-sdk-profiles/src/dto/transaction.ts
@@ -70,7 +70,7 @@ export class TransactionData {
 
 	public memo(): string | undefined {
 		// @ts-ignore
-		return this.#data.memo();
+		return this.#data.memo?.();
 	}
 
 	public asset(): Record<string, unknown> {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Prevent from throwing type error: `memo is not a function` when calling `transaction.memo()` for transaction types that don't have it. Return undefined instead.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
