### PR TITLE
feat(profiles): implement `ReadWriteWallet#knownName`

### DIFF
--- a/packages/platform-sdk-profiles/src/wallets/wallet.models.ts
+++ b/packages/platform-sdk-profiles/src/wallets/wallet.models.ts
@@ -85,11 +85,15 @@ export interface ReadWriteWallet {
 	settings(): SettingRepository;
 	toObject(): WalletStruct;
 
+	knownName(): string | undefined;
 	secondPublicKey(): string | undefined;
 	username(): string | undefined;
 
 	isDelegate(): boolean;
 	isResignedDelegate(): boolean;
+	isKnown(): boolean;
+	isOwnedByExchange(): boolean;
+	isOwnedByTeam(): boolean;
 	isLedger(): boolean;
 	isMultiSignature(): boolean;
 	isSecondSignature(): boolean;

--- a/packages/platform-sdk-profiles/src/wallets/wallet.test.ts
+++ b/packages/platform-sdk-profiles/src/wallets/wallet.test.ts
@@ -221,6 +221,14 @@ it("should have an avatar", () => {
 	expect(subject.avatar()).toMatchInlineSnapshot(`"my-avatar"`);
 });
 
+it("should have a known name", () => {
+	container.rebind(Identifiers.KnownWalletService, {
+		name: (a, b) => "arkx",
+	});
+
+	expect(subject.knownName()).toBe("arkx");
+});
+
 it("should have a second public key", () => {
 	expect(subject.secondPublicKey()).toBeUndefined();
 

--- a/packages/platform-sdk-profiles/src/wallets/wallet.ts
+++ b/packages/platform-sdk-profiles/src/wallets/wallet.ts
@@ -282,6 +282,10 @@ export class Wallet implements ReadWriteWallet {
 	 * These methods serve as identifiers for special types of wallets.
 	 */
 
+	public knownName(): string | undefined {
+		return container.get<KnownWalletService>(Identifiers.KnownWalletService).name(this.networkId(), this.address());
+	}
+
 	public secondPublicKey(): string | undefined {
 		if (!this.#wallet) {
 			throw new Error("This wallet has not been synchronized yet. Please call [syncIdentity] before using it.");


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Implements a `knownWallet` method to easily retrieve the known name of a wallet.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
