### PR TITLE
refactor(sdk): remove `signTransactionWithSchnorr` and `signMessageWithSchnorr`

### DIFF
--- a/packages/platform-sdk-ada/src/services/ledger.ts
+++ b/packages/platform-sdk-ada/src/services/ledger.ts
@@ -29,15 +29,7 @@ export class LedgerService implements Contracts.LedgerService {
 		throw new Exceptions.NotImplemented(this.constructor.name, "signTransaction");
 	}
 
-	public async signTransactionWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signTransactionWithSchnorr");
-	}
-
 	public async signMessage(path: string, payload: Buffer): Promise<string> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "signMessage");
-	}
-
-	public async signMessageWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signMessageWithSchnorr");
 	}
 }

--- a/packages/platform-sdk-ark/src/services/ledger.test.ts
+++ b/packages/platform-sdk-ark/src/services/ledger.test.ts
@@ -53,41 +53,21 @@ describe("getPublicKey", () => {
 });
 
 describe("signTransaction", () => {
-	it("should pass with an ecdsa signature", async () => {
-		const ark = await createMockService(ledger.transaction.ecdsa.record);
-
-		await expect(
-			ark.signTransaction(ledger.bip44.path, Buffer.from(ledger.transaction.ecdsa.payload, "hex")),
-		).resolves.toEqual(ledger.transaction.ecdsa.result);
-	});
-});
-
-describe("signTransactionWithSchnorr", () => {
 	it("should pass with a schnorr signature", async () => {
 		const ark = await createMockService(ledger.transaction.schnorr.record);
 
 		await expect(
-			ark.signTransactionWithSchnorr(ledger.bip44.path, Buffer.from(ledger.transaction.schnorr.payload, "hex")),
+			ark.signTransaction(ledger.bip44.path, Buffer.from(ledger.transaction.schnorr.payload, "hex")),
 		).resolves.toEqual(ledger.transaction.schnorr.result);
 	});
 });
 
 describe("signMessage", () => {
-	it("should pass with an ecdsa signature", async () => {
-		const ark = await createMockService(ledger.message.ecdsa.record);
-
-		await expect(
-			ark.signMessage(ledger.bip44.path, Buffer.from(ledger.message.ecdsa.payload, "hex")),
-		).resolves.toEqual(ledger.message.ecdsa.result);
-	});
-});
-
-describe("signMessageWithSchnorr", () => {
 	it("should pass with a schnorr signature", async () => {
 		const ark = await createMockService(ledger.message.schnorr.record);
 
 		await expect(
-			ark.signMessageWithSchnorr(ledger.bip44.path, Buffer.from(ledger.message.schnorr.payload, "hex")),
+			ark.signMessage(ledger.bip44.path, Buffer.from(ledger.message.schnorr.payload, "hex")),
 		).resolves.toEqual(ledger.message.schnorr.result);
 	});
 });

--- a/packages/platform-sdk-ark/src/services/ledger.ts
+++ b/packages/platform-sdk-ark/src/services/ledger.ts
@@ -31,18 +31,10 @@ export class LedgerService implements Contracts.LedgerService {
 	}
 
 	public async signTransaction(path: string, payload: Buffer): Promise<string> {
-		return this.#transport.signTransaction(path, payload);
-	}
-
-	public async signTransactionWithSchnorr(path: string, payload: Buffer): Promise<string> {
 		return this.#transport.signTransactionWithSchnorr(path, payload);
 	}
 
 	public async signMessage(path: string, payload: Buffer): Promise<string> {
-		return this.#transport.signMessage(path, payload);
-	}
-
-	public async signMessageWithSchnorr(path: string, payload: Buffer): Promise<string> {
 		return this.#transport.signMessageWithSchnorr(path, payload);
 	}
 }

--- a/packages/platform-sdk-atom/src/services/ledger.test.ts
+++ b/packages/platform-sdk-atom/src/services/ledger.test.ts
@@ -48,26 +48,10 @@ describe("signTransaction", () => {
 	});
 });
 
-describe("signTransactionWithSchnorr", () => {
-	it("should fail with a 'NotImplemented' error", async () => {
-		const subject = await createMockService("");
-
-		await expect(subject.signTransactionWithSchnorr("", Buffer.alloc(0))).rejects.toThrow();
-	});
-});
-
 describe("signMessage", () => {
 	it("should fail with a 'NotImplemented' error", async () => {
 		const subject = await createMockService("");
 
 		await expect(subject.signMessage("", Buffer.alloc(0))).rejects.toThrow();
-	});
-});
-
-describe("signMessageWithSchnorr", () => {
-	it("should fail with a 'NotImplemented' error", async () => {
-		const subject = await createMockService("");
-
-		await expect(subject.signMessageWithSchnorr("", Buffer.alloc(0))).rejects.toThrow();
 	});
 });

--- a/packages/platform-sdk-atom/src/services/ledger.ts
+++ b/packages/platform-sdk-atom/src/services/ledger.ts
@@ -43,15 +43,7 @@ export class LedgerService implements Contracts.LedgerService {
 		return signature.toString("hex");
 	}
 
-	public async signTransactionWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signTransactionWithSchnorr");
-	}
-
 	public async signMessage(path: string, payload: Buffer): Promise<string> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "signMessage");
-	}
-
-	public async signMessageWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signMessageWithSchnorr");
 	}
 }

--- a/packages/platform-sdk-btc/src/services/ledger.test.ts
+++ b/packages/platform-sdk-btc/src/services/ledger.test.ts
@@ -70,14 +70,6 @@ describe("signTransaction", () => {
 	});
 });
 
-describe("signTransactionWithSchnorr", () => {
-	it("should fail with a 'NotImplemented' error", async () => {
-		const subject = await createMockService("");
-
-		await expect(subject.signTransactionWithSchnorr("", Buffer.alloc(0))).rejects.toThrow();
-	});
-});
-
 describe("signMessage", () => {
 	it("should pass with an ecdsa signature", async () => {
 		const subject = await createMockService(ledger.message.record);
@@ -85,13 +77,5 @@ describe("signMessage", () => {
 		await expect(
 			subject.signMessage(ledger.bip44.path, Buffer.from(ledger.message.payload, "utf-8")),
 		).resolves.toEqual(ledger.message.result);
-	});
-});
-
-describe("signMessageWithSchnorr", () => {
-	it("should fail with a 'NotImplemented' error", async () => {
-		const subject = await createMockService("");
-
-		await expect(subject.signMessageWithSchnorr("", Buffer.alloc(0))).rejects.toThrow();
 	});
 });

--- a/packages/platform-sdk-btc/src/services/ledger.ts
+++ b/packages/platform-sdk-btc/src/services/ledger.ts
@@ -1,4 +1,4 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts } from "@arkecosystem/platform-sdk";
 import Bitcoin from "@ledgerhq/hw-app-btc";
 import { getAppAndVersion } from "@ledgerhq/hw-app-btc/lib/getAppAndVersion";
 import { serializeTransactionOutputs } from "@ledgerhq/hw-app-btc/lib/serializeTransaction";
@@ -50,17 +50,9 @@ export class LedgerService implements Contracts.LedgerService {
 		return signature.toString();
 	}
 
-	public async signTransactionWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signTransactionWithSchnorr");
-	}
-
 	public async signMessage(path: string, payload: Buffer): Promise<string> {
 		const signature = await this.#transport.signMessageNew(path, payload.toString("hex"));
 
 		return JSON.stringify(signature);
-	}
-
-	public async signMessageWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signMessageWithSchnorr");
 	}
 }

--- a/packages/platform-sdk-eos/src/services/ledger.test.ts
+++ b/packages/platform-sdk-eos/src/services/ledger.test.ts
@@ -70,26 +70,10 @@ describe("signTransaction", () => {
 	});
 });
 
-describe("signTransactionWithSchnorr", () => {
-	it("should fail with a 'NotImplemented' error", async () => {
-		const subject = await createMockService("");
-
-		await expect(subject.signTransactionWithSchnorr("", Buffer.alloc(0))).rejects.toThrow();
-	});
-});
-
 describe("signMessage", () => {
 	it("should fail with a 'NotImplemented' error", async () => {
 		const subject = await createMockService("");
 
 		await expect(subject.signMessage("", Buffer.alloc(0))).rejects.toThrow();
-	});
-});
-
-describe("signMessageWithSchnorr", () => {
-	it("should fail with a 'NotImplemented' error", async () => {
-		const subject = await createMockService("");
-
-		await expect(subject.signMessageWithSchnorr("", Buffer.alloc(0))).rejects.toThrow();
 	});
 });

--- a/packages/platform-sdk-eos/src/services/ledger.ts
+++ b/packages/platform-sdk-eos/src/services/ledger.ts
@@ -38,16 +38,8 @@ export class LedgerService implements Contracts.LedgerService {
 		return signature;
 	}
 
-	public async signTransactionWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signTransactionWithSchnorr");
-	}
-
 	public async signMessage(path: string, payload: Buffer): Promise<string> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "signMessage");
-	}
-
-	public async signMessageWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signMessageWithSchnorr");
 	}
 
 	/**

--- a/packages/platform-sdk-eth/src/services/ledger.test.ts
+++ b/packages/platform-sdk-eth/src/services/ledger.test.ts
@@ -48,14 +48,6 @@ describe("signTransaction", () => {
 	});
 });
 
-describe("signTransactionWithSchnorr", () => {
-	it("should fail with a 'NotImplemented' error", async () => {
-		const trx = await createMockService("");
-
-		await expect(trx.signTransactionWithSchnorr("", Buffer.alloc(0))).rejects.toThrow();
-	});
-});
-
 describe("signMessage", () => {
 	it("should pass with a signature", async () => {
 		const trx = await createMockService(ledger.message.record);
@@ -63,13 +55,5 @@ describe("signMessage", () => {
 		const result = await trx.signMessage(ledger.bip44.path, Buffer.from(ledger.message.payload, "hex"));
 
 		expect(JSON.parse(result)).toEqual(ledger.message.result);
-	});
-});
-
-describe("signMessageWithSchnorr", () => {
-	it("should fail with a 'NotImplemented' error", async () => {
-		const trx = await createMockService("");
-
-		await expect(trx.signMessageWithSchnorr("", Buffer.alloc(0))).rejects.toThrow();
 	});
 });

--- a/packages/platform-sdk-eth/src/services/ledger.ts
+++ b/packages/platform-sdk-eth/src/services/ledger.ts
@@ -1,4 +1,4 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts } from "@arkecosystem/platform-sdk";
 import Ethereum from "@ledgerhq/hw-app-eth";
 
 export class LedgerService implements Contracts.LedgerService {
@@ -38,15 +38,7 @@ export class LedgerService implements Contracts.LedgerService {
 		return JSON.stringify(await this.#transport.signTransaction(path, payload));
 	}
 
-	public async signTransactionWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signTransactionWithSchnorr");
-	}
-
 	public async signMessage(path: string, payload: Buffer): Promise<string> {
 		return JSON.stringify(await this.#transport.signPersonalMessage(path, payload));
-	}
-
-	public async signMessageWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signMessageWithSchnorr");
 	}
 }

--- a/packages/platform-sdk-lsk/src/services/ledger.test.ts
+++ b/packages/platform-sdk-lsk/src/services/ledger.test.ts
@@ -48,14 +48,6 @@ describe("signTransaction", () => {
 	});
 });
 
-describe("signTransactionWithSchnorr", () => {
-	it("should fail with a 'NotImplemented' error", async () => {
-		const lsk = await createMockService("");
-
-		await expect(lsk.signTransactionWithSchnorr("", Buffer.alloc(0))).rejects.toThrow();
-	});
-});
-
 describe("signMessage", () => {
 	it("should pass with a signature", async () => {
 		const lsk = await createMockService(ledger.message.record);
@@ -63,13 +55,5 @@ describe("signMessage", () => {
 		await expect(lsk.signMessage(ledger.bip44.path, Buffer.from(ledger.message.payload, "hex"))).resolves.toEqual(
 			ledger.message.result,
 		);
-	});
-});
-
-describe("signMessageWithSchnorr", () => {
-	it("should fail with a 'NotImplemented' error", async () => {
-		const lsk = await createMockService("");
-
-		await expect(lsk.signMessageWithSchnorr("", Buffer.alloc(0))).rejects.toThrow();
 	});
 });

--- a/packages/platform-sdk-lsk/src/services/ledger.ts
+++ b/packages/platform-sdk-lsk/src/services/ledger.ts
@@ -1,4 +1,4 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts } from "@arkecosystem/platform-sdk";
 import { BIP44 } from "@arkecosystem/platform-sdk-crypto";
 import { CommHandler, DposLedger, LedgerAccount, SupportedCoin } from "dpos-ledger-api";
 
@@ -42,18 +42,10 @@ export class LedgerService implements Contracts.LedgerService {
 		return signature.toString("hex");
 	}
 
-	public async signTransactionWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signTransactionWithSchnorr");
-	}
-
 	public async signMessage(path: string, payload: Buffer): Promise<string> {
 		const signature: Buffer = await this.#transport.signMSG(this.getLedgerAccount(path), payload);
 
 		return signature.slice(0, 64).toString("hex");
-	}
-
-	public async signMessageWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signMessageWithSchnorr");
 	}
 
 	private getLedgerAccount(path: string): LedgerAccount {

--- a/packages/platform-sdk-neo/src/services/ledger.test.ts
+++ b/packages/platform-sdk-neo/src/services/ledger.test.ts
@@ -80,26 +80,10 @@ describe("signTransaction", () => {
 	});
 });
 
-describe("signTransactionWithSchnorr", () => {
-	it("should fail with a 'NotImplemented' error", async () => {
-		const subject = await createMockService("");
-
-		await expect(subject.signTransactionWithSchnorr("", Buffer.alloc(0))).rejects.toThrow();
-	});
-});
-
 describe("signMessage", () => {
 	it("should pass with an ecdsa signature", async () => {
 		const subject = await createMockService("");
 
 		await expect(subject.signMessage("", Buffer.alloc(0))).rejects.toThrow();
-	});
-});
-
-describe("signMessageWithSchnorr", () => {
-	it("should fail with a 'NotImplemented' error", async () => {
-		const subject = await createMockService("");
-
-		await expect(subject.signMessageWithSchnorr("", Buffer.alloc(0))).rejects.toThrow();
 	});
 });

--- a/packages/platform-sdk-neo/src/services/ledger.ts
+++ b/packages/platform-sdk-neo/src/services/ledger.ts
@@ -52,16 +52,8 @@ export class LedgerService implements Contracts.LedgerService {
 		return signature;
 	}
 
-	public async signTransactionWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signTransactionWithSchnorr");
-	}
-
 	public async signMessage(path: string, payload: Buffer): Promise<string> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "signMessage");
-	}
-
-	public async signMessageWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signMessageWithSchnorr");
 	}
 
 	/**

--- a/packages/platform-sdk-trx/src/services/ledger.test.ts
+++ b/packages/platform-sdk-trx/src/services/ledger.test.ts
@@ -48,26 +48,10 @@ describe("signTransaction", () => {
 	});
 });
 
-describe("signTransactionWithSchnorr", () => {
-	it("should fail with a 'NotImplemented' error", async () => {
-		const trx = await createMockService("");
-
-		await expect(trx.signTransactionWithSchnorr("", Buffer.alloc(0))).rejects.toThrow();
-	});
-});
-
 describe("signMessage", () => {
 	it("should fail with a 'NotImplemented' error", async () => {
 		const trx = await createMockService("");
 
 		await expect(trx.signMessage("", Buffer.alloc(0))).rejects.toThrow();
-	});
-});
-
-describe("signMessageWithSchnorr", () => {
-	it("should fail with a 'NotImplemented' error", async () => {
-		const trx = await createMockService("");
-
-		await expect(trx.signMessageWithSchnorr("", Buffer.alloc(0))).rejects.toThrow();
 	});
 });

--- a/packages/platform-sdk-trx/src/services/ledger.ts
+++ b/packages/platform-sdk-trx/src/services/ledger.ts
@@ -38,15 +38,7 @@ export class LedgerService implements Contracts.LedgerService {
 		return this.#transport.signTransaction(path, payload);
 	}
 
-	public async signTransactionWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signTransactionWithSchnorr");
-	}
-
 	public async signMessage(path: string, payload: Buffer): Promise<string> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "signMessage");
-	}
-
-	public async signMessageWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signMessageWithSchnorr");
 	}
 }

--- a/packages/platform-sdk-xlm/src/services/ledger.test.ts
+++ b/packages/platform-sdk-xlm/src/services/ledger.test.ts
@@ -48,26 +48,10 @@ describe("signTransaction", () => {
 	});
 });
 
-describe("signTransactionWithSchnorr", () => {
-	it("should fail with a 'NotImplemented' error", async () => {
-		const trx = await createMockService("");
-
-		await expect(trx.signTransactionWithSchnorr("", Buffer.alloc(0))).rejects.toThrow();
-	});
-});
-
 describe("signMessage", () => {
 	it("should fail with a 'NotImplemented' error", async () => {
 		const trx = await createMockService("");
 
 		await expect(trx.signMessage("", Buffer.alloc(0))).rejects.toThrow();
-	});
-});
-
-describe("signMessageWithSchnorr", () => {
-	it("should fail with a 'NotImplemented' error", async () => {
-		const trx = await createMockService("");
-
-		await expect(trx.signMessageWithSchnorr("", Buffer.alloc(0))).rejects.toThrow();
 	});
 });

--- a/packages/platform-sdk-xlm/src/services/ledger.ts
+++ b/packages/platform-sdk-xlm/src/services/ledger.ts
@@ -40,15 +40,7 @@ export class LedgerService implements Contracts.LedgerService {
 		return signature.toString("hex");
 	}
 
-	public async signTransactionWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signTransactionWithSchnorr");
-	}
-
 	public async signMessage(path: string, payload: Buffer): Promise<string> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "signMessage");
-	}
-
-	public async signMessageWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signMessageWithSchnorr");
 	}
 }

--- a/packages/platform-sdk-xrp/src/services/ledger.test.ts
+++ b/packages/platform-sdk-xrp/src/services/ledger.test.ts
@@ -48,26 +48,10 @@ describe("signTransaction", () => {
 	});
 });
 
-describe("signTransactionWithSchnorr", () => {
-	it("should fail with a 'NotImplemented' error", async () => {
-		const xrp = await createMockService("");
-
-		await expect(xrp.signTransactionWithSchnorr("", Buffer.alloc(0))).rejects.toThrow();
-	});
-});
-
 describe("signMessage", () => {
 	it("should fail with a 'NotImplemented' error", async () => {
 		const xrp = await createMockService("");
 
 		await expect(xrp.signMessage("", Buffer.alloc(0))).rejects.toThrow();
-	});
-});
-
-describe("signMessageWithSchnorr", () => {
-	it("should fail with a 'NotImplemented' error", async () => {
-		const xrp = await createMockService("");
-
-		await expect(xrp.signMessageWithSchnorr("", Buffer.alloc(0))).rejects.toThrow();
 	});
 });

--- a/packages/platform-sdk-xrp/src/services/ledger.ts
+++ b/packages/platform-sdk-xrp/src/services/ledger.ts
@@ -38,15 +38,7 @@ export class LedgerService implements Contracts.LedgerService {
 		return this.#transport.signTransaction(path, payload);
 	}
 
-	public async signTransactionWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signTransactionWithSchnorr");
-	}
-
 	public async signMessage(path: string, payload: Buffer): Promise<string> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "signMessage");
-	}
-
-	public async signMessageWithSchnorr(path: string, payload: Buffer): Promise<string> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "signMessageWithSchnorr");
 	}
 }

--- a/packages/platform-sdk/src/contracts/coins/ledger.ts
+++ b/packages/platform-sdk/src/contracts/coins/ledger.ts
@@ -18,9 +18,5 @@ export interface LedgerService {
 
 	signTransaction(path: string, payload: Buffer): Promise<string>;
 
-	signTransactionWithSchnorr(path: string, payload: Buffer): Promise<string>;
-
 	signMessage(path: string, payload: Buffer): Promise<string>;
-
-	signMessageWithSchnorr(path: string, payload: Buffer): Promise<string>;
 }


### PR DESCRIPTION
These methods are implementation details and their usage should be determined internally based on network configurations as only ARK has a distinction between schnorr and non-schnorr signing.