### PR TITLE
fix: ensure wallet is marked as fully restored when coin is synced in `setCoin`

### DIFF
--- a/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet.ts
@@ -92,7 +92,7 @@ export class Wallet implements IReadWriteWallet {
 	 * @memberof Wallet
 	 */
 	public async connect(): Promise<void> {
-		if (! this.hasCoin()) {
+		if (!this.hasCoin()) {
 			throw new Exceptions.BadVariableDependencyException(this.constructor.name, "connect", "coin");
 		}
 
@@ -117,7 +117,11 @@ export class Wallet implements IReadWriteWallet {
 	 * These methods allow to switch out the underlying implementation of certain things like the coin.
 	 */
 
-	 public async setCoin(coin: string, network: string, options: { sync: boolean; } = { sync: true }): Promise<IReadWriteWallet> {
+	public async setCoin(
+		coin: string,
+		network: string,
+		options: { sync: boolean } = { sync: true },
+	): Promise<IReadWriteWallet> {
 		if (this.usesCustomPeer() && this.peers().has(coin, network)) {
 			this.#coin = makeCoin(
 				coin,
@@ -146,6 +150,8 @@ export class Wallet implements IReadWriteWallet {
 				} else {
 					this.markAsPartiallyRestored();
 				}
+			} else {
+				this.markAsFullyRestored();
 			}
 		} catch {
 			this.markAsPartiallyRestored();
@@ -629,7 +635,7 @@ export class Wallet implements IReadWriteWallet {
 	 * These methods serve as helpers to keep the wallet data updated.
 	 */
 
-	public async sync(options: { resetCoin: boolean; } = { resetCoin: false }): Promise<void> {
+	public async sync(options: { resetCoin: boolean } = { resetCoin: false }): Promise<void> {
 		if (options.resetCoin) {
 			this.#coin = makeCoin(this.coinId(), this.networkId(), {}, true);
 		}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
When calling `profile.restore` with multiple wallets, the wallets are marked (as expected) as partially restored. Though there are some wallets that are not marked as fully restored when running `profile.sync` when wallet's coin is already synced. 
This PR ensures that the wallet is marked as fully restored when syncing with network.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
