### PR TITLE
fix: allow multiple addresses in profile transactions aggregate

### DIFF
--- a/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet.ts
@@ -17,7 +17,18 @@ import { SettingRepository } from "../repositories/setting-repository";
 import { Avatar } from "../../../helpers/avatar";
 import { ReadOnlyWallet } from "./read-only-wallet";
 import { TransactionService } from "./wallet-transaction-service";
-import { IPeerRepository, IProfile, IReadWriteWallet, IReadOnlyWallet, IWalletStruct, ProfileSetting, WalletData, WalletFlag, WalletSetting, IDelegateService } from "../../../contracts";
+import {
+	IPeerRepository,
+	IProfile,
+	IReadWriteWallet,
+	IReadOnlyWallet,
+	IWalletStruct,
+	ProfileSetting,
+	WalletData,
+	WalletFlag,
+	WalletSetting,
+	IDelegateService,
+} from "../../../contracts";
 import { ExtendedTransactionDataCollection } from "../../../dto";
 
 export class Wallet implements IReadWriteWallet {
@@ -449,19 +460,19 @@ export class Wallet implements IReadWriteWallet {
 	public async transactions(
 		query: Contracts.ClientTransactionsInput = {},
 	): Promise<ExtendedTransactionDataCollection> {
-		return this.fetchTransactions({ addresses: [this.address()], ...query });
+		return this.fetchTransactions({ ...query, addresses: [this.address()] });
 	}
 
 	public async sentTransactions(
 		query: Contracts.ClientTransactionsInput = {},
 	): Promise<ExtendedTransactionDataCollection> {
-		return this.fetchTransactions({ senderId: this.address(), ...query });
+		return this.fetchTransactions({ ...query, senderId: this.address() });
 	}
 
 	public async receivedTransactions(
 		query: Contracts.ClientTransactionsInput = {},
 	): Promise<ExtendedTransactionDataCollection> {
-		return this.fetchTransactions({ recipientId: this.address(), ...query });
+		return this.fetchTransactions({ ...query, recipientId: this.address() });
 	}
 
 	public multiSignature(): Contracts.WalletMultiSignature {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
When calling `profile.aggregate()` with multiple addresses, the wrong `addresses` array is passed in each wallets query, resulting in having the requests of most of the wallets fail because of the wrong address. This PR ensures that `wallet.fetchTransactions` has the correct address of the wallet instance

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
