### PR TITLE
refactor: support additional input for `ClientService#transaction`

### DIFF
--- a/packages/platform-sdk-ada/src/services/client.ts
+++ b/packages/platform-sdk-ada/src/services/client.ts
@@ -31,7 +31,7 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transaction");
 	}
 

--- a/packages/platform-sdk-ada/src/services/client.ts
+++ b/packages/platform-sdk-ada/src/services/client.ts
@@ -31,7 +31,10 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
+	public async transaction(
+		id: string,
+		input?: Contracts.TransactionDetailInput,
+	): Promise<Contracts.TransactionDataType> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transaction");
 	}
 

--- a/packages/platform-sdk-ada/src/services/client.ts
+++ b/packages/platform-sdk-ada/src/services/client.ts
@@ -31,7 +31,7 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transaction");
 	}
 

--- a/packages/platform-sdk-ark/src/services/client.ts
+++ b/packages/platform-sdk-ark/src/services/client.ts
@@ -24,7 +24,7 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
 		const body = await this.get(`transactions/${id}`);
 
 		return Helpers.createTransactionDataWithType(body.data, TransactionDTO);

--- a/packages/platform-sdk-ark/src/services/client.ts
+++ b/packages/platform-sdk-ark/src/services/client.ts
@@ -24,7 +24,10 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
+	public async transaction(
+		id: string,
+		input?: Contracts.TransactionDetailInput,
+	): Promise<Contracts.TransactionDataType> {
 		const body = await this.get(`transactions/${id}`);
 
 		return Helpers.createTransactionDataWithType(body.data, TransactionDTO);

--- a/packages/platform-sdk-ark/src/services/client.ts
+++ b/packages/platform-sdk-ark/src/services/client.ts
@@ -24,7 +24,7 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
 		const body = await this.get(`transactions/${id}`);
 
 		return Helpers.createTransactionDataWithType(body.data, TransactionDTO);

--- a/packages/platform-sdk-atom/src/services/client.ts
+++ b/packages/platform-sdk-atom/src/services/client.ts
@@ -61,7 +61,10 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
+	public async transaction(
+		id: string,
+		input?: Contracts.TransactionDetailInput,
+	): Promise<Contracts.TransactionDataType> {
 		const response = await this.get(`txs/${id}`);
 
 		return Helpers.createTransactionDataWithType(response, TransactionDTO);

--- a/packages/platform-sdk-atom/src/services/client.ts
+++ b/packages/platform-sdk-atom/src/services/client.ts
@@ -61,7 +61,7 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
 		const response = await this.get(`txs/${id}`);
 
 		return Helpers.createTransactionDataWithType(response, TransactionDTO);

--- a/packages/platform-sdk-atom/src/services/client.ts
+++ b/packages/platform-sdk-atom/src/services/client.ts
@@ -61,7 +61,7 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
 		const response = await this.get(`txs/${id}`);
 
 		return Helpers.createTransactionDataWithType(response, TransactionDTO);

--- a/packages/platform-sdk-avax/src/services/client.ts
+++ b/packages/platform-sdk-avax/src/services/client.ts
@@ -23,7 +23,10 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
+	public async transaction(
+		id: string,
+		input?: Contracts.TransactionDetailInput,
+	): Promise<Contracts.TransactionDataType> {
 		const transaction = new Tx();
 		transaction.fromString(await this.#chain.getTx(id));
 

--- a/packages/platform-sdk-avax/src/services/client.ts
+++ b/packages/platform-sdk-avax/src/services/client.ts
@@ -23,7 +23,7 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
 		const transaction = new Tx();
 		transaction.fromString(await this.#chain.getTx(id));
 

--- a/packages/platform-sdk-avax/src/services/client.ts
+++ b/packages/platform-sdk-avax/src/services/client.ts
@@ -23,7 +23,7 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
 		const transaction = new Tx();
 		transaction.fromString(await this.#chain.getTx(id));
 

--- a/packages/platform-sdk-btc/src/services/client.ts
+++ b/packages/platform-sdk-btc/src/services/client.ts
@@ -39,7 +39,7 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
 		return Helpers.createTransactionDataWithType(await this.get(`transactions/${id}`), TransactionDTO);
 	}
 

--- a/packages/platform-sdk-btc/src/services/client.ts
+++ b/packages/platform-sdk-btc/src/services/client.ts
@@ -39,7 +39,10 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
+	public async transaction(
+		id: string,
+		input?: Contracts.TransactionDetailInput,
+	): Promise<Contracts.TransactionDataType> {
 		return Helpers.createTransactionDataWithType(await this.get(`transactions/${id}`), TransactionDTO);
 	}
 

--- a/packages/platform-sdk-btc/src/services/client.ts
+++ b/packages/platform-sdk-btc/src/services/client.ts
@@ -39,7 +39,7 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
 		return Helpers.createTransactionDataWithType(await this.get(`transactions/${id}`), TransactionDTO);
 	}
 

--- a/packages/platform-sdk-dot/src/services/client.ts
+++ b/packages/platform-sdk-dot/src/services/client.ts
@@ -19,7 +19,10 @@ export class ClientService implements Contracts.ClientService {
 		await this.#client.disconnect();
 	}
 
-	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
+	public async transaction(
+		id: string,
+		input?: Contracts.TransactionDetailInput,
+	): Promise<Contracts.TransactionDataType> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transaction");
 	}
 

--- a/packages/platform-sdk-dot/src/services/client.ts
+++ b/packages/platform-sdk-dot/src/services/client.ts
@@ -19,7 +19,7 @@ export class ClientService implements Contracts.ClientService {
 		await this.#client.disconnect();
 	}
 
-	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transaction");
 	}
 

--- a/packages/platform-sdk-dot/src/services/client.ts
+++ b/packages/platform-sdk-dot/src/services/client.ts
@@ -19,7 +19,7 @@ export class ClientService implements Contracts.ClientService {
 		await this.#client.disconnect();
 	}
 
-	public async transaction(id: string): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transaction");
 	}
 

--- a/packages/platform-sdk-eos/src/services/client.ts
+++ b/packages/platform-sdk-eos/src/services/client.ts
@@ -37,7 +37,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	// https://developers.eos.io/manuals/eosjs/latest/how-to-guides/how-to-get-transaction-information
-	public async transaction(id: string): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transaction");
 	}
 

--- a/packages/platform-sdk-eos/src/services/client.ts
+++ b/packages/platform-sdk-eos/src/services/client.ts
@@ -37,7 +37,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	// https://developers.eos.io/manuals/eosjs/latest/how-to-guides/how-to-get-transaction-information
-	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transaction");
 	}
 

--- a/packages/platform-sdk-eos/src/services/client.ts
+++ b/packages/platform-sdk-eos/src/services/client.ts
@@ -37,7 +37,10 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	// https://developers.eos.io/manuals/eosjs/latest/how-to-guides/how-to-get-transaction-information
-	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
+	public async transaction(
+		id: string,
+		input?: Contracts.TransactionDetailInput,
+	): Promise<Contracts.TransactionDataType> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transaction");
 	}
 

--- a/packages/platform-sdk-eth/src/services/client.ts
+++ b/packages/platform-sdk-eth/src/services/client.ts
@@ -44,7 +44,7 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
 		return Helpers.createTransactionDataWithType(await this.get(`transactions/${id}`), TransactionDTO);
 	}
 

--- a/packages/platform-sdk-eth/src/services/client.ts
+++ b/packages/platform-sdk-eth/src/services/client.ts
@@ -44,7 +44,7 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
 		return Helpers.createTransactionDataWithType(await this.get(`transactions/${id}`), TransactionDTO);
 	}
 

--- a/packages/platform-sdk-eth/src/services/client.ts
+++ b/packages/platform-sdk-eth/src/services/client.ts
@@ -44,7 +44,10 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
+	public async transaction(
+		id: string,
+		input?: Contracts.TransactionDetailInput,
+	): Promise<Contracts.TransactionDataType> {
 		return Helpers.createTransactionDataWithType(await this.get(`transactions/${id}`), TransactionDTO);
 	}
 

--- a/packages/platform-sdk-lsk/src/services/client.ts
+++ b/packages/platform-sdk-lsk/src/services/client.ts
@@ -39,7 +39,7 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
 		const result = await this.get("transactions", { id });
 
 		return Helpers.createTransactionDataWithType(result.data[0], TransactionDTO);

--- a/packages/platform-sdk-lsk/src/services/client.ts
+++ b/packages/platform-sdk-lsk/src/services/client.ts
@@ -39,7 +39,7 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
 		const result = await this.get("transactions", { id });
 
 		return Helpers.createTransactionDataWithType(result.data[0], TransactionDTO);

--- a/packages/platform-sdk-lsk/src/services/client.ts
+++ b/packages/platform-sdk-lsk/src/services/client.ts
@@ -39,7 +39,10 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
+	public async transaction(
+		id: string,
+		input?: Contracts.TransactionDetailInput,
+	): Promise<Contracts.TransactionDataType> {
 		const result = await this.get("transactions", { id });
 
 		return Helpers.createTransactionDataWithType(result.data[0], TransactionDTO);

--- a/packages/platform-sdk-neo/src/services/client.ts
+++ b/packages/platform-sdk-neo/src/services/client.ts
@@ -42,7 +42,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	// get_transaction/{txid}
-	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transaction");
 	}
 

--- a/packages/platform-sdk-neo/src/services/client.ts
+++ b/packages/platform-sdk-neo/src/services/client.ts
@@ -42,7 +42,7 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	// get_transaction/{txid}
-	public async transaction(id: string): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transaction");
 	}
 

--- a/packages/platform-sdk-neo/src/services/client.ts
+++ b/packages/platform-sdk-neo/src/services/client.ts
@@ -42,7 +42,10 @@ export class ClientService implements Contracts.ClientService {
 	}
 
 	// get_transaction/{txid}
-	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
+	public async transaction(
+		id: string,
+		input?: Contracts.TransactionDetailInput,
+	): Promise<Contracts.TransactionDataType> {
 		throw new Exceptions.NotImplemented(this.constructor.name, "transaction");
 	}
 

--- a/packages/platform-sdk-trx/src/services/client.ts
+++ b/packages/platform-sdk-trx/src/services/client.ts
@@ -41,7 +41,10 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
+	public async transaction(
+		id: string,
+		input?: Contracts.TransactionDetailInput,
+	): Promise<Contracts.TransactionDataType> {
 		const result = await this.#connection.trx.getTransaction(id);
 
 		return Helpers.createTransactionDataWithType(result, TransactionDTO);

--- a/packages/platform-sdk-trx/src/services/client.ts
+++ b/packages/platform-sdk-trx/src/services/client.ts
@@ -41,7 +41,7 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
 		const result = await this.#connection.trx.getTransaction(id);
 
 		return Helpers.createTransactionDataWithType(result, TransactionDTO);

--- a/packages/platform-sdk-trx/src/services/client.ts
+++ b/packages/platform-sdk-trx/src/services/client.ts
@@ -41,7 +41,7 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
 		const result = await this.#connection.trx.getTransaction(id);
 
 		return Helpers.createTransactionDataWithType(result, TransactionDTO);

--- a/packages/platform-sdk-xlm/src/services/client.ts
+++ b/packages/platform-sdk-xlm/src/services/client.ts
@@ -31,7 +31,7 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
 		const transaction = await this.#client.transactions().transaction(id).call();
 		const operations = await transaction.operations();
 

--- a/packages/platform-sdk-xlm/src/services/client.ts
+++ b/packages/platform-sdk-xlm/src/services/client.ts
@@ -31,7 +31,7 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
 		const transaction = await this.#client.transactions().transaction(id).call();
 		const operations = await transaction.operations();
 

--- a/packages/platform-sdk-xlm/src/services/client.ts
+++ b/packages/platform-sdk-xlm/src/services/client.ts
@@ -31,7 +31,10 @@ export class ClientService implements Contracts.ClientService {
 		//
 	}
 
-	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
+	public async transaction(
+		id: string,
+		input?: Contracts.TransactionDetailInput,
+	): Promise<Contracts.TransactionDataType> {
 		const transaction = await this.#client.transactions().transaction(id).call();
 		const operations = await transaction.operations();
 

--- a/packages/platform-sdk-xrp/src/services/client.ts
+++ b/packages/platform-sdk-xrp/src/services/client.ts
@@ -152,7 +152,7 @@ export class ClientService implements Contracts.ClientService {
 		await this.#connection.disconnect();
 	}
 
-	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
 		const transaction = await this.#connection.getTransaction(id);
 
 		return Helpers.createTransactionDataWithType(transaction, TransactionDTO);

--- a/packages/platform-sdk-xrp/src/services/client.ts
+++ b/packages/platform-sdk-xrp/src/services/client.ts
@@ -152,7 +152,10 @@ export class ClientService implements Contracts.ClientService {
 		await this.#connection.disconnect();
 	}
 
-	public async transaction(id: string, input?: Contracts.TransactionDetailInput): Promise<Contracts.TransactionDataType> {
+	public async transaction(
+		id: string,
+		input?: Contracts.TransactionDetailInput,
+	): Promise<Contracts.TransactionDataType> {
 		const transaction = await this.#connection.getTransaction(id);
 
 		return Helpers.createTransactionDataWithType(transaction, TransactionDTO);

--- a/packages/platform-sdk-xrp/src/services/client.ts
+++ b/packages/platform-sdk-xrp/src/services/client.ts
@@ -152,7 +152,7 @@ export class ClientService implements Contracts.ClientService {
 		await this.#connection.disconnect();
 	}
 
-	public async transaction(id: string): Promise<Contracts.TransactionDataType> {
+	public async transaction(id: string, opts?: Contracts.TransactionDetailOptions): Promise<Contracts.TransactionDataType> {
 		const transaction = await this.#connection.getTransaction(id);
 
 		return Helpers.createTransactionDataWithType(transaction, TransactionDTO);

--- a/packages/platform-sdk/src/contracts/coins/client.ts
+++ b/packages/platform-sdk/src/contracts/coins/client.ts
@@ -78,6 +78,6 @@ export interface VoteReport {
 	publicKeys: string[];
 }
 
-export interface TransactionDetailOptions {
+export interface TransactionDetailInput {
 	walletId?: string;
 }

--- a/packages/platform-sdk/src/contracts/coins/client.ts
+++ b/packages/platform-sdk/src/contracts/coins/client.ts
@@ -77,3 +77,7 @@ export interface VoteReport {
 	available: number;
 	publicKeys: string[];
 }
+
+export interface TransactionDetailOptions {
+	walletId?: string;
+}


### PR DESCRIPTION
Some coins require additional information to retrieve transactions. Initially this will be limited to a `walletId` property which is required by ADA. A separate PR will implement the storage for this value.