### PR TITLE
refactor(profiles): save changes only for restored profiles

### DIFF
--- a/packages/platform-sdk-profiles/src/drivers/memory/index.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/index.ts
@@ -52,6 +52,10 @@ export class MemoryDriver implements Driver {
 			try {
 				const profile = container.get<IProfileRepository>(Identifiers.ProfileRepository).findById(id);
 
+				if (!profile.status().isRestored()) {
+					return;
+				}
+
 				if (profile.usesPassword() && profile.password().exists()) {
 					profile.getAttributes().set("data", new ProfileExporter(profile).export(profile.password().get()));
 				}

--- a/packages/platform-sdk-profiles/src/drivers/memory/repositories/profile-repository.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/repositories/profile-repository.test.ts
@@ -189,7 +189,6 @@ describe("ProfileRepository", () => {
 
 	it("should dump profiles without a password", async () => {
 		const john = subject.create("John");
-		await subject.restore(john);
 
 		await importByMnemonic(john, identity.mnemonic, "ARK", "ark.devnet");
 
@@ -204,7 +203,7 @@ describe("ProfileRepository", () => {
 
 	it("should dump profiles with a password", async () => {
 		const jane = subject.create("Jane");
-		await subject.restore(jane);
+
 		await importByMnemonic(jane, identity.mnemonic, "ARK", "ark.devnet");
 
 		jane.password().set("password");
@@ -273,7 +272,6 @@ describe("ProfileRepository", () => {
 
 	it("should dump", async () => {
 		const profile = subject.create("John");
-		await subject.restore(profile);
 
 		expect(subject.dump(profile)).toBeObject();
 	});
@@ -283,7 +281,6 @@ describe("ProfileRepository", () => {
 
 		const profile = subject.create("John");
 
-		expect(profile.status().isRestored()).toBeFalse();
 		await subject.restore(profile);
 
 		expect(profile.status().isRestored()).toBeTrue();
@@ -293,6 +290,8 @@ describe("ProfileRepository", () => {
 		subject.flush();
 
 		const profile = subject.create("John");
+		profile.status().reset();
+
 		const profileAttibuteSetMock = jest.spyOn(profile.getAttributes(), "set").mockImplementation(() => {
 			return true;
 		});
@@ -310,6 +309,8 @@ describe("ProfileRepository", () => {
 		subject.flush();
 
 		const profile = subject.create("John");
+		profile.status().reset();
+
 		const profileAttibuteSetMock = jest.spyOn(profile.getAttributes(), "set").mockImplementation(() => {
 			return true;
 		});

--- a/packages/platform-sdk-profiles/src/drivers/memory/repositories/profile-repository.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/repositories/profile-repository.test.ts
@@ -268,8 +268,6 @@ describe("ProfileRepository", () => {
 		subject.flush();
 
 		const profile = subject.create("John");
-		await subject.restore(profile);
-
 		await expect(subject.restore(profile)).toResolve();
 	});
 

--- a/packages/platform-sdk-profiles/src/drivers/memory/repositories/profile-repository.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/repositories/profile-repository.test.ts
@@ -5,13 +5,14 @@ import nock from "nock";
 
 import { identity } from "../../../../test/fixtures/identity";
 import { bootContainer, importByMnemonic } from "../../../../test/helpers";
-import { IProfileRepository } from "../../../contracts";
+import { IProfileRepository, ProfileSetting } from "../../../contracts";
 import { Profile } from "../profiles/profile";
 import { ProfileRepository } from "./profile-repository";
 import { ProfileImporter } from "../profiles/profile.importer";
 import { ProfileSerialiser } from "../profiles/profile.serialiser";
 import { container } from "../../../environment/container";
 import { Identifiers } from "../../../environment/container.models";
+import * as helpers from "../helpers";
 
 let subject: IProfileRepository;
 
@@ -188,6 +189,8 @@ describe("ProfileRepository", () => {
 
 	it("should dump profiles without a password", async () => {
 		const john = subject.create("John");
+		await subject.restore(john);
+
 		await importByMnemonic(john, identity.mnemonic, "ARK", "ark.devnet");
 
 		const repositoryDump = subject.toObject();
@@ -201,6 +204,7 @@ describe("ProfileRepository", () => {
 
 	it("should dump profiles with a password", async () => {
 		const jane = subject.create("Jane");
+		await subject.restore(jane);
 		await importByMnemonic(jane, identity.mnemonic, "ARK", "ark.devnet");
 
 		jane.password().set("password");
@@ -264,12 +268,14 @@ describe("ProfileRepository", () => {
 		subject.flush();
 
 		const profile = subject.create("John");
+		await subject.restore(profile);
 
 		await expect(subject.restore(profile)).toResolve();
 	});
 
 	it("should dump", async () => {
 		const profile = subject.create("John");
+		await subject.restore(profile);
 
 		expect(subject.dump(profile)).toBeObject();
 	});
@@ -278,9 +284,47 @@ describe("ProfileRepository", () => {
 		subject.flush();
 
 		const profile = subject.create("John");
+
 		expect(profile.status().isRestored()).toBeFalse();
 		await subject.restore(profile);
 
 		expect(profile.status().isRestored()).toBeTrue();
+	});
+
+	it("should not save profile data if profile is not restored", async () => {
+		subject.flush();
+
+		const profile = subject.create("John");
+		const profileAttibuteSetMock = jest.spyOn(profile.getAttributes(), "set").mockImplementation(() => {
+			return true;
+		});
+
+		expect(profile.status().isRestored()).toBeFalse();
+		expect(profileAttibuteSetMock).toHaveBeenCalledTimes(0);
+
+		await subject.restore(profile);
+
+		expect(profile.status().isRestored()).toBeTrue();
+		expect(profileAttibuteSetMock).toHaveBeenCalledTimes(0);
+	});
+
+	it("should emit profile change and save data only when profile is restored", async () => {
+		subject.flush();
+
+		const profile = subject.create("John");
+		const profileAttibuteSetMock = jest.spyOn(profile.getAttributes(), "set").mockImplementation(() => {
+			return true;
+		});
+
+		expect(profile.status().isRestored()).toBeFalse();
+		expect(profileAttibuteSetMock).toHaveBeenCalledTimes(0);
+
+		await subject.restore(profile);
+
+		expect(profile.status().isRestored()).toBeTrue();
+		expect(profileAttibuteSetMock).toHaveBeenCalledTimes(0);
+
+		profile.settings().set(ProfileSetting.Name, "Test");
+		expect(profileAttibuteSetMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/platform-sdk-profiles/src/drivers/memory/repositories/profile-repository.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/repositories/profile-repository.ts
@@ -9,7 +9,6 @@ import { ProfileExporter } from "../profiles/profile.exporter";
 import { ProfileImporter } from "../profiles/profile.importer";
 import { ProfileDumper } from "../profiles/profile.dumper";
 import { ProfileInitialiser } from "../profiles/profile.initialiser";
-import { emitProfileChanged } from "../helpers";
 
 @injectable()
 export class ProfileRepository implements IProfileRepository {

--- a/packages/platform-sdk-profiles/src/drivers/memory/repositories/profile-repository.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/repositories/profile-repository.ts
@@ -81,6 +81,7 @@ export class ProfileRepository implements IProfileRepository {
 		this.push(result);
 
 		new ProfileInitialiser(result).initialise(name);
+		result.getAttributes().set("data", new ProfileExporter(result).export());
 
 		return result;
 	}

--- a/packages/platform-sdk-profiles/src/drivers/memory/repositories/profile-repository.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/repositories/profile-repository.ts
@@ -81,6 +81,7 @@ export class ProfileRepository implements IProfileRepository {
 
 		new ProfileInitialiser(result).initialise(name);
 		result.getAttributes().set("data", new ProfileExporter(result).export());
+		result.status().markAsRestored();
 
 		return result;
 	}

--- a/packages/platform-sdk-profiles/src/drivers/memory/wallets/services/serialiser.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/wallets/services/serialiser.test.ts
@@ -131,4 +131,18 @@ describe.each([123, 456, 789])("%s", (slip44) => {
 		expect(actual.settings).toBeObject();
 		expect(actual.settings.AVATAR).toBeString();
 	});
+
+	it("should turn into an object with initial state for partially restored wallet", () => {
+		subject.coin().config().set("network.crypto.slip44", slip44);
+		subject.data().set("key", "value");
+
+		subject.data().set(WalletData.LedgerPath, "1");
+		subject.data().set(WalletFlag.Starred, true);
+		const partiallyRestoredMock = jest.spyOn(subject, "hasBeenPartiallyRestored").mockReturnValue(true);
+
+		const actual: any = subject.toObject();
+
+		expect(actual).toEqual({});
+		partiallyRestoredMock.mockRestore();
+	});
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
- [x] Reduce profile save calls only when a profile is restored. Change events will be ignored if the profile is not restored as there is no need to save the profile (performance improvement).
- [x] Ensure profile default data is always encoded and saved upon profile creation (don't rely on change emitter).

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
