### PR TITLE
refactor(ark): return empty list if known wallets response is not an array

### DIFF
--- a/packages/platform-sdk-ark/src/services/known-wallets.test.ts
+++ b/packages/platform-sdk-ark/src/services/known-wallets.test.ts
@@ -35,10 +35,18 @@ describe("KnownWalletService", () => {
 		await expect(subject.all()).resolves.toEqual(wallets);
 	});
 
-	it("should fail to return a list of known wallets if the request fails", async () => {
+	it("should return an empty list if the request fails", async () => {
 		nock("https://raw.githubusercontent.com")
 			.get("/ArkEcosystem/common/master/devnet/known-wallets-extended.json")
 			.reply(404);
+
+		await expect(subject.all()).resolves.toEqual([]);
+	});
+
+	it("should return an empty list if the request response is not an array", async () => {
+		nock("https://raw.githubusercontent.com")
+			.get("/ArkEcosystem/common/master/devnet/known-wallets-extended.json")
+			.reply(200, {});
 
 		await expect(subject.all()).resolves.toEqual([]);
 	});

--- a/packages/platform-sdk-ark/src/services/known-wallets.ts
+++ b/packages/platform-sdk-ark/src/services/known-wallets.ts
@@ -18,7 +18,12 @@ export class KnownWalletService implements Contracts.KnownWalletService {
 	public async all(): Promise<Contracts.KnownWallet[]> {
 		try {
 			const results = (await this.#httpClient.get(this.#source)).json();
-			return (Array.isArray(results) ? results : []) as Contracts.KnownWallet[];
+
+			if (Array.isArray(results)) {
+				return results;
+			}
+
+			return [];
 		} catch (error) {
 			return [];
 		}

--- a/packages/platform-sdk-ark/src/services/known-wallets.ts
+++ b/packages/platform-sdk-ark/src/services/known-wallets.ts
@@ -17,7 +17,8 @@ export class KnownWalletService implements Contracts.KnownWalletService {
 
 	public async all(): Promise<Contracts.KnownWallet[]> {
 		try {
-			return (await this.#httpClient.get(this.#source)).json() as Contracts.KnownWallet[];
+			const results = (await this.#httpClient.get(this.#source)).json();
+			return (Array.isArray(results) ? results : []) as Contracts.KnownWallet[];
 		} catch (error) {
 			return [];
 		}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The known wallets should be in the form of an array, if this is not the case, an empty array should be returned instead.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
