### PR TITLE
refactor(profiles): enable password verification for an unrestored profile

### DIFF
--- a/packages/platform-sdk-profiles/src/contracts/profiles/authenticator.ts
+++ b/packages/platform-sdk-profiles/src/contracts/profiles/authenticator.ts
@@ -1,3 +1,5 @@
+import { IProfile } from "../../contracts";
+
 /**
  * Defines the implementation contract for the authentication service.
  *
@@ -20,7 +22,7 @@ export interface IAuthenticator {
 	 * @return {boolean}
 	 * @memberof IAuthenticator
 	 */
-	verifyPassword(password: string): boolean;
+	verifyPassword({ profile, password }: { profile?: IProfile; password: string }): boolean;
 
 	/**
 	 * Change the password for the currently selected profile.

--- a/packages/platform-sdk-profiles/src/drivers/memory/profiles/authenticator.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/profiles/authenticator.test.ts
@@ -32,12 +32,25 @@ it("should set the password", async () => {
 it("should verify the password", async () => {
 	subject.setPassword("password");
 
-	expect(subject.verifyPassword("password")).toBeTrue();
-	expect(subject.verifyPassword("invalid")).toBeFalse();
+	expect(subject.verifyPassword({ password: "password" })).toBeTrue();
+	expect(subject.verifyPassword({ password: "invalid" })).toBeFalse();
+});
+
+it("should verify the password for a given profile", async () => {
+	const passwordProtectedProfile = new Profile({
+		id: "password-protected",
+		name: "name",
+		avatar: "avatar",
+		password: "$2a$10$Qy/Mcjg2AAZ.Wqj7MUba4eQtNTC5c4Vh6SCWKezmolrp/58TlCA8u", // password
+		data: "",
+	});
+
+	expect(subject.verifyPassword({ profile: passwordProtectedProfile, password: "password" })).toBeTrue();
+	expect(subject.verifyPassword({ profile: passwordProtectedProfile, password: "invalid" })).toBeFalse();
 });
 
 it("should fail to verify the password for a profile that doesn't use a profile", async () => {
-	expect(() => subject.verifyPassword("password")).toThrow("No password is set.");
+	expect(() => subject.verifyPassword({ password: "password" })).toThrow("No password is set.");
 });
 
 it("should change the password", () => {

--- a/packages/platform-sdk-profiles/src/drivers/memory/profiles/authenticator.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/profiles/authenticator.ts
@@ -1,7 +1,7 @@
 import { Bcrypt } from "@arkecosystem/platform-sdk-crypto";
 
 import { MemoryPassword } from "../../../helpers/password";
-import { IAuthenticator, ProfileSetting } from "../../../contracts";
+import { IAuthenticator, ProfileSetting, IProfile } from "../../../contracts";
 import { State } from "../../../environment/state";
 import { emitProfileChanged } from "../helpers";
 
@@ -25,12 +25,14 @@ export class Authenticator implements IAuthenticator {
 	}
 
 	/** {@inheritDoc IAuthenticator.verifyPassword} */
-	public verifyPassword(password: string): boolean {
-		if (!State.profile().usesPassword()) {
+	public verifyPassword({ profile, password }: { profile?: IProfile; password: string }): boolean {
+		const activeProfile = profile || State.profile();
+
+		if (!activeProfile.usesPassword()) {
 			throw new Error("No password is set.");
 		}
 
-		return Bcrypt.verify(State.profile().getAttributes().get("password"), password);
+		return Bcrypt.verify(activeProfile.getAttributes().get("password"), password);
 	}
 
 	/** {@inheritDoc IAuthenticator.changePassword} */

--- a/packages/platform-sdk-profiles/src/drivers/memory/profiles/profile.encrypter.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/profiles/profile.encrypter.ts
@@ -16,7 +16,7 @@ export class ProfileEncrypter implements IProfileEncrypter {
 			password = MemoryPassword.get();
 		}
 
-		if (!this.#profile.auth().verifyPassword(password)) {
+		if (!this.#profile.auth().verifyPassword({ profile: this.#profile, password })) {
 			throw new Error("The password did not match our records.");
 		}
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Because `password.usesPassword()` and `profile.getAttributes().get("password")` as properties can be accessed before a profile is restored, they can also be used to validate a given password of a given profile before a restoration. 

This PR covers the use case where password verification is needed before a profile is restored such as signing in with a password-protected profile in DW.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
