### PR TITLE
feat(sdk): implement `TransactionData#inputs/outputs`

### DIFF
--- a/packages/platform-sdk-ark/src/dto/transaction.ts
+++ b/packages/platform-sdk-ark/src/dto/transaction.ts
@@ -59,6 +59,14 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return this.data.asset;
 	}
 
+	public inputs(): Record<string, unknown>[] {
+		return [];
+	}
+
+	public outputs(): Record<string, unknown>[] {
+		return [];
+	}
+
 	public isConfirmed(): boolean {
 		return this.confirmations().isGreaterThanOrEqualTo(51);
 	}

--- a/packages/platform-sdk-atom/src/dto/transaction.ts
+++ b/packages/platform-sdk-atom/src/dto/transaction.ts
@@ -57,6 +57,14 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return {};
 	}
 
+	public inputs(): Record<string, unknown>[] {
+		return [];
+	}
+
+	public outputs(): Record<string, unknown>[] {
+		return [];
+	}
+
 	public isConfirmed(): boolean {
 		return false;
 	}

--- a/packages/platform-sdk-avax/src/dto/transaction.ts
+++ b/packages/platform-sdk-avax/src/dto/transaction.ts
@@ -44,11 +44,11 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 	}
 
 	public inputs(): Record<string, unknown>[] {
-		return [];
+		return this.data.inputs;
 	}
 
 	public outputs(): Record<string, unknown>[] {
-		return [];
+		return this.data.outputs;
 	}
 
 	public isConfirmed(): boolean {

--- a/packages/platform-sdk-avax/src/dto/transaction.ts
+++ b/packages/platform-sdk-avax/src/dto/transaction.ts
@@ -43,6 +43,14 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return {};
 	}
 
+	public inputs(): Record<string, unknown>[] {
+		return [];
+	}
+
+	public outputs(): Record<string, unknown>[] {
+		return [];
+	}
+
 	public isConfirmed(): boolean {
 		return true;
 	}

--- a/packages/platform-sdk-btc/src/dto/transaction.ts
+++ b/packages/platform-sdk-btc/src/dto/transaction.ts
@@ -43,6 +43,14 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return {};
 	}
 
+	public inputs(): Record<string, unknown>[] {
+		return [];
+	}
+
+	public outputs(): Record<string, unknown>[] {
+		return [];
+	}
+
 	public isConfirmed(): boolean {
 		return false;
 	}

--- a/packages/platform-sdk-eos/src/dto/transaction.ts
+++ b/packages/platform-sdk-eos/src/dto/transaction.ts
@@ -47,6 +47,14 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return {};
 	}
 
+	public inputs(): Record<string, unknown>[] {
+		return [];
+	}
+
+	public outputs(): Record<string, unknown>[] {
+		return [];
+	}
+
 	public isConfirmed(): boolean {
 		return false;
 	}

--- a/packages/platform-sdk-eth/src/dto/transaction.ts
+++ b/packages/platform-sdk-eth/src/dto/transaction.ts
@@ -48,6 +48,14 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return {};
 	}
 
+	public inputs(): Record<string, unknown>[] {
+		return [];
+	}
+
+	public outputs(): Record<string, unknown>[] {
+		return [];
+	}
+
 	public isConfirmed(): boolean {
 		return false;
 	}

--- a/packages/platform-sdk-lsk/src/dto/transaction.ts
+++ b/packages/platform-sdk-lsk/src/dto/transaction.ts
@@ -48,6 +48,14 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return {};
 	}
 
+	public inputs(): Record<string, unknown>[] {
+		return [];
+	}
+
+	public outputs(): Record<string, unknown>[] {
+		return [];
+	}
+
 	public isConfirmed(): boolean {
 		return this.confirmations().isGreaterThanOrEqualTo(101);
 	}

--- a/packages/platform-sdk-neo/src/dto/transaction.ts
+++ b/packages/platform-sdk-neo/src/dto/transaction.ts
@@ -47,6 +47,14 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return {};
 	}
 
+	public inputs(): Record<string, unknown>[] {
+		return [];
+	}
+
+	public outputs(): Record<string, unknown>[] {
+		return [];
+	}
+
 	public isConfirmed(): boolean {
 		return false;
 	}

--- a/packages/platform-sdk-profiles/src/dto/transaction.test.ts
+++ b/packages/platform-sdk-profiles/src/dto/transaction.test.ts
@@ -54,6 +54,8 @@ const createSubject = (wallet, properties, klass) => {
 		amount: () => BigNumber.make(18).times(1e8),
 		fee: () => BigNumber.make(2).times(1e8),
 		asset: () => ({}),
+		inputs: () => [],
+		outputs: () => [],
 		isSent: () => true,
 		toObject: () => ({}),
 		getMeta: (): Contracts.TransactionDataMeta => meta,
@@ -245,6 +247,30 @@ describe("Transaction", () => {
 		);
 
 		expect(subject.memo()).toBe("memo");
+	});
+
+	test("#inputs", () => {
+		subject = createSubject(
+			wallet,
+			{
+				inputs: () => [{}, {}, {}],
+			},
+			TransactionData,
+		);
+
+		expect(subject.inputs()).toHaveLength(3);
+	});
+
+	test("#outputs", () => {
+		subject = createSubject(
+			wallet,
+			{
+				outputs: () => [{}, {}, {}],
+			},
+			TransactionData,
+		);
+
+		expect(subject.outputs()).toHaveLength(3);
 	});
 
 	test("should not throw if transaction type does not have memo", () => {

--- a/packages/platform-sdk-profiles/src/dto/transaction.ts
+++ b/packages/platform-sdk-profiles/src/dto/transaction.ts
@@ -79,6 +79,14 @@ export class TransactionData {
 		return this.#data.isConfirmed();
 	}
 
+	public inputs(): Record<string, unknown>[] {
+		return this.#data.inputs();
+	}
+
+	public outputs(): Record<string, unknown>[] {
+		return this.#data.outputs();
+	}
+
 	public isSent(): boolean {
 		return this.#data.isSent();
 	}

--- a/packages/platform-sdk-profiles/src/wallets/wallet.ts
+++ b/packages/platform-sdk-profiles/src/wallets/wallet.ts
@@ -2,6 +2,7 @@ import { Coins, Contracts } from "@arkecosystem/platform-sdk";
 import { DateTime } from "@arkecosystem/platform-sdk-intl";
 import { BigNumber } from "@arkecosystem/platform-sdk-support";
 import { decrypt } from "bip38";
+import dot from "dot-prop";
 
 import { ExtendedTransactionData } from "../dto/transaction";
 import { ExtendedTransactionDataCollection } from "../dto/transaction-collection";
@@ -243,8 +244,8 @@ export class Wallet implements ReadWriteWallet {
 				},
 				networking: {
 					hosts: network.networking.hosts,
-					hostsMultiSignature: network.networking.hostsMultiSignature || [],
-					hostsArchival: network.networking.hostsArchival || [],
+					hostsMultiSignature: dot.get(network, "networking.hostsMultiSignature", []),
+					hostsArchival: dot.get(network, "networking.hostsArchival", []),
 				},
 			},
 			address: this.address(),

--- a/packages/platform-sdk-trx/src/dto/transaction.ts
+++ b/packages/platform-sdk-trx/src/dto/transaction.ts
@@ -47,6 +47,14 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return {};
 	}
 
+	public inputs(): Record<string, unknown>[] {
+		return [];
+	}
+
+	public outputs(): Record<string, unknown>[] {
+		return [];
+	}
+
 	public isConfirmed(): boolean {
 		return false;
 	}

--- a/packages/platform-sdk-xlm/src/dto/transaction.ts
+++ b/packages/platform-sdk-xlm/src/dto/transaction.ts
@@ -48,6 +48,14 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return {};
 	}
 
+	public inputs(): Record<string, unknown>[] {
+		return [];
+	}
+
+	public outputs(): Record<string, unknown>[] {
+		return [];
+	}
+
 	public isConfirmed(): boolean {
 		return false;
 	}

--- a/packages/platform-sdk-xrp/src/dto/transaction.ts
+++ b/packages/platform-sdk-xrp/src/dto/transaction.ts
@@ -56,6 +56,14 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 		return {};
 	}
 
+	public inputs(): Record<string, unknown>[] {
+		return [];
+	}
+
+	public outputs(): Record<string, unknown>[] {
+		return [];
+	}
+
 	public isConfirmed(): boolean {
 		return false;
 	}

--- a/packages/platform-sdk/src/contracts/coins/data.ts
+++ b/packages/platform-sdk/src/contracts/coins/data.ts
@@ -100,6 +100,10 @@ export interface TransactionData {
 
 	asset(): Record<string, unknown>;
 
+	inputs(): Record<string, unknown>[];
+
+	outputs(): Record<string, unknown>[];
+
 	isConfirmed(): boolean;
 
 	isSent(): boolean;

--- a/packages/platform-sdk/src/dto/transaction.test.ts
+++ b/packages/platform-sdk/src/dto/transaction.test.ts
@@ -317,6 +317,14 @@ class Transaction extends AbstractTransactionData {
 		return {};
 	}
 
+	public inputs(): Record<string, unknown>[] {
+		return [];
+	}
+
+	public outputs(): Record<string, unknown>[] {
+		return [];
+	}
+
 	public isConfirmed(): boolean {
 		return false;
 	}

--- a/packages/platform-sdk/src/dto/transaction.ts
+++ b/packages/platform-sdk/src/dto/transaction.ts
@@ -89,6 +89,10 @@ export abstract class AbstractTransactionData {
 
 	abstract asset(): Record<string, unknown>;
 
+	abstract inputs(): Record<string, unknown>[];
+
+	abstract outputs(): Record<string, unknown>[];
+
 	abstract isConfirmed(): boolean;
 
 	abstract isSent(): boolean;


### PR DESCRIPTION
These methods are required for coins that make use of UTXO. The data will have to be normalised in a separate PR.