### PR TITLE
feat(profiles): use optional addresses param in transaction aggregate

### DIFF
--- a/packages/platform-sdk-profiles/src/profiles/aggregates/transaction-aggregate.test.ts
+++ b/packages/platform-sdk-profiles/src/profiles/aggregates/transaction-aggregate.test.ts
@@ -187,10 +187,7 @@ describe("TransactionAggregate", () => {
 		nock(/.+/)
 			.get("/api/transactions")
 			.query(true)
-			.reply(200, (params) => {
-				console.log("params", params);
-				return require("../../../test/fixtures/client/transactions.json");
-			});
+			.reply(200, require("../../../test/fixtures/client/transactions.json"));
 
 		const result = await subject.transactions({ addresses: ["D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD"] });
 		expect(result).toBeInstanceOf(ExtendedTransactionDataCollection);

--- a/packages/platform-sdk-profiles/src/profiles/aggregates/transaction-aggregate.test.ts
+++ b/packages/platform-sdk-profiles/src/profiles/aggregates/transaction-aggregate.test.ts
@@ -182,4 +182,21 @@ describe("TransactionAggregate", () => {
 		expect(results).toBeInstanceOf(ExtendedTransactionDataCollection);
 		promiseAllSettledByKeyMock.mockRestore();
 	});
+
+	it("should aggregate and filter transactions based on provided addresses", async () => {
+		nock(/.+/)
+			.get("/api/transactions")
+			.query(true)
+			.reply(200, (params) => {
+				console.log("params", params);
+				return require("../../../test/fixtures/client/transactions.json");
+			});
+
+		const result = await subject.transactions({ addresses: ["D8rr7B1d6TL6pf14LgMz4sKp1VBMs6YUYD"] });
+		expect(result).toBeInstanceOf(ExtendedTransactionDataCollection);
+		//@ts-ignore
+		expect(result.items()).toHaveLength(0);
+
+		subject.flush();
+	});
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Aggregate transactions by wallet addresses if provided in `profile.transactionAggregate()`

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
