### PR TITLE
refactor(profiles): change plugin ID type from `number` to `string`

### DIFF
--- a/packages/platform-sdk-profiles/src/plugins/plugin-registry.models.ts
+++ b/packages/platform-sdk-profiles/src/plugins/plugin-registry.models.ts
@@ -77,6 +77,10 @@ export class RegistryPlugin {
 		this.#date = date;
 	}
 
+	public id(): string {
+		return this.#data._id;
+	}
+
 	public name(): string {
 		return this.#data.name;
 	}

--- a/packages/platform-sdk-profiles/src/plugins/plugin-repository.test.ts
+++ b/packages/platform-sdk-profiles/src/plugins/plugin-repository.test.ts
@@ -5,7 +5,7 @@ import { PluginRegistry } from "./plugin-registry";
 import { PluginRepository } from "./plugin-repository";
 
 const stubPlugin = {
-	id: 1,
+	id: "@hello/world",
 	name: "@hello/world",
 	version: "1.0.0",
 	isEnabled: true,
@@ -44,28 +44,28 @@ it("should return all data values", () => {
 it("should find a plugin by its ID", () => {
 	subject.push(stubPlugin);
 
-	expect(subject.findById(1)).toEqual(stubPlugin);
+	expect(subject.findById(stubPlugin.id)).toEqual(stubPlugin);
 });
 
 it("should throw if a plugin cannot be found by its ID", () => {
-	expect(() => subject.findById(1)).toThrow("Failed to find a plugin for [1].");
+	expect(() => subject.findById(stubPlugin.id)).toThrow(`Failed to find a plugin for [${stubPlugin.id}].`);
 });
 
 it("should restore previously created data", () => {
-	subject.fill({ data: { 1: stubPlugin }, blacklist: [] });
+	subject.fill({ data: { [stubPlugin.id]: stubPlugin }, blacklist: [] });
 
-	expect(subject.findById(1)).toEqual(stubPlugin);
+	expect(subject.findById(stubPlugin.id)).toEqual(stubPlugin);
 });
 
 it("should restore the blacklist", () => {
-	subject.fill({ data: { stubPlugin }, blacklist: [1] });
+	subject.fill({ data: { stubPlugin }, blacklist: [stubPlugin.id] });
 
 	expect(subject.blacklist()).toMatchInlineSnapshot(`
 		Set {
-		  1,
+		  "@hello/world",
 		}
 	`);
-	expect(subject.isBlacklisted(1)).toBeTrue();
+	expect(subject.isBlacklisted(stubPlugin.id)).toBeTrue();
 });
 
 it("should forget specific data", () => {
@@ -73,7 +73,7 @@ it("should forget specific data", () => {
 
 	expect(subject.count()).toBe(1);
 
-	subject.forget(1);
+	subject.forget(stubPlugin.id);
 
 	expect(subject.count()).toBe(0);
 });
@@ -97,11 +97,11 @@ it("should add an item to the blacklist", () => {
 
 	expect(blacklist.size).toBe(0);
 
-	blacklist.add(1);
+	blacklist.add(stubPlugin.id);
 
 	expect(blacklist.size).toBe(1);
 
-	blacklist.delete(1);
+	blacklist.delete(stubPlugin.id);
 
 	expect(blacklist.size).toBe(0);
 });

--- a/packages/platform-sdk-profiles/src/plugins/plugin-repository.ts
+++ b/packages/platform-sdk-profiles/src/plugins/plugin-repository.ts
@@ -2,7 +2,7 @@ import { DataRepository } from "../repositories/data-repository";
 import { PluginRegistry } from "./plugin-registry";
 
 interface Plugin {
-	id: number;
+	id: string;
 	name: string;
 	version: string;
 	isEnabled: boolean;
@@ -13,7 +13,7 @@ interface Plugin {
 export class PluginRepository {
 	readonly #data: DataRepository;
 	readonly #registry: PluginRegistry;
-	readonly #blacklist: Set<number> = new Set<number>();
+	readonly #blacklist: Set<string> = new Set<string>();
 
 	public constructor() {
 		this.#data = new DataRepository();
@@ -44,7 +44,7 @@ export class PluginRepository {
 		this.#data.set(`${plugin.id}`, plugin);
 	}
 
-	public fill({ data, blacklist }: { data: object; blacklist: number[] }): void {
+	public fill({ data, blacklist }: { data: object; blacklist: string[] }): void {
 		this.#data.fill(data);
 
 		for (const blacklistValue of blacklist) {
@@ -74,11 +74,11 @@ export class PluginRepository {
 		return this.keys().length;
 	}
 
-	public blacklist(): Set<number> {
+	public blacklist(): Set<string> {
 		return this.#blacklist;
 	}
 
-	public isBlacklisted(id: number): boolean {
+	public isBlacklisted(id: string): boolean {
 		return this.#blacklist.has(id);
 	}
 

--- a/packages/platform-sdk-profiles/src/plugins/plugin-repository.ts
+++ b/packages/platform-sdk-profiles/src/plugins/plugin-repository.ts
@@ -52,8 +52,8 @@ export class PluginRepository {
 		}
 	}
 
-	public findById(id: number): Plugin {
-		const plugin: Plugin | undefined = this.#data.get(`${id}`);
+	public findById(id: string): Plugin {
+		const plugin: Plugin | undefined = this.#data.get(id);
 
 		if (!plugin) {
 			throw new Error(`Failed to find a plugin for [${id}].`);
@@ -62,8 +62,8 @@ export class PluginRepository {
 		return plugin;
 	}
 
-	public forget(id: number): void {
-		this.#data.forget(`${id}`);
+	public forget(id: string): void {
+		this.#data.forget(id);
 	}
 
 	public flush(): void {

--- a/packages/platform-sdk/src/coins/network-repository.test.ts
+++ b/packages/platform-sdk/src/coins/network-repository.test.ts
@@ -341,6 +341,7 @@ test("#all", () => {
 		      },
 		    },
 		    "id": "compendia.mainnet",
+		    "knownWallets": null,
 		    "name": "Compendia - Mainnet",
 		    "networking": Object {
 		      "hosts": Array [


### PR DESCRIPTION
MSQ used unsigned integers for IDs but NPM uses strings like `"_id": "@dated/transaction-export-plugin"`.