### PR TITLE
refactor(profiles): store active profile in container

### DIFF
--- a/packages/platform-sdk-cli/src/commands/access-profile.ts
+++ b/packages/platform-sdk-cli/src/commands/access-profile.ts
@@ -39,7 +39,7 @@ export const accessProfile = async (env: Environment): Promise<void> => {
 
 		await profile.restore(password);
 
-		Helpers.MemoryPassword.set(profile, password);
+		Helpers.MemoryPassword.set(password);
 	} else {
 		await profile.restore();
 	}

--- a/packages/platform-sdk-cli/src/commands/import-ledger-wallet.ts
+++ b/packages/platform-sdk-cli/src/commands/import-ledger-wallet.ts
@@ -32,7 +32,8 @@ export const importLedgerWallet = async (env: Environment, profile: Contracts.IP
 	]);
 
 	const slip44 = network === "ark.mainnet" ? 111 : 1;
-	const instance = await env.coin(coin, network);
+	const instance = profile.coins().push(coin, network);
+	await instance.__construct();
 
 	await LedgerTransportNodeHID.create();
 

--- a/packages/platform-sdk-profiles/src/contracts/profiles/profile.ts
+++ b/packages/platform-sdk-profiles/src/contracts/profiles/profile.ts
@@ -7,6 +7,7 @@ import { INotificationRepository } from "../repositories/notification-repository
 import { IPeerRepository } from "../repositories/peer-repository";
 import { ISettingRepository } from "../repositories/setting-repository";
 import { IWalletRepository } from "../repositories/wallet-repository";
+import { ICoinService } from "../services";
 import { ICountAggregate } from "./aggregates/count-aggregate";
 import { IRegistrationAggregate } from "./aggregates/registration-aggregate";
 import { ITransactionAggregate } from "./aggregates/transaction-aggregate";
@@ -44,6 +45,8 @@ export interface IProfileExportOptions extends IWalletExportOptions {
 }
 
 export interface IProfile {
+	coins(): ICoinService;
+
 	id(): string;
 	name(): string;
 	avatar(): string;

--- a/packages/platform-sdk-profiles/src/contracts/services/delegate-service.ts
+++ b/packages/platform-sdk-profiles/src/contracts/services/delegate-service.ts
@@ -1,3 +1,4 @@
+import { IProfile } from "../profiles";
 import { IReadWriteWallet } from "../wallets";
 import { IReadOnlyWallet } from "../wallets/read-only-wallet";
 

--- a/packages/platform-sdk-profiles/src/contracts/services/fee-service.ts
+++ b/packages/platform-sdk-profiles/src/contracts/services/fee-service.ts
@@ -1,4 +1,5 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
+import { IProfile } from "../profiles";
 
 export interface IFeeService {
 	all(coin: string, network: string): Contracts.TransactionFees;

--- a/packages/platform-sdk-profiles/src/contracts/services/known-wallet-service.ts
+++ b/packages/platform-sdk-profiles/src/contracts/services/known-wallet-service.ts
@@ -1,3 +1,5 @@
+import { IProfile } from "../profiles";
+
 export interface IKnownWalletService {
 	syncAll(): Promise<void>;
 	name(network: string, address: string): string | undefined;

--- a/packages/platform-sdk-profiles/src/drivers/memory/contacts/contact-address.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/contacts/contact-address.test.ts
@@ -5,6 +5,8 @@ import nock from "nock";
 
 import { bootContainer } from "../../../../test/helpers";
 import { ContactAddress } from "./contact-address";
+import { Profile } from "../profiles/profile";
+import { State } from "../../../environment/state";
 
 let subject: ContactAddress;
 
@@ -25,6 +27,8 @@ beforeEach(async () => {
 		.get("/api/wallets/D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib")
 		.reply(200, require("../../../../test/fixtures/client/wallet.json"))
 		.persist();
+
+	State.profile(new Profile({ id: "uuid", name: "name", avatar: "avatar", data: "" }));
 
 	subject = await ContactAddress.make({
 		id: "uuid",

--- a/packages/platform-sdk-profiles/src/drivers/memory/contacts/contact-address.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/contacts/contact-address.ts
@@ -1,10 +1,10 @@
 import { Coins, Contracts } from "@arkecosystem/platform-sdk";
 
 import { container } from "../../../environment/container";
-import { makeCoin } from "../../../environment/container.helpers";
 import { Identifiers } from "../../../environment/container.models";
 import { Avatar } from "../../../helpers/avatar";
-import { IContactAddress, IContactAddressProps, IKnownWalletService } from "../../../contracts";
+import { IContactAddress, IContactAddressProps, IKnownWalletService, IProfile } from "../../../contracts";
+import { State } from "../../../environment/state";
 
 export class ContactAddress implements IContactAddress {
 	readonly #coin: Coins.Coin;
@@ -17,7 +17,7 @@ export class ContactAddress implements IContactAddress {
 	}
 
 	public static async make(data: IContactAddressProps): Promise<ContactAddress> {
-		const instance: Coins.Coin = makeCoin(data.coin, data.network);
+		const instance: Coins.Coin = State.profile().coins().push(data.coin, data.network);
 
 		if (!instance.hasBeenSynchronized()) {
 			await instance.__construct();

--- a/packages/platform-sdk-profiles/src/drivers/memory/contacts/contact.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/contacts/contact.test.ts
@@ -7,6 +7,7 @@ import { bootContainer } from "../../../../test/helpers";
 import { Profile } from "../profiles/profile";
 import { ContactAddressRepository } from "../repositories/contact-address-repository";
 import { Contact } from "./contact";
+import { State } from "../../../environment/state";
 
 beforeAll(() => bootContainer());
 
@@ -15,13 +16,15 @@ describe("contact", () => {
 
 	beforeEach(async () => {
 		const profile = new Profile({ id: "uuid", name: "name", avatar: "avatar", data: "" });
+
+		State.profile(profile);
+
 		subject = new Contact(
 			{
 				id: "uuid",
 				name: "John Doe",
 				starred: true,
-			},
-			profile,
+			}
 		);
 	});
 

--- a/packages/platform-sdk-profiles/src/drivers/memory/contacts/contact.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/contacts/contact.ts
@@ -1,12 +1,9 @@
 import { IContact, IContactAddressInput, IContactAddressRepository, IContactStruct } from "../../../contracts";
-import { IProfile } from "../../../contracts";
 import { pqueue } from "../../../helpers/queue";
 import { ContactAddressRepository } from "../repositories/contact-address-repository";
 import { Avatar } from "../../../helpers/avatar";
 
 export class Contact implements IContact {
-	#profile: IProfile;
-
 	readonly #id: string;
 	#name: string;
 	#addresses: ContactAddressRepository = new ContactAddressRepository();
@@ -14,9 +11,7 @@ export class Contact implements IContact {
 
 	#avatar: string;
 
-	public constructor({ id, name, starred }: IContactStruct, profile: IProfile) {
-		this.#profile = profile;
-
+	public constructor({ id, name, starred }: IContactStruct) {
 		this.#id = id;
 		this.#name = name;
 		this.#starred = starred;

--- a/packages/platform-sdk-profiles/src/drivers/memory/index.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/index.ts
@@ -4,7 +4,6 @@ import { EnvironmentOptions } from "../../environment/env.models";
 import { Driver } from "../../contracts";
 import { DataRepository } from "../../repositories/data-repository";
 import { ProfileRepository } from "./repositories/profile-repository";
-import { CoinService } from "./services/coin-service";
 import { DelegateService } from "./services/delegate-service";
 import { ExchangeRateService } from "./services/exchange-rate-service";
 import { FeeService } from "./services/fee-service";
@@ -22,7 +21,6 @@ export class MemoryDriver implements Driver {
 	 */
 	public make(container: Container, options: EnvironmentOptions): void {
 		container.singleton(Identifiers.AppData, DataRepository);
-		container.singleton(Identifiers.CoinService, CoinService);
 		container.singleton(Identifiers.DelegateService, DelegateService);
 		container.singleton(Identifiers.ExchangeRateService, ExchangeRateService);
 		container.singleton(Identifiers.FeeService, FeeService);

--- a/packages/platform-sdk-profiles/src/drivers/memory/profiles/aggregates/count-aggregate.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/profiles/aggregates/count-aggregate.test.ts
@@ -2,6 +2,7 @@ import "jest-extended";
 import "reflect-metadata";
 
 import { bootContainer } from "../../../../../test/helpers";
+import { State } from "../../../../environment/state";
 import { Profile } from "../profile";
 import { CountAggregate } from "./count-aggregate";
 
@@ -10,7 +11,9 @@ let subject: CountAggregate;
 beforeAll(() => bootContainer());
 
 beforeEach(async () => {
-	subject = new CountAggregate(new Profile({ id: "uuid", name: "name", avatar: "avatar", data: "" }));
+	State.profile(new Profile({ id: "uuid", name: "name", avatar: "avatar", data: "" }));
+
+	subject = new CountAggregate();
 });
 
 it.each(["contacts", "notifications", "wallets"])("should count %s", (method: string) => {

--- a/packages/platform-sdk-profiles/src/drivers/memory/profiles/aggregates/count-aggregate.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/profiles/aggregates/count-aggregate.ts
@@ -1,21 +1,15 @@
-import { IProfile } from "../../../../contracts";
+import { State } from "../../../../environment/state";
 
 export class CountAggregate implements CountAggregate {
-	readonly #profile: IProfile;
-
-	public constructor(profile: IProfile) {
-		this.#profile = profile;
-	}
-
 	public contacts(): number {
-		return this.#profile.contacts().count();
+		return State.profile().contacts().count();
 	}
 
 	public notifications(): number {
-		return this.#profile.notifications().count();
+		return State.profile().notifications().count();
 	}
 
 	public wallets(): number {
-		return this.#profile.wallets().count();
+		return State.profile().wallets().count();
 	}
 }

--- a/packages/platform-sdk-profiles/src/drivers/memory/profiles/aggregates/registration-aggregate.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/profiles/aggregates/registration-aggregate.test.ts
@@ -8,6 +8,7 @@ import { bootContainer } from "../../../../../test/helpers";
 import { IProfile } from "../../../../contracts";
 import { Profile } from "../profile";
 import { RegistrationAggregate } from "./registration-aggregate";
+import { State } from "../../../../environment/state";
 
 let subject: RegistrationAggregate;
 let profile: IProfile;
@@ -30,9 +31,11 @@ beforeAll(() => {
 beforeEach(async () => {
 	profile = new Profile({ id: "uuid", name: "name", avatar: "avatar", data: "" });
 
+	State.profile(profile);
+
 	await profile.wallets().importByMnemonic(identity.mnemonic, "ARK", "ark.devnet");
 
-	subject = new RegistrationAggregate(profile);
+	subject = new RegistrationAggregate();
 });
 
 describe("RegistrationAggregate", () => {

--- a/packages/platform-sdk-profiles/src/drivers/memory/profiles/aggregates/registration-aggregate.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/profiles/aggregates/registration-aggregate.ts
@@ -1,14 +1,9 @@
-import { IProfile, IReadWriteWallet } from "../../../../contracts";
+import { IReadWriteWallet } from "../../../../contracts";
+import { State } from "../../../../environment/state";
 
 export class RegistrationAggregate implements RegistrationAggregate {
-	readonly #profile: IProfile;
-
-	public constructor(profile: IProfile) {
-		this.#profile = profile;
-	}
-
 	public delegates(): IReadWriteWallet[] {
-		return this.#profile
+		return State.profile()
 			.wallets()
 			.values()
 			.filter((wallet: IReadWriteWallet) => wallet.hasSyncedWithNetwork() && wallet.isDelegate());

--- a/packages/platform-sdk-profiles/src/drivers/memory/profiles/aggregates/transaction-aggregate.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/profiles/aggregates/transaction-aggregate.test.ts
@@ -9,6 +9,7 @@ import { ExtendedTransactionDataCollection } from "../../../../dto/transaction-c
 import * as promiseHelpers from "../../../../helpers/promise";
 import { Profile } from "../profile";
 import { TransactionAggregate } from "./transaction-aggregate";
+import { State } from "../../../../environment/state";
 
 let subject: TransactionAggregate;
 
@@ -34,9 +35,11 @@ beforeAll(() => {
 beforeEach(async () => {
 	const profile = new Profile({ id: "uuid", name: "name", avatar: "avatar", data: "" });
 
+	State.profile(profile);
+
 	await profile.wallets().importByMnemonic(identity.mnemonic, "ARK", "ark.devnet");
 
-	subject = new TransactionAggregate(profile);
+	subject = new TransactionAggregate();
 });
 
 afterAll(() => nock.enableNetConnect());

--- a/packages/platform-sdk-profiles/src/drivers/memory/profiles/aggregates/transaction-aggregate.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/profiles/aggregates/transaction-aggregate.ts
@@ -1,9 +1,10 @@
 import { Coins, Contracts } from "@arkecosystem/platform-sdk";
-import { IProfile, IReadWriteWallet, ITransactionAggregate } from "../../../../contracts";
+import { IReadWriteWallet, ITransactionAggregate } from "../../../../contracts";
 import { ExtendedTransactionDataCollection } from "../../../../dto";
 
 import { ExtendedTransactionData } from "../../../../dto/transaction";
 import { transformTransactionData } from "../../../../dto/transaction-mapper";
+import { State } from "../../../../environment/state";
 import { promiseAllSettledByKey } from "../../../../helpers/promise";
 
 type HistoryMethod = string;
@@ -14,13 +15,7 @@ type AggregateQuery = {
 } & Contracts.ClientPagination;
 
 export class TransactionAggregate implements ITransactionAggregate {
-	readonly #profile: IProfile;
-
 	#history: Record<HistoryMethod, Record<string, HistoryWallet>> = {};
-
-	public constructor(profile: IProfile) {
-		this.#profile = profile;
-	}
 
 	public async transactions(query: AggregateQuery = {}): Promise<ExtendedTransactionDataCollection> {
 		return this.aggregate("transactions", query);
@@ -104,11 +99,11 @@ export class TransactionAggregate implements ITransactionAggregate {
 	}
 
 	private getWallet(id: string): IReadWriteWallet {
-		return this.#profile.wallets().findById(id);
+		return State.profile().wallets().findById(id);
 	}
 
 	private getWallets(addresses: string[] = []): IReadWriteWallet[] {
-		return this.#profile
+		return State.profile()
 			.wallets()
 			.values()
 			.filter((wallet: IReadWriteWallet) => {

--- a/packages/platform-sdk-profiles/src/drivers/memory/profiles/aggregates/wallet-aggregate.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/profiles/aggregates/wallet-aggregate.test.ts
@@ -9,6 +9,7 @@ import { bootContainer } from "../../../../../test/helpers";
 import { Profile } from "../profile";
 import { WalletAggregate } from "./wallet-aggregate";
 import { IProfile } from "../../../../contracts";
+import { State } from "../../../../environment/state";
 
 let subject: WalletAggregate;
 let profile: IProfile;
@@ -31,9 +32,11 @@ beforeAll(() => {
 beforeEach(async () => {
 	profile = new Profile({ id: "uuid", name: "name", avatar: "avatar", data: "" });
 
+	State.profile(profile);
+
 	await profile.wallets().importByMnemonic(identity.mnemonic, "ARK", "ark.devnet");
 
-	subject = new WalletAggregate(profile);
+	subject = new WalletAggregate();
 });
 
 describe("WalletAggregate", () => {

--- a/packages/platform-sdk-profiles/src/drivers/memory/profiles/aggregates/wallet-aggregate.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/profiles/aggregates/wallet-aggregate.ts
@@ -1,21 +1,16 @@
 import { BigNumber } from "@arkecosystem/platform-sdk-support";
-import { IProfile, IReadWriteWallet, IWalletAggregate } from "../../../../contracts";
+import { IReadWriteWallet, IWalletAggregate } from "../../../../contracts";
+import { State } from "../../../../environment/state";
 
 type NetworkType = "live" | "test";
 
 export class WalletAggregate implements IWalletAggregate {
-	readonly #profile: IProfile;
-
-	public constructor(profile: IProfile) {
-		this.#profile = profile;
-	}
-
 	public balance(networkType: NetworkType = "live"): BigNumber {
 		return this.balancesByNetworkType()[networkType];
 	}
 
 	public balancesByNetworkType(): Record<NetworkType, BigNumber> {
-		return this.#profile
+		return State.profile()
 			.wallets()
 			.values()
 			.reduce(
@@ -35,7 +30,7 @@ export class WalletAggregate implements IWalletAggregate {
 	}
 
 	public convertedBalance(): BigNumber {
-		return this.#profile
+		return State.profile()
 			.wallets()
 			.values()
 			.reduce(
@@ -48,7 +43,7 @@ export class WalletAggregate implements IWalletAggregate {
 		const result = {};
 
 		const totalByProfile: BigNumber = this.balance(networkType);
-		const walletsByCoin: Record<string, Record<string, IReadWriteWallet>> = this.#profile.wallets().allByCoin();
+		const walletsByCoin: Record<string, Record<string, IReadWriteWallet>> = State.profile().wallets().allByCoin();
 
 		for (const [coin, wallets] of Object.entries(walletsByCoin)) {
 			const matchingWallets = Object.values(wallets).filter(

--- a/packages/platform-sdk-profiles/src/drivers/memory/profiles/authenticator.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/profiles/authenticator.test.ts
@@ -3,6 +3,7 @@ import "reflect-metadata";
 
 import { bootContainer } from "../../../../test/helpers";
 import { IProfile, ProfileSetting } from "../../../contracts";
+import { State } from "../../../environment/state";
 import { MemoryPassword } from "../../../helpers/password";
 import { Authenticator } from "./authenticator";
 import { Profile } from "./profile";
@@ -14,7 +15,10 @@ beforeAll(() => bootContainer());
 
 beforeEach(() => {
 	profile = new Profile({ id: "uuid", name: "name", avatar: "avatar", data: "" });
-	subject = new Authenticator(profile);
+
+	State.profile(profile);
+
+	subject = new Authenticator();
 });
 
 it("should set the password", async () => {
@@ -59,5 +63,5 @@ it("should fail to change the password if the old password is invalid", () => {
 it("should set password in memory", () => {
 	subject.setPassword("password");
 
-	expect(MemoryPassword.get(profile)).toEqual("password");
+expect(MemoryPassword.get()).toEqual("password");
 });

--- a/packages/platform-sdk-profiles/src/drivers/memory/profiles/authenticator.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/profiles/authenticator.ts
@@ -1,45 +1,40 @@
 import { Bcrypt } from "@arkecosystem/platform-sdk-crypto";
 
 import { MemoryPassword } from "../../../helpers/password";
-import { IAuthenticator, IProfile, ProfileSetting } from "../../../contracts";
+import { IAuthenticator, ProfileSetting } from "../../../contracts";
+import { State } from "../../../environment/state";
 
 export class Authenticator implements IAuthenticator {
-	readonly #profile: IProfile;
-
-	public constructor(profile: IProfile) {
-		this.#profile = profile;
-	}
-
 	public setPassword(password: string): void {
 		const encrypted: string = Bcrypt.hash(password);
 
-		this.#profile.settings().set(ProfileSetting.Password, encrypted);
+		State.profile().settings().set(ProfileSetting.Password, encrypted);
 
 		// This is needed for new profiles because they are initialised
 		// without any data besides their ID and name which means the
 		// password will be omitted and we won't know to use it.
-		this.#profile.setRawDataKey("password", encrypted);
+		State.profile().setRawDataKey("password", encrypted);
 
 		// We'll need the password for future use in plain-text
 		// during the lifetime of this profile session.
-		MemoryPassword.set(this.#profile, password);
+		MemoryPassword.set(password);
 
 		// When the password gets changed we need to re-encrypt the
 		// data of the profile or we could end up with a corrupted
 		// profile that can no longer be used or restored.
-		this.#profile.save(password);
+		State.profile().save(password);
 	}
 
 	public verifyPassword(password: string): boolean {
-		if (!this.#profile.usesPassword()) {
+		if (!State.profile().usesPassword()) {
 			throw new Error("No password is set.");
 		}
 
-		return Bcrypt.verify(this.#profile.getRawData().password!, password);
+		return Bcrypt.verify(State.profile().getRawData().password!, password);
 	}
 
 	public changePassword(oldPassword: string, newPassword: string): void {
-		const currentPassword: string | undefined = this.#profile.settings().get(ProfileSetting.Password);
+		const currentPassword: string | undefined = State.profile().settings().get(ProfileSetting.Password);
 
 		if (!currentPassword) {
 			throw new Error("No password is set. Call [setPassword] instead.");

--- a/packages/platform-sdk-profiles/src/drivers/memory/profiles/migrator.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/profiles/migrator.test.ts
@@ -7,6 +7,7 @@ import { bootContainer } from "../../../../test/helpers";
 import { Migrator } from "./migrator";
 import { Profile } from "./profile";
 import { IProfile, ProfileData } from "../../../contracts";
+import { State } from "../../../environment/state";
 
 let subject: Migrator;
 let profile: IProfile;
@@ -15,7 +16,10 @@ beforeAll(() => bootContainer());
 
 beforeEach(async () => {
 	profile = new Profile({ id: "id", name: "name", avatar: "avatar", data: Base64.encode("{}") });
-	subject = new Migrator(profile);
+
+	State.profile(profile);
+
+	subject = new Migrator();
 });
 
 it("should save the project version as the initial migrated version", async () => {
@@ -208,7 +212,10 @@ it("should migrate profiles from JSON to Base64", async () => {
 			},
 		},
 	});
-	subject = new Migrator(profile);
+
+	State.profile(profile);
+
+	subject = new Migrator();
 
 	await subject.migrate(
 		{

--- a/packages/platform-sdk-profiles/src/drivers/memory/profiles/portfolio.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/profiles/portfolio.test.ts
@@ -10,6 +10,7 @@ import { container } from "../../../environment/container";
 import { Identifiers } from "../../../environment/container.models";
 import { Wallet } from "../wallets/wallet";
 import { IExchangeRateService, IProfile, IProfileRepository, IReadWriteWallet, WalletData } from "../../../contracts";
+import { State } from "../../../environment/state";
 
 let profile: IProfile;
 let subject: IReadWriteWallet;
@@ -45,7 +46,9 @@ beforeEach(async () => {
 	profileRepository.flush();
 	profile = profileRepository.create("John Doe");
 
-	subject = new Wallet(uuidv4(), {}, profile);
+	State.profile(profile);
+
+	subject = new Wallet(uuidv4(), {});
 
 	await subject.setCoin("ARK", "ark.devnet");
 	await subject.setIdentity(identity.mnemonic);

--- a/packages/platform-sdk-profiles/src/drivers/memory/profiles/portfolio.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/profiles/portfolio.ts
@@ -1,16 +1,11 @@
-import { IPortfolio, IPortfolioItem, IProfile } from "../../../contracts";
+import { IPortfolio, IPortfolioItem } from "../../../contracts";
+import { State } from "../../../environment/state";
 
 export class Portfolio implements IPortfolio {
-	readonly #profile: IProfile;
-
-	public constructor(profile: IProfile) {
-		this.#profile = profile;
-	}
-
 	public breakdown(): IPortfolioItem[] {
 		const result: Record<string, IPortfolioItem> = {};
 
-		for (const wallet of this.#profile.wallets().values()) {
+		for (const wallet of State.profile().wallets().values()) {
 			if (wallet.network().isTest()) {
 				continue;
 			}

--- a/packages/platform-sdk-profiles/src/drivers/memory/profiles/profile.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/profiles/profile.test.ts
@@ -20,6 +20,7 @@ import { WalletAggregate } from "./aggregates/wallet-aggregate";
 import { Authenticator } from "./authenticator";
 import { Profile } from "./profile";
 import { IProfile, ProfileSetting } from "../../../contracts";
+import { State } from "../../../environment/state";
 
 let subject: IProfile;
 
@@ -44,6 +45,9 @@ beforeAll(() => {
 
 beforeEach(() => {
 	subject = new Profile({ id: "uuid", name: "name", data: "" });
+
+	State.profile(subject);
+
 	subject.settings().set(ProfileSetting.Name, "John Doe");
 });
 

--- a/packages/platform-sdk-profiles/src/drivers/memory/profiles/services/coin-service.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/profiles/services/coin-service.ts
@@ -1,9 +1,9 @@
 import { Coins } from "@arkecosystem/platform-sdk";
 
-import { DataRepository } from "../../../repositories/data-repository";
-import { container } from "../../../environment/container";
-import { Identifiers } from "../../../environment/container.models";
-import { ICoinService } from "../../../contracts";
+import { DataRepository } from "../../../../repositories/data-repository";
+import { container } from "../../../../environment/container";
+import { Identifiers } from "../../../../environment/container.models";
+import { ICoinService } from "../../../../contracts";
 import { injectable } from "inversify";
 
 @injectable()

--- a/packages/platform-sdk-profiles/src/drivers/memory/repositories/contact-address-repository.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/repositories/contact-address-repository.test.ts
@@ -6,6 +6,8 @@ import { v4 as uuidv4 } from "uuid";
 
 import { bootContainer } from "../../../../test/helpers";
 import { ContactAddressRepository } from "./contact-address-repository";
+import { State } from "../../../environment/state";
+import { Profile } from "../profiles/profile";
 
 let subject: ContactAddressRepository;
 
@@ -31,6 +33,8 @@ beforeEach(async () => {
 		.get("/api/wallets/D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib")
 		.reply(200, require("../../../../test/fixtures/client/wallet.json"))
 		.persist();
+
+	State.profile(new Profile({ id: "uuid", name: "name", avatar: "avatar", data: "" }));
 
 	subject = new ContactAddressRepository();
 });

--- a/packages/platform-sdk-profiles/src/drivers/memory/repositories/contact-address-repository.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/repositories/contact-address-repository.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from "uuid";
-import { IContactAddress, IContactAddressInput, IContactAddressRepository } from "../../../contracts";
+import { IContactAddress, IContactAddressInput, IContactAddressRepository, IProfile } from "../../../contracts";
 import { ContactAddress } from "../contacts/contact-address";
 import { injectable } from "inversify";
 
@@ -7,7 +7,7 @@ import { DataRepository } from "../../../repositories/data-repository";
 
 @injectable()
 export class ContactAddressRepository implements IContactAddressRepository {
-	#data: DataRepository = new DataRepository();
+	readonly #data: DataRepository = new DataRepository();
 
 	public all(): Record<string, IContactAddress> {
 		return this.#data.all() as Record<string, IContactAddress>;

--- a/packages/platform-sdk-profiles/src/drivers/memory/repositories/contact-repository.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/repositories/contact-repository.test.ts
@@ -8,6 +8,7 @@ import { bootContainer } from "../../../../test/helpers";
 import { ProfileSetting } from "../../../contracts";
 import { Profile } from "../profiles/profile";
 import { ContactRepository } from "./contact-repository";
+import { State } from "../../../environment/state";
 
 let subject: ContactRepository;
 
@@ -33,11 +34,14 @@ beforeEach(async () => {
 		.persist();
 
 	const profile = new Profile({ id: "profile-id", name: "name", avatar: "avatar", data: "" });
+
+	State.profile(profile);
+
 	profile.settings().set(ProfileSetting.Name, "John Doe");
 
 	await profile.wallets().importByMnemonic(identity.mnemonic, "ARK", "ark.devnet");
 
-	subject = new ContactRepository(profile);
+	subject = new ContactRepository();
 
 	subject.flush();
 });

--- a/packages/platform-sdk-profiles/src/drivers/memory/repositories/contact-repository.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/repositories/contact-repository.ts
@@ -8,14 +8,8 @@ import { DataRepository } from "../../../repositories/data-repository";
 
 @injectable()
 export class ContactRepository implements IContactRepository {
-	#data: DataRepository;
+	readonly #data: DataRepository = new DataRepository();
 	#dataRaw: object = {};
-	#profile: IProfile;
-
-	public constructor(profile: IProfile) {
-		this.#data = new DataRepository();
-		this.#profile = profile;
-	}
 
 	public all(): Record<string, IContact> {
 		return this.#data.all() as Record<string, IContact>;
@@ -48,7 +42,7 @@ export class ContactRepository implements IContactRepository {
 
 		const id: string = uuidv4();
 
-		const result: IContact = new Contact({ id, name, starred: false }, this.#profile);
+		const result: IContact = new Contact({ id, name, starred: false });
 
 		this.#data.set(id, result);
 
@@ -154,7 +148,7 @@ export class ContactRepository implements IContactRepository {
 		this.#dataRaw = contacts;
 
 		for (const [id, contact] of Object.entries(contacts)) {
-			this.#data.set(id, new Contact(contact, this.#profile));
+			this.#data.set(id, new Contact(contact));
 		}
 	}
 

--- a/packages/platform-sdk-profiles/src/drivers/memory/repositories/profile-repository.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/repositories/profile-repository.test.ts
@@ -8,6 +8,7 @@ import { bootContainer } from "../../../../test/helpers";
 import { IProfileRepository } from "../../../contracts";
 import { Profile } from "../profiles/profile";
 import { ProfileRepository } from "./profile-repository";
+import { State } from "../../../environment/state";
 
 let subject: IProfileRepository;
 
@@ -182,10 +183,12 @@ describe("ProfileRepository", () => {
 
 	it("should dump all profiles", async () => {
 		const john = subject.create("John");
+		State.profile(john);
 		await john.wallets().importByMnemonic(identity.mnemonic, "ARK", "ark.devnet");
 		john.save();
 
 		const jane = subject.create("Jane");
+		State.profile(jane);
 		await jane.wallets().importByMnemonic(identity.mnemonic, "ARK", "ark.devnet");
 		jane.auth().setPassword("password");
 		jane.save("password");
@@ -206,6 +209,7 @@ describe("ProfileRepository", () => {
 
 	it("should export ok", async () => {
 		const profile = subject.create("John");
+		State.profile(profile);
 		await profile.wallets().importByMnemonic(identity.mnemonic, "ARK", "ark.devnet");
 
 		const exported = subject.export(profile, {
@@ -220,6 +224,7 @@ describe("ProfileRepository", () => {
 
 	it("should export ok with password", async () => {
 		const profile = subject.create("John");
+		State.profile(profile);
 		profile.auth().setPassword("some pass");
 		await profile.wallets().importByMnemonic(identity.mnemonic, "ARK", "ark.devnet");
 		profile.save("some pass");

--- a/packages/platform-sdk-profiles/src/drivers/memory/repositories/wallet-repository.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/repositories/wallet-repository.test.ts
@@ -10,6 +10,7 @@ import { IReadWriteWallet, ProfileSetting } from "../../../contracts";
 import { Profile } from "../profiles/profile";
 import { Wallet } from "../wallets/wallet";
 import { WalletRepository } from "./wallet-repository";
+import { State } from "../../../environment/state";
 
 jest.setTimeout(60000);
 
@@ -34,9 +35,12 @@ beforeEach(async () => {
 		.persist();
 
 	const profile = new Profile({ id: "profile-id", name: "name", avatar: "avatar", data: "" });
+
+	State.profile(profile);
+
 	profile.settings().set(ProfileSetting.Name, "John Doe");
 
-	subject = new WalletRepository(profile);
+	subject = new WalletRepository();
 
 	const wallet = await subject.importByMnemonic(identity.mnemonic, "ARK", "ark.devnet");
 	subject.update(wallet.id(), { alias: "Alias" });
@@ -196,7 +200,7 @@ test("#fill", async () => {
 	const profile = new Profile({ id: "profile-id", name: "name", avatar: "avatar", data: "" });
 	profile.settings().set(ProfileSetting.Name, "John Doe");
 
-	const newWallet = new Wallet(uuidv4(), {}, profile);
+	const newWallet = new Wallet(uuidv4(), {});
 	await newWallet.setCoin("ARK", "ark.devnet");
 	await newWallet.setIdentity("this is another top secret passphrase");
 

--- a/packages/platform-sdk-profiles/src/drivers/memory/services/delegate-service.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/services/delegate-service.test.ts
@@ -10,6 +10,7 @@ import { Profile } from "../profiles/profile";
 import { Wallet } from "../wallets/wallet";
 import { DelegateService } from "./delegate-service";
 import { IReadWriteWallet } from "../../../contracts";
+import { State } from "../../../environment/state";
 
 let subject: DelegateService;
 
@@ -39,7 +40,9 @@ let wallet: IReadWriteWallet;
 beforeEach(async () => {
 	subject = new DelegateService();
 
-	wallet = new Wallet(uuidv4(), {}, new Profile({ id: "profile-id", name: "name", avatar: "avatar", data: "" }));
+	State.profile(new Profile({ id: "profile-id", name: "name", avatar: "avatar", data: "" }));
+
+	wallet = new Wallet(uuidv4(), {});
 
 	await wallet.setCoin("ARK", "ark.devnet");
 	await wallet.setIdentity(identity.mnemonic);

--- a/packages/platform-sdk-profiles/src/drivers/memory/services/delegate-service.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/services/delegate-service.ts
@@ -3,12 +3,9 @@ import { Coins, Contracts } from "@arkecosystem/platform-sdk";
 import { pqueueSettled } from "../../../helpers/queue";
 import { DataRepository } from "../../../repositories/data-repository";
 import { ReadOnlyWallet } from "../wallets/read-only-wallet";
-import { container } from "../../../environment/container";
-import { makeCoin } from "../../../environment/container.helpers";
-import { Identifiers } from "../../../environment/container.models";
-import { CoinService } from "./coin-service";
-import { IDelegateService, IReadOnlyWallet, IReadWriteWallet } from "../../../contracts";
+import { IDelegateService, IProfile, IReadOnlyWallet, IReadWriteWallet } from "../../../contracts";
 import { injectable } from "inversify";
+import { State } from "../../../environment/state";
 
 @injectable()
 export class DelegateService implements IDelegateService {
@@ -39,7 +36,7 @@ export class DelegateService implements IDelegateService {
 	}
 
 	public async sync(coin: string, network: string): Promise<void> {
-		const instance: Coins.Coin = makeCoin(coin, network);
+		const instance: Coins.Coin = State.profile().coins().push(coin, network);
 
 		if (!instance.hasBeenSynchronized()) {
 			await instance.__construct();
@@ -114,7 +111,7 @@ export class DelegateService implements IDelegateService {
 	public async syncAll(): Promise<void> {
 		const promises: (() => Promise<void>)[] = [];
 
-		for (const [coin, networks] of container.get<CoinService>(Identifiers.CoinService).entries()) {
+		for (const [coin, networks] of State.profile().coins().entries()) {
 			for (const network of networks) {
 				promises.push(() => this.sync(coin, network));
 			}

--- a/packages/platform-sdk-profiles/src/drivers/memory/services/exchange-rate-service.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/services/exchange-rate-service.test.ts
@@ -11,6 +11,7 @@ import { container } from "../../../environment/container";
 import { Identifiers } from "../../../environment/container.models";
 import { ProfileRepository } from "../repositories/profile-repository";
 import { ExchangeRateService } from "./exchange-rate-service";
+import { State } from "../../../environment/state";
 
 let profile: IProfile;
 let wallet: IReadWriteWallet;
@@ -53,6 +54,9 @@ beforeEach(async () => {
 	container.rebind(Identifiers.ExchangeRateService, subject);
 
 	profile = profileRepository.create("John Doe");
+
+	State.profile(profile);
+
 	profile.settings().set(ProfileSetting.MarketProvider, "cryptocompare");
 
 	wallet = await profile.wallets().importByMnemonic(identity.mnemonic, "ARK", "ark.devnet");

--- a/packages/platform-sdk-profiles/src/drivers/memory/services/fee-service.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/services/fee-service.test.ts
@@ -8,6 +8,8 @@ import { FeeService } from "./fee-service";
 
 let subject: FeeService;
 import NodeFeesFixture from "../../../../test/fixtures/client/node-fees.json";
+import { State } from "../../../environment/state";
+import { Profile } from "../profiles/profile";
 
 beforeAll(() => {
 	bootContainer();
@@ -30,6 +32,8 @@ beforeAll(() => {
 		.query(true)
 		.reply(200, require("../../../../test/fixtures/client/transaction-fees.json"))
 		.persist();
+
+	State.profile(new Profile({ id: "uuid", name: "name", avatar: "avatar", data: "" }));
 });
 
 beforeEach(async () => {

--- a/packages/platform-sdk-profiles/src/drivers/memory/services/fee-service.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/services/fee-service.ts
@@ -2,12 +2,9 @@ import { Coins, Contracts } from "@arkecosystem/platform-sdk";
 
 import { pqueueSettled } from "../../../helpers/queue";
 import { DataRepository } from "../../../repositories/data-repository";
-import { container } from "../../../environment/container";
-import { makeCoin } from "../../../environment/container.helpers";
-import { Identifiers } from "../../../environment/container.models";
-import { CoinService } from "./coin-service";
 import { IFeeService } from "../../../contracts";
 import { injectable } from "inversify";
+import { State } from "../../../environment/state";
 
 @injectable()
 export class FeeService implements IFeeService {
@@ -30,7 +27,7 @@ export class FeeService implements IFeeService {
 	}
 
 	public async sync(coin: string, network: string): Promise<void> {
-		const instance: Coins.Coin = makeCoin(coin, network);
+		const instance: Coins.Coin = State.profile().coins().push(coin, network);
 
 		if (!instance.hasBeenSynchronized()) {
 			await instance.__construct();
@@ -42,7 +39,7 @@ export class FeeService implements IFeeService {
 	public async syncAll(): Promise<void> {
 		const promises: (() => Promise<void>)[] = [];
 
-		for (const [coin, networks] of container.get<CoinService>(Identifiers.CoinService).entries()) {
+		for (const [coin, networks] of State.profile().coins().entries()) {
 			for (const network of networks) {
 				promises.push(() => this.sync(coin, network));
 			}

--- a/packages/platform-sdk-profiles/src/drivers/memory/services/known-wallet-service.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/services/known-wallet-service.test.ts
@@ -6,8 +6,9 @@ import nock from "nock";
 import { bootContainer } from "../../../../test/helpers";
 import { container } from "../../../environment/container";
 import { Identifiers } from "../../../environment/container.models";
-import { CoinService } from "./coin-service";
 import { KnownWalletService } from "./known-wallet-service";
+import { Profile } from "../profiles/profile";
+import { State } from "../../../environment/state";
 
 let subject: KnownWalletService;
 
@@ -55,11 +56,11 @@ beforeEach(async () => {
 		])
 		.persist();
 
-	const coinService = new CoinService();
+	const profile = new Profile({ id: "uuid", name: "name", avatar: "avatar", data: "" });
 
-	container.rebind(Identifiers.CoinService, coinService);
+	State.profile(profile);
 
-	await coinService.push("ARK", "ark.devnet").__construct();
+	await profile.coins().push("ARK", "ark.devnet").__construct();
 
 	subject = new KnownWalletService();
 

--- a/packages/platform-sdk-profiles/src/drivers/memory/services/known-wallet-service.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/services/known-wallet-service.ts
@@ -1,26 +1,24 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
 
 import { pqueue } from "../../../helpers/queue";
-import { container } from "../../../environment/container";
-import { Identifiers } from "../../../environment/container.models";
-import { ICoinService, IKnownWalletService } from "../../../contracts";
+import { IKnownWalletService } from "../../../contracts";
 import { injectable } from "inversify";
+import { State } from "../../../environment/state";
 
 type KnownWalletRegistry = Record<string, Contracts.KnownWallet[]>;
 
 @injectable()
 export class KnownWalletService implements IKnownWalletService {
-	private registry: KnownWalletRegistry = {};
+	readonly #registry: KnownWalletRegistry = {};
 
 	public async syncAll(): Promise<void> {
 		const promises: (() => Promise<void>)[] = [];
 
-		for (const [coin, networks] of container.get<ICoinService>(Identifiers.CoinService).entries()) {
+		for (const [coin, networks] of State.profile().coins().entries()) {
 			for (const network of networks) {
 				promises.push(async () => {
 					try {
-						this.registry[network] = await container
-							.get<ICoinService>(Identifiers.CoinService)
+						this.#registry[network] = await State.profile().coins()
 							.get(coin, network)
 							.knownWallets()
 							.all();
@@ -51,7 +49,7 @@ export class KnownWalletService implements IKnownWalletService {
 	}
 
 	private findByAddress(network: string, address: string): Contracts.KnownWallet | undefined {
-		const registry: Contracts.KnownWallet[] = this.registry[network];
+		const registry: Contracts.KnownWallet[] = this.#registry[network];
 
 		if (registry === undefined) {
 			return undefined;

--- a/packages/platform-sdk-profiles/src/drivers/memory/services/wallet-service.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/services/wallet-service.test.ts
@@ -10,6 +10,7 @@ import { container } from "../../../environment/container";
 import { Identifiers } from "../../../environment/container.models";
 import { ProfileRepository } from "../repositories/profile-repository";
 import { WalletService } from "./wallet-service";
+import { State } from "../../../environment/state";
 
 let profile: IProfile;
 let wallet: IReadWriteWallet;
@@ -79,6 +80,8 @@ beforeEach(async () => {
 	container.rebind(Identifiers.ProfileRepository, profileRepository);
 
 	profile = profileRepository.create("John Doe");
+
+	State.profile(profile);
 
 	wallet = await profile.wallets().importByMnemonic(identity.mnemonic, "ARK", "ark.devnet");
 

--- a/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet-transaction-service.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet-transaction-service.test.ts
@@ -10,6 +10,7 @@ import { Profile } from "../profiles/profile";
 import { Wallet } from "./wallet";
 import { TransactionService } from "./wallet-transaction-service";
 import { IProfile, IReadWriteWallet, ProfileSetting, WalletData } from "../../../contracts";
+import { State } from "../../../environment/state";
 
 let profile: IProfile;
 let wallet: IReadWriteWallet;
@@ -65,9 +66,12 @@ beforeEach(async () => {
 		.persist();
 
 	profile = new Profile({ id: "profile-id", name: "name", avatar: "avatar", data: "" });
+
+	State.profile(profile);
+
 	profile.settings().set(ProfileSetting.Name, "John Doe");
 
-	wallet = new Wallet(uuidv4(), {}, profile);
+	wallet = new Wallet(uuidv4(), {});
 
 	await wallet.setCoin("ARK", "ark.devnet");
 	await wallet.setIdentity(identity.mnemonic);

--- a/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet.factory.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet.factory.test.ts
@@ -9,6 +9,7 @@ import { bootContainer } from "../../../../test/helpers";
 import { Profile } from "../profiles/profile";
 import { WalletFactory } from "./wallet.factory";
 import { WalletData } from "../../../contracts";
+import { State } from "../../../environment/state";
 
 jest.setTimeout(60000);
 
@@ -19,7 +20,9 @@ beforeAll(() => {
 
 	nock.disableNetConnect();
 
-	subject = new WalletFactory(new Profile({ id: "id", name: "name", avatar: "avatar", data: "" }));
+	State.profile(new Profile({ id: "id", name: "name", avatar: "avatar", data: "" }));
+
+	subject = new WalletFactory();
 });
 
 beforeEach(async () => {

--- a/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet.factory.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet.factory.ts
@@ -7,12 +7,6 @@ import { IProfile, IReadWriteWallet, IWalletFactory, WalletData } from "../../..
 import { Wallet } from "./wallet";
 
 export class WalletFactory implements IWalletFactory {
-	readonly #profile: IProfile;
-
-	public constructor(profile: IProfile) {
-		this.#profile = profile;
-	}
-
 	public async fromMnemonic({
 		coin,
 		network,
@@ -26,7 +20,7 @@ export class WalletFactory implements IWalletFactory {
 		useBIP39?: boolean;
 		useBIP44?: boolean;
 	}): Promise<IReadWriteWallet> {
-		const wallet: IReadWriteWallet = new Wallet(uuidv4(), {}, this.#profile);
+		const wallet: IReadWriteWallet = new Wallet(uuidv4(), {});
 
 		await wallet.setCoin(coin, network);
 
@@ -57,7 +51,7 @@ export class WalletFactory implements IWalletFactory {
 		network: string;
 		address: string;
 	}): Promise<IReadWriteWallet> {
-		const wallet: IReadWriteWallet = new Wallet(uuidv4(), {}, this.#profile);
+		const wallet: IReadWriteWallet = new Wallet(uuidv4(), {});
 
 		await wallet.setCoin(coin, network);
 		await wallet.setAddress(address);
@@ -74,7 +68,7 @@ export class WalletFactory implements IWalletFactory {
 		network: string;
 		publicKey: string;
 	}): Promise<IReadWriteWallet> {
-		const wallet: IReadWriteWallet = new Wallet(uuidv4(), {}, this.#profile);
+		const wallet: IReadWriteWallet = new Wallet(uuidv4(), {});
 
 		await wallet.setCoin(coin, network);
 		await wallet.setAddress(await wallet.coin().identity().address().fromPublicKey(publicKey));
@@ -91,7 +85,7 @@ export class WalletFactory implements IWalletFactory {
 		network: string;
 		privateKey: string;
 	}): Promise<IReadWriteWallet> {
-		const wallet: IReadWriteWallet = new Wallet(uuidv4(), {}, this.#profile);
+		const wallet: IReadWriteWallet = new Wallet(uuidv4(), {});
 
 		await wallet.setCoin(coin, network);
 		await wallet.setAddress(await wallet.coin().identity().address().fromPrivateKey(privateKey));
@@ -148,7 +142,7 @@ export class WalletFactory implements IWalletFactory {
 		network: string;
 		wif: string;
 	}): Promise<IReadWriteWallet> {
-		const wallet: IReadWriteWallet = new Wallet(uuidv4(), {}, this.#profile);
+		const wallet: IReadWriteWallet = new Wallet(uuidv4(), {});
 
 		await wallet.setCoin(coin, network);
 		await wallet.setAddress(await wallet.coin().identity().address().fromWIF(wif));
@@ -167,7 +161,7 @@ export class WalletFactory implements IWalletFactory {
 		wif: string;
 		password: string;
 	}): Promise<IReadWriteWallet> {
-		const wallet: IReadWriteWallet = new Wallet(uuidv4(), {}, this.#profile);
+		const wallet: IReadWriteWallet = new Wallet(uuidv4(), {});
 
 		await wallet.setCoin(coin, network);
 

--- a/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet.test.ts
@@ -26,6 +26,7 @@ import {
 	WalletSetting,
 } from "../../../contracts";
 import { ExtendedTransactionDataCollection } from "../../../dto";
+import { State } from "../../../environment/state";
 
 let profile: IProfile;
 let subject: IReadWriteWallet;
@@ -92,7 +93,9 @@ beforeEach(async () => {
 	profileRepository.flush();
 	profile = profileRepository.create("John Doe");
 
-	subject = new Wallet(uuidv4(), {}, profile);
+	State.profile(profile);
+
+	subject = new Wallet(uuidv4(), {});
 
 	await subject.setCoin("ARK", "ark.devnet");
 	await subject.setIdentity(identity.mnemonic);
@@ -259,7 +262,7 @@ it("should have a known name", () => {
 it("should have a second public key", () => {
 	expect(subject.secondPublicKey()).toBeUndefined();
 
-	subject = new Wallet(uuidv4(), {}, profile);
+	subject = new Wallet(uuidv4(), {});
 
 	expect(() => subject.secondPublicKey()).toThrow(
 		"This wallet has not been synchronized yet. Please call [syncIdentity] before using it.",
@@ -269,7 +272,7 @@ it("should have a second public key", () => {
 it("should have a username", () => {
 	expect(subject.username()).toBe("arkx");
 
-	subject = new Wallet(uuidv4(), {}, profile);
+	subject = new Wallet(uuidv4(), {});
 
 	expect(() => subject.username()).toThrow(
 		"This wallet has not been synchronized yet. Please call [syncIdentity] before using it.",
@@ -279,7 +282,7 @@ it("should have a username", () => {
 it("should respond on whether it is a delegate or not", () => {
 	expect(subject.isDelegate()).toBeTrue();
 
-	subject = new Wallet(uuidv4(), {}, profile);
+	subject = new Wallet(uuidv4(), {});
 
 	expect(() => subject.isDelegate()).toThrow(
 		"This wallet has not been synchronized yet. Please call [syncIdentity] before using it.",
@@ -289,7 +292,7 @@ it("should respond on whether it is a delegate or not", () => {
 it("should respond on whether it is a resigned delegate or not", () => {
 	expect(subject.isResignedDelegate()).toBeTrue();
 
-	subject = new Wallet(uuidv4(), {}, profile);
+	subject = new Wallet(uuidv4(), {});
 
 	expect(() => subject.isResignedDelegate()).toThrow(
 		"This wallet has not been synchronized yet. Please call [syncIdentity] before using it.",
@@ -327,7 +330,7 @@ it("should respond on whether it is ledger", () => {
 it("should respond on whether it is multi signature or not", () => {
 	expect(subject.isMultiSignature()).toBeFalse();
 
-	subject = new Wallet(uuidv4(), {}, profile);
+	subject = new Wallet(uuidv4(), {});
 
 	expect(() => subject.isMultiSignature()).toThrow(
 		"This wallet has not been synchronized yet. Please call [syncIdentity] before using it.",
@@ -337,7 +340,7 @@ it("should respond on whether it is multi signature or not", () => {
 it("should respond on whether it is second signature or not", () => {
 	expect(subject.isSecondSignature()).toBeFalse();
 
-	subject = new Wallet(uuidv4(), {}, profile);
+	subject = new Wallet(uuidv4(), {});
 
 	expect(() => subject.isSecondSignature()).toThrow(
 		"This wallet has not been synchronized yet. Please call [syncIdentity] before using it.",
@@ -353,7 +356,7 @@ it("should have a transaction service", () => {
 });
 
 it("should return whether it has synced with network", async () => {
-	subject = new Wallet(uuidv4(), {}, profile);
+	subject = new Wallet(uuidv4(), {});
 
 	expect(subject.hasSyncedWithNetwork()).toBeFalse();
 
@@ -390,7 +393,7 @@ it("should fetch transactions by id", async () => {
 it("should return multi signature", () => {
 	expect(() => subject.multiSignature()).toThrow("This wallet does not have a multi-signature registered.");
 
-	subject = new Wallet(uuidv4(), {}, profile);
+	subject = new Wallet(uuidv4(), {});
 
 	expect(() => subject.multiSignature()).toThrow(
 		"This wallet has not been synchronized yet. Please call [syncIdentity] before using it.",
@@ -448,7 +451,7 @@ describe("#multiSignatureParticipants", () => {
 });
 
 it("should sync multi signature when musig", async () => {
-	subject = new Wallet(uuidv4(), {}, profile);
+	subject = new Wallet(uuidv4(), {});
 	await subject.setCoin("ARK", "ark.devnet");
 	await subject.setIdentity("new super passphrase");
 
@@ -466,7 +469,7 @@ it("should sync multi signature when not musig", async () => {
 it("should return entities", () => {
 	expect(subject.entities()).toBeArrayOfSize(0);
 
-	subject = new Wallet(uuidv4(), {}, profile);
+	subject = new Wallet(uuidv4(), {});
 
 	expect(() => subject.entities()).toThrow(
 		"This wallet has not been synchronized yet. Please call [syncIdentity] before using it.",

--- a/packages/platform-sdk-profiles/src/dto/transaction-mapper.test.ts
+++ b/packages/platform-sdk-profiles/src/dto/transaction-mapper.test.ts
@@ -9,6 +9,7 @@ import { bootContainer } from "../../test/helpers";
 import { IProfile, IReadWriteWallet, ProfileSetting } from "../contracts";
 import { Profile } from "../drivers/memory/profiles/profile";
 import { Wallet } from "../drivers/memory/wallets/wallet";
+import { State } from "../environment/state";
 import {
 	BridgechainRegistrationData,
 	BridgechainResignationData,
@@ -103,9 +104,12 @@ describe("transaction-mapper", () => {
 			.persist();
 
 		profile = new Profile({ id: "profile-id", name: "name", avatar: "avatar", data: "" });
+
+		State.profile(profile);
+
 		profile.settings().set(ProfileSetting.Name, "John Doe");
 
-		wallet = new Wallet(uuidv4(), {}, profile);
+		wallet = new Wallet(uuidv4(), {});
 
 		await wallet.setCoin("ARK", "ark.devnet");
 		await wallet.setIdentity(identity.mnemonic);

--- a/packages/platform-sdk-profiles/src/dto/transaction.test.ts
+++ b/packages/platform-sdk-profiles/src/dto/transaction.test.ts
@@ -12,6 +12,7 @@ import { IExchangeRateService, IProfile, IReadWriteWallet, ProfileSetting } from
 import { Profile } from "../drivers/memory/profiles/profile";
 import { container } from "../environment/container";
 import { Identifiers } from "../environment/container.models";
+import { State } from "../environment/state";
 import {
 	BridgechainRegistrationData,
 	BridgechainResignationData,
@@ -35,7 +36,6 @@ import {
 	TransferData,
 	VoteData,
 } from "./transaction";
-import { State } from "../environment/state";
 
 const createSubject = (wallet, properties, klass) => {
 	let meta: Contracts.TransactionDataMeta = "some meta";

--- a/packages/platform-sdk-profiles/src/dto/transaction.test.ts
+++ b/packages/platform-sdk-profiles/src/dto/transaction.test.ts
@@ -35,6 +35,7 @@ import {
 	TransferData,
 	VoteData,
 } from "./transaction";
+import { State } from "../environment/state";
 
 const createSubject = (wallet, properties, klass) => {
 	let meta: Contracts.TransactionDataMeta = "some meta";
@@ -106,6 +107,9 @@ beforeAll(async () => {
 
 beforeEach(async () => {
 	profile = new Profile({ id: "profile-id", name: "name", avatar: "avatar", data: "" });
+
+	State.profile(profile);
+
 	profile.settings().set(ProfileSetting.Name, "John Doe");
 	profile.settings().set(ProfileSetting.ExchangeCurrency, "BTC");
 	profile.settings().set(ProfileSetting.MarketProvider, "cryptocompare");

--- a/packages/platform-sdk-profiles/src/environment/container.helpers.ts
+++ b/packages/platform-sdk-profiles/src/environment/container.helpers.ts
@@ -1,8 +1,0 @@
-import { Coins } from "@arkecosystem/platform-sdk";
-
-import { ICoinService } from "../contracts";
-import { container } from "./container";
-import { Identifiers } from "./container.models";
-
-export const makeCoin = (coin: string, network: string, options: object = {}, useForce = false): Coins.Coin =>
-	container.get<ICoinService>(Identifiers.CoinService).push(coin, network, options, useForce);

--- a/packages/platform-sdk-profiles/src/environment/container.models.ts
+++ b/packages/platform-sdk-profiles/src/environment/container.models.ts
@@ -1,7 +1,6 @@
 export const Identifiers = {
 	AppData: "Data<App>",
 	Coins: "Coins",
-	CoinService: "CoinService",
 	ContactRepository: "ContactRepository",
 	DataRepository: "DataRepository",
 	DelegateService: "DelegateService",
@@ -15,4 +14,8 @@ export const Identifiers = {
 	Storage: "Storage",
 	WalletRepository: "WalletRepository",
 	WalletService: "WalletService",
+};
+
+export const State = {
+	Profile: "State<Profile>",
 };

--- a/packages/platform-sdk-profiles/src/environment/env.test.ts
+++ b/packages/platform-sdk-profiles/src/environment/env.test.ts
@@ -21,6 +21,7 @@ import { DataRepository } from "../repositories/data-repository";
 import { container } from "./container";
 import { Identifiers } from "./container.models";
 import { Environment } from "./env";
+import { State } from "./state";
 import { MemoryStorage } from "./storage/memory";
 
 let subject: Environment;
@@ -118,6 +119,8 @@ it("should create a profile with data and persist it when instructed to do so", 
 	 */
 
 	const profile = subject.profiles().create("John Doe");
+
+	State.profile(profile);
 
 	// Create a Contact
 	profile.contacts().create("Jane Doe");
@@ -261,12 +264,6 @@ it("should throw error when calling boot without verify first", async () => {
 	await expect(env.boot()).rejects.toThrowError("Please call [verify] before booting the environment.");
 });
 
-it("should get available coins", async () => {
-	await makeSubject();
-
-	expect(subject.coins().values()).toEqual([]);
-});
-
 it("#exchangeRates", async () => {
 	await makeSubject();
 
@@ -276,6 +273,8 @@ it("#exchangeRates", async () => {
 it("#fees", async () => {
 	await makeSubject();
 
+	State.profile(new Profile({ id: "uuid", name: "name", avatar: "avatar", data: "" }));
+
 	await subject.fees().sync("ARK", "ark.devnet");
 	expect(Object.keys(subject.fees().all("ARK", "ark.devnet"))).toHaveLength(11);
 });
@@ -283,12 +282,16 @@ it("#fees", async () => {
 it("#delegates", async () => {
 	await makeSubject();
 
+	State.profile(new Profile({ id: "uuid", name: "name", avatar: "avatar", data: "" }));
+
 	await subject.delegates().sync("ARK", "ark.devnet");
 	expect(subject.delegates().all("ARK", "ark.devnet")).toHaveLength(200);
 });
 
 it("#knownWallets", async () => {
 	await makeSubject();
+
+	State.profile(new Profile({ id: "uuid", name: "name", avatar: "avatar", data: "" }));
 
 	await subject.knownWallets().syncAll();
 	expect(subject.knownWallets().is("ark.devnet", "unknownWallet")).toBeFalse();
@@ -298,12 +301,6 @@ it("#wallets", async () => {
 	await makeSubject();
 
 	expect(subject.wallets()).toBeInstanceOf(WalletService);
-});
-
-it("#coin", async () => {
-	await makeSubject();
-
-	await expect(subject.coin("ARK", "ark.devnet")).resolves.toBeInstanceOf(Coins.Coin);
 });
 
 it("#registerCoin", async () => {
@@ -328,6 +325,7 @@ it("should create a profile with password and persist", async () => {
 	await makeSubject();
 
 	const profile = subject.profiles().create("John Doe");
+	State.profile(profile);
 	profile.auth().setPassword("password");
 	expect(() => subject.persist()).not.toThrowError();
 });
@@ -353,14 +351,17 @@ it("should persist the env and restore it", async () => {
 	await makeSubject();
 
 	const john = subject.profiles().create("John");
+	State.profile(john);
 	await john.wallets().importByMnemonic(identity.mnemonic, "ARK", "ark.devnet");
 	john.save();
 
 	const jane = subject.profiles().create("Jane");
+	State.profile(jane);
 	jane.auth().setPassword("password");
 	jane.save("password");
 
 	const jack = subject.profiles().create("Jack");
+	State.profile(jack);
 	jack.auth().setPassword("password");
 	jack.save("password");
 

--- a/packages/platform-sdk-profiles/src/environment/env.ts
+++ b/packages/platform-sdk-profiles/src/environment/env.ts
@@ -2,7 +2,6 @@ import { Coins } from "@arkecosystem/platform-sdk";
 import Joi from "joi";
 
 import {
-	ICoinService,
 	IDataRepository,
 	IDelegateService,
 	IExchangeRateService,
@@ -14,7 +13,6 @@ import {
 } from "../contracts";
 import { DriverFactory } from "../drivers/driver.factory";
 import { container } from "./container";
-import { makeCoin } from "./container.helpers";
 import { Identifiers } from "./container.models";
 import { CoinList, EnvironmentOptions, Storage, StorageData } from "./env.models";
 import { StorageFactory } from "./storage/factory";
@@ -99,16 +97,6 @@ export class Environment {
 	}
 
 	/**
-	 * Access the coin service.
-	 *
-	 * @returns {CoinService}
-	 * @memberof Environment
-	 */
-	public coins(): ICoinService {
-		return container.get(Identifiers.CoinService);
-	}
-
-	/**
 	 * Access the application data.
 	 *
 	 * @returns {DataRepository}
@@ -186,23 +174,6 @@ export class Environment {
 	 */
 	public wallets(): IWalletService {
 		return container.get(Identifiers.WalletService);
-	}
-
-	/**
-	 * Creates an instance of a concrete coin implementation like ARK or BTC.
-	 *
-	 * The only times it should be used is when identity data has to be validated!
-	 *
-	 * It should never be used for anything else within ArkEcosystem products because
-	 * this package is responsible for abstracting all of the coin-specific interactions.
-	 *
-	 * @param {string} coin
-	 * @param {string} network
-	 * @returns {Promise<Coins.Coin>}
-	 * @memberof Environment
-	 */
-	public async coin(coin: string, network: string): Promise<Coins.Coin> {
-		return makeCoin(coin, network);
 	}
 
 	/**

--- a/packages/platform-sdk-profiles/src/environment/state.ts
+++ b/packages/platform-sdk-profiles/src/environment/state.ts
@@ -1,0 +1,30 @@
+import { Exceptions } from "@arkecosystem/platform-sdk";
+
+import { IProfile } from "../contracts";
+import { container } from "./container";
+import { State as Identifiers } from "./container.models";
+
+export class State {
+	/**
+	 * Get or set the active profile.
+	 *
+	 * @returns {IProfile}
+	 */
+	public static profile(instance?: IProfile): IProfile {
+		if (instance !== undefined) {
+			if (container.has(Identifiers.Profile)) {
+				container.rebind(Identifiers.Profile, instance);
+			} else {
+				container.bind(Identifiers.Profile, instance);
+			}
+		}
+
+		const profile: IProfile | undefined = container.get(Identifiers.Profile);
+
+		if (profile === undefined) {
+			throw new Exceptions.BadStateException("useProfile", "There is no active profile");
+		}
+
+		return profile;
+	}
+}

--- a/packages/platform-sdk-profiles/src/helpers/password.test.ts
+++ b/packages/platform-sdk-profiles/src/helpers/password.test.ts
@@ -1,22 +1,22 @@
 import "reflect-metadata";
 
 import { bootContainer } from "../../test/helpers";
-import { IProfile } from "../contracts";
 import { Profile } from "../drivers/memory/profiles/profile";
+import { State } from "../environment/state";
 import { MemoryPassword } from "./password";
 
 beforeAll(() => bootContainer());
 
 it("should set, get and forget the password", () => {
-	const profile: IProfile = new Profile({ id: "uuid", name: "name", avatar: "avatar", data: "" });
+	State.profile(new Profile({ id: "uuid", name: "name", avatar: "avatar", data: "" }));
 
-	expect(() => MemoryPassword.get(profile)).toThrow("Failed to find a password for the given profile.");
+	expect(() => MemoryPassword.get()).toThrow("Failed to find a password for the given profile.");
 
-	MemoryPassword.set(profile, "password");
+	MemoryPassword.set("password");
 
-	expect(MemoryPassword.get(profile)).toBe("password");
+	expect(MemoryPassword.get()).toBe("password");
 
-	MemoryPassword.forget(profile);
+	MemoryPassword.forget();
 
-	expect(() => MemoryPassword.get(profile)).toThrow("Failed to find a password for the given profile.");
+	expect(() => MemoryPassword.get()).toThrow("Failed to find a password for the given profile.");
 });

--- a/packages/platform-sdk-profiles/src/helpers/password.ts
+++ b/packages/platform-sdk-profiles/src/helpers/password.ts
@@ -1,12 +1,13 @@
 import { Hash } from "@arkecosystem/platform-sdk-crypto";
 
 import { IProfile } from "../contracts";
+import { State } from "../environment/state";
 
 const passwordKey = (profile: IProfile): string => Hash.sha256(`${profile.id()}/passwd`).toString("hex");
 
 export class MemoryPassword {
-	public static get(profile: IProfile): string {
-		const password: string | undefined = process.env[passwordKey(profile)];
+	public static get(): string {
+		const password: string | undefined = process.env[passwordKey(State.profile())];
 
 		if (password === undefined) {
 			throw new Error("Failed to find a password for the given profile.");
@@ -15,11 +16,11 @@ export class MemoryPassword {
 		return password;
 	}
 
-	public static set(profile: IProfile, password: string): void {
-		process.env[passwordKey(profile)] = password;
+	public static set(password: string): void {
+		process.env[passwordKey(State.profile())] = password;
 	}
 
-	public static forget(profile: IProfile): void {
-		delete process.env[passwordKey(profile)];
+	public static forget(): void {
+		delete process.env[passwordKey(State.profile())];
 	}
 }

--- a/packages/platform-sdk-profiles/test/helpers.ts
+++ b/packages/platform-sdk-profiles/test/helpers.ts
@@ -7,7 +7,6 @@ import { ETH } from "@arkecosystem/platform-sdk-eth";
 import { Request } from "@arkecosystem/platform-sdk-http-got";
 import nock from "nock";
 
-import { CoinService } from "../src/drivers/memory/services/coin-service";
 import { Contact } from "../src/drivers/memory/contacts/contact";
 import { container } from "../src/environment/container";
 import { DataRepository } from "../src/repositories/data-repository";
@@ -27,7 +26,6 @@ export const bootContainer = (): void => {
 	container.bind(Identifiers.Storage, new StubStorage());
 	container.bind(Identifiers.AppData, new DataRepository());
 	container.bind(Identifiers.Coins, { ADA, ARK, BTC, ETH });
-	container.bind(Identifiers.CoinService, new CoinService());
 	container.bind(Identifiers.DelegateService, new DelegateService());
 	container.bind(Identifiers.ExchangeRateService, new ExchangeRateService());
 	container.bind(Identifiers.FeeService, new FeeService());
@@ -62,5 +60,5 @@ export const knock = (): void => {
 
 export const makeProfile = (data: object = {}): IProfile =>
 	new Profile({ id: "uuid", name: "name", avatar: "avatar", data: "", ...data });
-export const makeContact = (data: IContactStruct, profile: IProfile): Contact => new Contact(data, profile);
-export const makeWallet = (id: string, profile: IProfile): IReadWriteWallet => new Wallet(id, {}, profile);
+export const makeContact = (data: IContactStruct): Contact => new Contact(data);
+export const makeWallet = (id: string): IReadWriteWallet => new Wallet(id, {});

--- a/packages/platform-sdk/src/exceptions.ts
+++ b/packages/platform-sdk/src/exceptions.ts
@@ -57,3 +57,9 @@ export class BadVariableDependencyException extends Exception {
 		super(`Method ${klass}#${method} depends on ${klass}#${dependency} being declared first.`);
 	}
 }
+
+export class BadStateException extends Exception {
+	public constructor(method: string, error: string) {
+		super(`Method [${method}] has entered a bad state: ${error}`);
+	}
+}


### PR DESCRIPTION
Stores the active profile in the container under the key `State.Profile` which will enable us to quickly access the profile from anywhere instead of passing into every class constructor that needs it. Throws an exception when no active profile is set when it is tried to be accessed.

**This is a basic implementation to see how it works out and will be reworked to use injection for v5.**