### PR TITLE
fix(profiles): avoid return a BigNumber instance that is a number as balance

### DIFF
--- a/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet.ts
@@ -143,11 +143,7 @@ export class Wallet implements IReadWriteWallet {
 	public balance(): BigNumber {
 		const value: Contracts.WalletBalance | undefined = this.data().get(WalletData.Balance);
 
-		if (value === undefined) {
-			return BigNumber.ZERO;
-		}
-
-		return BigNumber.make(value.available);
+		return BigNumber.make(value?.available || 0);
 	}
 
 	/** {@inheritDoc IReadWriteWallet.convertedBalance} */

--- a/packages/platform-sdk-trx/src/services/transaction.ts
+++ b/packages/platform-sdk-trx/src/services/transaction.ts
@@ -55,7 +55,11 @@ export class TransactionService implements Contracts.TransactionService {
 				1,
 			);
 			if (input.data.memo) {
-				transaction = await this.#connection.transactionBuilder.addUpdateData(transaction, input.data.memo, 'utf8')
+				transaction = await this.#connection.transactionBuilder.addUpdateData(
+					transaction,
+					input.data.memo,
+					"utf8",
+				);
 			}
 
 			const response = await this.#connection.trx.sign(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Under certain circumstances `wallet.data().get(WalletData.Balance)` is `"0"`, causing the balance method to return an invalid BigNumber instance which in turn breakes the calculation of converted balances.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
