### PR TITLE
refactor: introduce `AbstractSignatoryService`

### DIFF
--- a/packages/platform-sdk-ada/src/services/signatory.ts
+++ b/packages/platform-sdk-ada/src/services/signatory.ts
@@ -1,88 +1,9 @@
-import { Coins, Contracts, Signatories } from "@arkecosystem/platform-sdk";
+import { Coins, Signatories } from "@arkecosystem/platform-sdk";
 
 import { IdentityService } from "./identity";
 
-export class SignatoryService implements Contracts.SignatoryService {
-	readonly #identity: IdentityService;
-
-	private constructor(identityService: IdentityService) {
-		this.#identity = identityService;
-	}
-
+export class SignatoryService extends Signatories.AbstractSignatoryService {
 	public static async __construct(config: Coins.Config): Promise<SignatoryService> {
 		return new SignatoryService(await IdentityService.__construct(config));
-	}
-
-	public async __destruct(): Promise<void> {
-		//
-	}
-
-	public async mnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.MnemonicSignatory> {
-		return new Signatories.MnemonicSignatory(
-			mnemonic,
-			await this.#identity.address().fromMnemonic(mnemonic, options),
-		);
-	}
-
-	public async secondaryMnemonic(
-		primary: string,
-		secondary: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SecondaryMnemonicSignatory> {
-		return new Signatories.SecondaryMnemonicSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromMnemonic(primary, options),
-		);
-	}
-
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatories.MultiMnemonicSignatory> {
-		return new Signatories.MultiMnemonicSignatory(
-			mnemonics,
-			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
-		);
-	}
-
-	public async wif(primary: string): Promise<Signatories.WIFSignatory> {
-		return new Signatories.WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
-	}
-
-	public async secondaryWif(primary: string, secondary: string): Promise<Signatories.SecondaryWIFSignatory> {
-		return new Signatories.SecondaryWIFSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromWIF(primary),
-		);
-	}
-
-	public async privateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.PrivateKeySignatory> {
-		return new Signatories.PrivateKeySignatory(
-			privateKey,
-			await this.#identity.address().fromPrivateKey(privateKey, options),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatories.SignatureSignatory> {
-		return new Signatories.SignatureSignatory(signature, senderPublicKey);
-	}
-
-	public async senderPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SenderPublicKeySignatory> {
-		return new Signatories.SenderPublicKeySignatory(
-			publicKey,
-			await this.#identity.address().fromPublicKey(publicKey, options),
-		);
-	}
-
-	public async multiSignature(min: number, publicKeys: string[]): Promise<Signatories.MultiSignatureSignatory> {
-		return new Signatories.MultiSignatureSignatory({ min, publicKeys });
 	}
 }

--- a/packages/platform-sdk-ark/src/services/signatory.ts
+++ b/packages/platform-sdk-ark/src/services/signatory.ts
@@ -1,88 +1,9 @@
-import { Coins, Contracts, Signatories } from "@arkecosystem/platform-sdk";
+import { Coins, Signatories } from "@arkecosystem/platform-sdk";
 
 import { IdentityService } from "./identity";
 
-export class SignatoryService implements Contracts.SignatoryService {
-	readonly #identity: IdentityService;
-
-	private constructor(identityService: IdentityService) {
-		this.#identity = identityService;
-	}
-
+export class SignatoryService extends Signatories.AbstractSignatoryService {
 	public static async __construct(config: Coins.Config): Promise<SignatoryService> {
 		return new SignatoryService(await IdentityService.__construct(config));
-	}
-
-	public async __destruct(): Promise<void> {
-		//
-	}
-
-	public async mnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.MnemonicSignatory> {
-		return new Signatories.MnemonicSignatory(
-			mnemonic,
-			await this.#identity.address().fromMnemonic(mnemonic, options),
-		);
-	}
-
-	public async secondaryMnemonic(
-		primary: string,
-		secondary: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SecondaryMnemonicSignatory> {
-		return new Signatories.SecondaryMnemonicSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromMnemonic(primary, options),
-		);
-	}
-
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatories.MultiMnemonicSignatory> {
-		return new Signatories.MultiMnemonicSignatory(
-			mnemonics,
-			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
-		);
-	}
-
-	public async wif(primary: string): Promise<Signatories.WIFSignatory> {
-		return new Signatories.WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
-	}
-
-	public async secondaryWif(primary: string, secondary: string): Promise<Signatories.SecondaryWIFSignatory> {
-		return new Signatories.SecondaryWIFSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromWIF(primary),
-		);
-	}
-
-	public async privateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.PrivateKeySignatory> {
-		return new Signatories.PrivateKeySignatory(
-			privateKey,
-			await this.#identity.address().fromPrivateKey(privateKey, options),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatories.SignatureSignatory> {
-		return new Signatories.SignatureSignatory(signature, senderPublicKey);
-	}
-
-	public async senderPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SenderPublicKeySignatory> {
-		return new Signatories.SenderPublicKeySignatory(
-			publicKey,
-			await this.#identity.address().fromPublicKey(publicKey, options),
-		);
-	}
-
-	public async multiSignature(min: number, publicKeys: string[]): Promise<Signatories.MultiSignatureSignatory> {
-		return new Signatories.MultiSignatureSignatory({ min, publicKeys });
 	}
 }

--- a/packages/platform-sdk-atom/src/services/signatory.ts
+++ b/packages/platform-sdk-atom/src/services/signatory.ts
@@ -1,88 +1,9 @@
-import { Coins, Contracts, Signatories } from "@arkecosystem/platform-sdk";
+import { Coins, Signatories } from "@arkecosystem/platform-sdk";
 
 import { IdentityService } from "./identity";
 
-export class SignatoryService implements Contracts.SignatoryService {
-	readonly #identity: IdentityService;
-
-	private constructor(identityService: IdentityService) {
-		this.#identity = identityService;
-	}
-
+export class SignatoryService extends Signatories.AbstractSignatoryService {
 	public static async __construct(config: Coins.Config): Promise<SignatoryService> {
 		return new SignatoryService(await IdentityService.__construct(config));
-	}
-
-	public async __destruct(): Promise<void> {
-		//
-	}
-
-	public async mnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.MnemonicSignatory> {
-		return new Signatories.MnemonicSignatory(
-			mnemonic,
-			await this.#identity.address().fromMnemonic(mnemonic, options),
-		);
-	}
-
-	public async secondaryMnemonic(
-		primary: string,
-		secondary: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SecondaryMnemonicSignatory> {
-		return new Signatories.SecondaryMnemonicSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromMnemonic(primary, options),
-		);
-	}
-
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatories.MultiMnemonicSignatory> {
-		return new Signatories.MultiMnemonicSignatory(
-			mnemonics,
-			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
-		);
-	}
-
-	public async wif(primary: string): Promise<Signatories.WIFSignatory> {
-		return new Signatories.WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
-	}
-
-	public async secondaryWif(primary: string, secondary: string): Promise<Signatories.SecondaryWIFSignatory> {
-		return new Signatories.SecondaryWIFSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromWIF(primary),
-		);
-	}
-
-	public async privateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.PrivateKeySignatory> {
-		return new Signatories.PrivateKeySignatory(
-			privateKey,
-			await this.#identity.address().fromPrivateKey(privateKey, options),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatories.SignatureSignatory> {
-		return new Signatories.SignatureSignatory(signature, senderPublicKey);
-	}
-
-	public async senderPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SenderPublicKeySignatory> {
-		return new Signatories.SenderPublicKeySignatory(
-			publicKey,
-			await this.#identity.address().fromPublicKey(publicKey, options),
-		);
-	}
-
-	public async multiSignature(min: number, publicKeys: string[]): Promise<Signatories.MultiSignatureSignatory> {
-		return new Signatories.MultiSignatureSignatory({ min, publicKeys });
 	}
 }

--- a/packages/platform-sdk-avax/src/services/signatory.ts
+++ b/packages/platform-sdk-avax/src/services/signatory.ts
@@ -1,88 +1,9 @@
-import { Coins, Contracts, Signatories } from "@arkecosystem/platform-sdk";
+import { Coins, Signatories } from "@arkecosystem/platform-sdk";
 
 import { IdentityService } from "./identity";
 
-export class SignatoryService implements Contracts.SignatoryService {
-	readonly #identity: IdentityService;
-
-	private constructor(identityService: IdentityService) {
-		this.#identity = identityService;
-	}
-
+export class SignatoryService extends Signatories.AbstractSignatoryService {
 	public static async __construct(config: Coins.Config): Promise<SignatoryService> {
 		return new SignatoryService(await IdentityService.__construct(config));
-	}
-
-	public async __destruct(): Promise<void> {
-		//
-	}
-
-	public async mnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.MnemonicSignatory> {
-		return new Signatories.MnemonicSignatory(
-			mnemonic,
-			await this.#identity.address().fromMnemonic(mnemonic, options),
-		);
-	}
-
-	public async secondaryMnemonic(
-		primary: string,
-		secondary: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SecondaryMnemonicSignatory> {
-		return new Signatories.SecondaryMnemonicSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromMnemonic(primary, options),
-		);
-	}
-
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatories.MultiMnemonicSignatory> {
-		return new Signatories.MultiMnemonicSignatory(
-			mnemonics,
-			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
-		);
-	}
-
-	public async wif(primary: string): Promise<Signatories.WIFSignatory> {
-		return new Signatories.WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
-	}
-
-	public async secondaryWif(primary: string, secondary: string): Promise<Signatories.SecondaryWIFSignatory> {
-		return new Signatories.SecondaryWIFSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromWIF(primary),
-		);
-	}
-
-	public async privateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.PrivateKeySignatory> {
-		return new Signatories.PrivateKeySignatory(
-			privateKey,
-			await this.#identity.address().fromPrivateKey(privateKey, options),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatories.SignatureSignatory> {
-		return new Signatories.SignatureSignatory(signature, senderPublicKey);
-	}
-
-	public async senderPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SenderPublicKeySignatory> {
-		return new Signatories.SenderPublicKeySignatory(
-			publicKey,
-			await this.#identity.address().fromPublicKey(publicKey, options),
-		);
-	}
-
-	public async multiSignature(min: number, publicKeys: string[]): Promise<Signatories.MultiSignatureSignatory> {
-		return new Signatories.MultiSignatureSignatory({ min, publicKeys });
 	}
 }

--- a/packages/platform-sdk-btc/src/services/signatory.ts
+++ b/packages/platform-sdk-btc/src/services/signatory.ts
@@ -1,88 +1,9 @@
-import { Coins, Contracts, Signatories } from "@arkecosystem/platform-sdk";
+import { Coins, Signatories } from "@arkecosystem/platform-sdk";
 
 import { IdentityService } from "./identity";
 
-export class SignatoryService implements Contracts.SignatoryService {
-	readonly #identity: IdentityService;
-
-	private constructor(identityService: IdentityService) {
-		this.#identity = identityService;
-	}
-
+export class SignatoryService extends Signatories.AbstractSignatoryService {
 	public static async __construct(config: Coins.Config): Promise<SignatoryService> {
 		return new SignatoryService(await IdentityService.__construct(config));
-	}
-
-	public async __destruct(): Promise<void> {
-		//
-	}
-
-	public async mnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.MnemonicSignatory> {
-		return new Signatories.MnemonicSignatory(
-			mnemonic,
-			await this.#identity.address().fromMnemonic(mnemonic, options),
-		);
-	}
-
-	public async secondaryMnemonic(
-		primary: string,
-		secondary: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SecondaryMnemonicSignatory> {
-		return new Signatories.SecondaryMnemonicSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromMnemonic(primary, options),
-		);
-	}
-
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatories.MultiMnemonicSignatory> {
-		return new Signatories.MultiMnemonicSignatory(
-			mnemonics,
-			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
-		);
-	}
-
-	public async wif(primary: string): Promise<Signatories.WIFSignatory> {
-		return new Signatories.WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
-	}
-
-	public async secondaryWif(primary: string, secondary: string): Promise<Signatories.SecondaryWIFSignatory> {
-		return new Signatories.SecondaryWIFSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromWIF(primary),
-		);
-	}
-
-	public async privateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.PrivateKeySignatory> {
-		return new Signatories.PrivateKeySignatory(
-			privateKey,
-			await this.#identity.address().fromPrivateKey(privateKey, options),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatories.SignatureSignatory> {
-		return new Signatories.SignatureSignatory(signature, senderPublicKey);
-	}
-
-	public async senderPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SenderPublicKeySignatory> {
-		return new Signatories.SenderPublicKeySignatory(
-			publicKey,
-			await this.#identity.address().fromPublicKey(publicKey, options),
-		);
-	}
-
-	public async multiSignature(min: number, publicKeys: string[]): Promise<Signatories.MultiSignatureSignatory> {
-		return new Signatories.MultiSignatureSignatory({ min, publicKeys });
 	}
 }

--- a/packages/platform-sdk-dot/src/services/signatory.ts
+++ b/packages/platform-sdk-dot/src/services/signatory.ts
@@ -1,88 +1,9 @@
-import { Coins, Contracts, Signatories } from "@arkecosystem/platform-sdk";
+import { Coins, Signatories } from "@arkecosystem/platform-sdk";
 
 import { IdentityService } from "./identity";
 
-export class SignatoryService implements Contracts.SignatoryService {
-	readonly #identity: IdentityService;
-
-	private constructor(identityService: IdentityService) {
-		this.#identity = identityService;
-	}
-
+export class SignatoryService extends Signatories.AbstractSignatoryService {
 	public static async __construct(config: Coins.Config): Promise<SignatoryService> {
 		return new SignatoryService(await IdentityService.__construct(config));
-	}
-
-	public async __destruct(): Promise<void> {
-		//
-	}
-
-	public async mnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.MnemonicSignatory> {
-		return new Signatories.MnemonicSignatory(
-			mnemonic,
-			await this.#identity.address().fromMnemonic(mnemonic, options),
-		);
-	}
-
-	public async secondaryMnemonic(
-		primary: string,
-		secondary: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SecondaryMnemonicSignatory> {
-		return new Signatories.SecondaryMnemonicSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromMnemonic(primary, options),
-		);
-	}
-
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatories.MultiMnemonicSignatory> {
-		return new Signatories.MultiMnemonicSignatory(
-			mnemonics,
-			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
-		);
-	}
-
-	public async wif(primary: string): Promise<Signatories.WIFSignatory> {
-		return new Signatories.WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
-	}
-
-	public async secondaryWif(primary: string, secondary: string): Promise<Signatories.SecondaryWIFSignatory> {
-		return new Signatories.SecondaryWIFSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromWIF(primary),
-		);
-	}
-
-	public async privateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.PrivateKeySignatory> {
-		return new Signatories.PrivateKeySignatory(
-			privateKey,
-			await this.#identity.address().fromPrivateKey(privateKey, options),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatories.SignatureSignatory> {
-		return new Signatories.SignatureSignatory(signature, senderPublicKey);
-	}
-
-	public async senderPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SenderPublicKeySignatory> {
-		return new Signatories.SenderPublicKeySignatory(
-			publicKey,
-			await this.#identity.address().fromPublicKey(publicKey, options),
-		);
-	}
-
-	public async multiSignature(min: number, publicKeys: string[]): Promise<Signatories.MultiSignatureSignatory> {
-		return new Signatories.MultiSignatureSignatory({ min, publicKeys });
 	}
 }

--- a/packages/platform-sdk-egld/src/services/signatory.ts
+++ b/packages/platform-sdk-egld/src/services/signatory.ts
@@ -1,88 +1,9 @@
-import { Coins, Contracts, Signatories } from "@arkecosystem/platform-sdk";
+import { Coins, Signatories } from "@arkecosystem/platform-sdk";
 
 import { IdentityService } from "./identity";
 
-export class SignatoryService implements Contracts.SignatoryService {
-	readonly #identity: IdentityService;
-
-	private constructor(identityService: IdentityService) {
-		this.#identity = identityService;
-	}
-
+export class SignatoryService extends Signatories.AbstractSignatoryService {
 	public static async __construct(config: Coins.Config): Promise<SignatoryService> {
 		return new SignatoryService(await IdentityService.__construct(config));
-	}
-
-	public async __destruct(): Promise<void> {
-		//
-	}
-
-	public async mnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.MnemonicSignatory> {
-		return new Signatories.MnemonicSignatory(
-			mnemonic,
-			await this.#identity.address().fromMnemonic(mnemonic, options),
-		);
-	}
-
-	public async secondaryMnemonic(
-		primary: string,
-		secondary: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SecondaryMnemonicSignatory> {
-		return new Signatories.SecondaryMnemonicSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromMnemonic(primary, options),
-		);
-	}
-
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatories.MultiMnemonicSignatory> {
-		return new Signatories.MultiMnemonicSignatory(
-			mnemonics,
-			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
-		);
-	}
-
-	public async wif(primary: string): Promise<Signatories.WIFSignatory> {
-		return new Signatories.WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
-	}
-
-	public async secondaryWif(primary: string, secondary: string): Promise<Signatories.SecondaryWIFSignatory> {
-		return new Signatories.SecondaryWIFSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromWIF(primary),
-		);
-	}
-
-	public async privateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.PrivateKeySignatory> {
-		return new Signatories.PrivateKeySignatory(
-			privateKey,
-			await this.#identity.address().fromPrivateKey(privateKey, options),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatories.SignatureSignatory> {
-		return new Signatories.SignatureSignatory(signature, senderPublicKey);
-	}
-
-	public async senderPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SenderPublicKeySignatory> {
-		return new Signatories.SenderPublicKeySignatory(
-			publicKey,
-			await this.#identity.address().fromPublicKey(publicKey, options),
-		);
-	}
-
-	public async multiSignature(min: number, publicKeys: string[]): Promise<Signatories.MultiSignatureSignatory> {
-		return new Signatories.MultiSignatureSignatory({ min, publicKeys });
 	}
 }

--- a/packages/platform-sdk-eos/src/services/signatory.ts
+++ b/packages/platform-sdk-eos/src/services/signatory.ts
@@ -1,88 +1,9 @@
-import { Coins, Contracts, Signatories } from "@arkecosystem/platform-sdk";
+import { Coins, Signatories } from "@arkecosystem/platform-sdk";
 
 import { IdentityService } from "./identity";
 
-export class SignatoryService implements Contracts.SignatoryService {
-	readonly #identity: IdentityService;
-
-	private constructor(identityService: IdentityService) {
-		this.#identity = identityService;
-	}
-
+export class SignatoryService extends Signatories.AbstractSignatoryService {
 	public static async __construct(config: Coins.Config): Promise<SignatoryService> {
 		return new SignatoryService(await IdentityService.__construct(config));
-	}
-
-	public async __destruct(): Promise<void> {
-		//
-	}
-
-	public async mnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.MnemonicSignatory> {
-		return new Signatories.MnemonicSignatory(
-			mnemonic,
-			await this.#identity.address().fromMnemonic(mnemonic, options),
-		);
-	}
-
-	public async secondaryMnemonic(
-		primary: string,
-		secondary: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SecondaryMnemonicSignatory> {
-		return new Signatories.SecondaryMnemonicSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromMnemonic(primary, options),
-		);
-	}
-
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatories.MultiMnemonicSignatory> {
-		return new Signatories.MultiMnemonicSignatory(
-			mnemonics,
-			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
-		);
-	}
-
-	public async wif(primary: string): Promise<Signatories.WIFSignatory> {
-		return new Signatories.WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
-	}
-
-	public async secondaryWif(primary: string, secondary: string): Promise<Signatories.SecondaryWIFSignatory> {
-		return new Signatories.SecondaryWIFSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromWIF(primary),
-		);
-	}
-
-	public async privateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.PrivateKeySignatory> {
-		return new Signatories.PrivateKeySignatory(
-			privateKey,
-			await this.#identity.address().fromPrivateKey(privateKey, options),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatories.SignatureSignatory> {
-		return new Signatories.SignatureSignatory(signature, senderPublicKey);
-	}
-
-	public async senderPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SenderPublicKeySignatory> {
-		return new Signatories.SenderPublicKeySignatory(
-			publicKey,
-			await this.#identity.address().fromPublicKey(publicKey, options),
-		);
-	}
-
-	public async multiSignature(min: number, publicKeys: string[]): Promise<Signatories.MultiSignatureSignatory> {
-		return new Signatories.MultiSignatureSignatory({ min, publicKeys });
 	}
 }

--- a/packages/platform-sdk-eth/src/services/signatory.ts
+++ b/packages/platform-sdk-eth/src/services/signatory.ts
@@ -1,88 +1,9 @@
-import { Coins, Contracts, Signatories } from "@arkecosystem/platform-sdk";
+import { Coins, Signatories } from "@arkecosystem/platform-sdk";
 
 import { IdentityService } from "./identity";
 
-export class SignatoryService implements Contracts.SignatoryService {
-	readonly #identity: IdentityService;
-
-	private constructor(identityService: IdentityService) {
-		this.#identity = identityService;
-	}
-
+export class SignatoryService extends Signatories.AbstractSignatoryService {
 	public static async __construct(config: Coins.Config): Promise<SignatoryService> {
 		return new SignatoryService(await IdentityService.__construct(config));
-	}
-
-	public async __destruct(): Promise<void> {
-		//
-	}
-
-	public async mnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.MnemonicSignatory> {
-		return new Signatories.MnemonicSignatory(
-			mnemonic,
-			await this.#identity.address().fromMnemonic(mnemonic, options),
-		);
-	}
-
-	public async secondaryMnemonic(
-		primary: string,
-		secondary: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SecondaryMnemonicSignatory> {
-		return new Signatories.SecondaryMnemonicSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromMnemonic(primary, options),
-		);
-	}
-
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatories.MultiMnemonicSignatory> {
-		return new Signatories.MultiMnemonicSignatory(
-			mnemonics,
-			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
-		);
-	}
-
-	public async wif(primary: string): Promise<Signatories.WIFSignatory> {
-		return new Signatories.WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
-	}
-
-	public async secondaryWif(primary: string, secondary: string): Promise<Signatories.SecondaryWIFSignatory> {
-		return new Signatories.SecondaryWIFSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromWIF(primary),
-		);
-	}
-
-	public async privateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.PrivateKeySignatory> {
-		return new Signatories.PrivateKeySignatory(
-			privateKey,
-			await this.#identity.address().fromPrivateKey(privateKey, options),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatories.SignatureSignatory> {
-		return new Signatories.SignatureSignatory(signature, senderPublicKey);
-	}
-
-	public async senderPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SenderPublicKeySignatory> {
-		return new Signatories.SenderPublicKeySignatory(
-			publicKey,
-			await this.#identity.address().fromPublicKey(publicKey, options),
-		);
-	}
-
-	public async multiSignature(min: number, publicKeys: string[]): Promise<Signatories.MultiSignatureSignatory> {
-		return new Signatories.MultiSignatureSignatory({ min, publicKeys });
 	}
 }

--- a/packages/platform-sdk-lsk/src/services/signatory.ts
+++ b/packages/platform-sdk-lsk/src/services/signatory.ts
@@ -1,88 +1,9 @@
-import { Coins, Contracts, Signatories } from "@arkecosystem/platform-sdk";
+import { Coins, Signatories } from "@arkecosystem/platform-sdk";
 
 import { IdentityService } from "./identity";
 
-export class SignatoryService implements Contracts.SignatoryService {
-	readonly #identity: IdentityService;
-
-	private constructor(identityService: IdentityService) {
-		this.#identity = identityService;
-	}
-
+export class SignatoryService extends Signatories.AbstractSignatoryService {
 	public static async __construct(config: Coins.Config): Promise<SignatoryService> {
 		return new SignatoryService(await IdentityService.__construct(config));
-	}
-
-	public async __destruct(): Promise<void> {
-		//
-	}
-
-	public async mnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.MnemonicSignatory> {
-		return new Signatories.MnemonicSignatory(
-			mnemonic,
-			await this.#identity.address().fromMnemonic(mnemonic, options),
-		);
-	}
-
-	public async secondaryMnemonic(
-		primary: string,
-		secondary: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SecondaryMnemonicSignatory> {
-		return new Signatories.SecondaryMnemonicSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromMnemonic(primary, options),
-		);
-	}
-
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatories.MultiMnemonicSignatory> {
-		return new Signatories.MultiMnemonicSignatory(
-			mnemonics,
-			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
-		);
-	}
-
-	public async wif(primary: string): Promise<Signatories.WIFSignatory> {
-		return new Signatories.WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
-	}
-
-	public async secondaryWif(primary: string, secondary: string): Promise<Signatories.SecondaryWIFSignatory> {
-		return new Signatories.SecondaryWIFSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromWIF(primary),
-		);
-	}
-
-	public async privateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.PrivateKeySignatory> {
-		return new Signatories.PrivateKeySignatory(
-			privateKey,
-			await this.#identity.address().fromPrivateKey(privateKey, options),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatories.SignatureSignatory> {
-		return new Signatories.SignatureSignatory(signature, senderPublicKey);
-	}
-
-	public async senderPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SenderPublicKeySignatory> {
-		return new Signatories.SenderPublicKeySignatory(
-			publicKey,
-			await this.#identity.address().fromPublicKey(publicKey, options),
-		);
-	}
-
-	public async multiSignature(min: number, publicKeys: string[]): Promise<Signatories.MultiSignatureSignatory> {
-		return new Signatories.MultiSignatureSignatory({ min, publicKeys });
 	}
 }

--- a/packages/platform-sdk-luna/src/services/signatory.ts
+++ b/packages/platform-sdk-luna/src/services/signatory.ts
@@ -1,88 +1,9 @@
-import { Coins, Contracts, Signatories } from "@arkecosystem/platform-sdk";
+import { Coins, Signatories } from "@arkecosystem/platform-sdk";
 
 import { IdentityService } from "./identity";
 
-export class SignatoryService implements Contracts.SignatoryService {
-	readonly #identity: IdentityService;
-
-	private constructor(identityService: IdentityService) {
-		this.#identity = identityService;
-	}
-
+export class SignatoryService extends Signatories.AbstractSignatoryService {
 	public static async __construct(config: Coins.Config): Promise<SignatoryService> {
 		return new SignatoryService(await IdentityService.__construct(config));
-	}
-
-	public async __destruct(): Promise<void> {
-		//
-	}
-
-	public async mnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.MnemonicSignatory> {
-		return new Signatories.MnemonicSignatory(
-			mnemonic,
-			await this.#identity.address().fromMnemonic(mnemonic, options),
-		);
-	}
-
-	public async secondaryMnemonic(
-		primary: string,
-		secondary: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SecondaryMnemonicSignatory> {
-		return new Signatories.SecondaryMnemonicSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromMnemonic(primary, options),
-		);
-	}
-
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatories.MultiMnemonicSignatory> {
-		return new Signatories.MultiMnemonicSignatory(
-			mnemonics,
-			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
-		);
-	}
-
-	public async wif(primary: string): Promise<Signatories.WIFSignatory> {
-		return new Signatories.WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
-	}
-
-	public async secondaryWif(primary: string, secondary: string): Promise<Signatories.SecondaryWIFSignatory> {
-		return new Signatories.SecondaryWIFSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromWIF(primary),
-		);
-	}
-
-	public async privateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.PrivateKeySignatory> {
-		return new Signatories.PrivateKeySignatory(
-			privateKey,
-			await this.#identity.address().fromPrivateKey(privateKey, options),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatories.SignatureSignatory> {
-		return new Signatories.SignatureSignatory(signature, senderPublicKey);
-	}
-
-	public async senderPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SenderPublicKeySignatory> {
-		return new Signatories.SenderPublicKeySignatory(
-			publicKey,
-			await this.#identity.address().fromPublicKey(publicKey, options),
-		);
-	}
-
-	public async multiSignature(min: number, publicKeys: string[]): Promise<Signatories.MultiSignatureSignatory> {
-		return new Signatories.MultiSignatureSignatory({ min, publicKeys });
 	}
 }

--- a/packages/platform-sdk-nano/src/services/signatory.ts
+++ b/packages/platform-sdk-nano/src/services/signatory.ts
@@ -1,88 +1,9 @@
-import { Coins, Contracts, Signatories } from "@arkecosystem/platform-sdk";
+import { Coins, Signatories } from "@arkecosystem/platform-sdk";
 
 import { IdentityService } from "./identity";
 
-export class SignatoryService implements Contracts.SignatoryService {
-	readonly #identity: IdentityService;
-
-	private constructor(identityService: IdentityService) {
-		this.#identity = identityService;
-	}
-
+export class SignatoryService extends Signatories.AbstractSignatoryService {
 	public static async __construct(config: Coins.Config): Promise<SignatoryService> {
 		return new SignatoryService(await IdentityService.__construct(config));
-	}
-
-	public async __destruct(): Promise<void> {
-		//
-	}
-
-	public async mnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.MnemonicSignatory> {
-		return new Signatories.MnemonicSignatory(
-			mnemonic,
-			await this.#identity.address().fromMnemonic(mnemonic, options),
-		);
-	}
-
-	public async secondaryMnemonic(
-		primary: string,
-		secondary: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SecondaryMnemonicSignatory> {
-		return new Signatories.SecondaryMnemonicSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromMnemonic(primary, options),
-		);
-	}
-
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatories.MultiMnemonicSignatory> {
-		return new Signatories.MultiMnemonicSignatory(
-			mnemonics,
-			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
-		);
-	}
-
-	public async wif(primary: string): Promise<Signatories.WIFSignatory> {
-		return new Signatories.WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
-	}
-
-	public async secondaryWif(primary: string, secondary: string): Promise<Signatories.SecondaryWIFSignatory> {
-		return new Signatories.SecondaryWIFSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromWIF(primary),
-		);
-	}
-
-	public async privateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.PrivateKeySignatory> {
-		return new Signatories.PrivateKeySignatory(
-			privateKey,
-			await this.#identity.address().fromPrivateKey(privateKey, options),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatories.SignatureSignatory> {
-		return new Signatories.SignatureSignatory(signature, senderPublicKey);
-	}
-
-	public async senderPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SenderPublicKeySignatory> {
-		return new Signatories.SenderPublicKeySignatory(
-			publicKey,
-			await this.#identity.address().fromPublicKey(publicKey, options),
-		);
-	}
-
-	public async multiSignature(min: number, publicKeys: string[]): Promise<Signatories.MultiSignatureSignatory> {
-		return new Signatories.MultiSignatureSignatory({ min, publicKeys });
 	}
 }

--- a/packages/platform-sdk-neo/src/services/signatory.ts
+++ b/packages/platform-sdk-neo/src/services/signatory.ts
@@ -1,88 +1,9 @@
-import { Coins, Contracts, Signatories } from "@arkecosystem/platform-sdk";
+import { Coins, Signatories } from "@arkecosystem/platform-sdk";
 
 import { IdentityService } from "./identity";
 
-export class SignatoryService implements Contracts.SignatoryService {
-	readonly #identity: IdentityService;
-
-	private constructor(identityService: IdentityService) {
-		this.#identity = identityService;
-	}
-
+export class SignatoryService extends Signatories.AbstractSignatoryService {
 	public static async __construct(config: Coins.Config): Promise<SignatoryService> {
 		return new SignatoryService(await IdentityService.__construct(config));
-	}
-
-	public async __destruct(): Promise<void> {
-		//
-	}
-
-	public async mnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.MnemonicSignatory> {
-		return new Signatories.MnemonicSignatory(
-			mnemonic,
-			await this.#identity.address().fromMnemonic(mnemonic, options),
-		);
-	}
-
-	public async secondaryMnemonic(
-		primary: string,
-		secondary: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SecondaryMnemonicSignatory> {
-		return new Signatories.SecondaryMnemonicSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromMnemonic(primary, options),
-		);
-	}
-
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatories.MultiMnemonicSignatory> {
-		return new Signatories.MultiMnemonicSignatory(
-			mnemonics,
-			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
-		);
-	}
-
-	public async wif(primary: string): Promise<Signatories.WIFSignatory> {
-		return new Signatories.WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
-	}
-
-	public async secondaryWif(primary: string, secondary: string): Promise<Signatories.SecondaryWIFSignatory> {
-		return new Signatories.SecondaryWIFSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromWIF(primary),
-		);
-	}
-
-	public async privateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.PrivateKeySignatory> {
-		return new Signatories.PrivateKeySignatory(
-			privateKey,
-			await this.#identity.address().fromPrivateKey(privateKey, options),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatories.SignatureSignatory> {
-		return new Signatories.SignatureSignatory(signature, senderPublicKey);
-	}
-
-	public async senderPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SenderPublicKeySignatory> {
-		return new Signatories.SenderPublicKeySignatory(
-			publicKey,
-			await this.#identity.address().fromPublicKey(publicKey, options),
-		);
-	}
-
-	public async multiSignature(min: number, publicKeys: string[]): Promise<Signatories.MultiSignatureSignatory> {
-		return new Signatories.MultiSignatureSignatory({ min, publicKeys });
 	}
 }

--- a/packages/platform-sdk-sol/src/services/signatory.ts
+++ b/packages/platform-sdk-sol/src/services/signatory.ts
@@ -1,88 +1,9 @@
-import { Coins, Contracts, Signatories } from "@arkecosystem/platform-sdk";
+import { Coins, Signatories } from "@arkecosystem/platform-sdk";
 
 import { IdentityService } from "./identity";
 
-export class SignatoryService implements Contracts.SignatoryService {
-	readonly #identity: IdentityService;
-
-	private constructor(identityService: IdentityService) {
-		this.#identity = identityService;
-	}
-
+export class SignatoryService extends Signatories.AbstractSignatoryService {
 	public static async __construct(config: Coins.Config): Promise<SignatoryService> {
 		return new SignatoryService(await IdentityService.__construct(config));
-	}
-
-	public async __destruct(): Promise<void> {
-		//
-	}
-
-	public async mnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.MnemonicSignatory> {
-		return new Signatories.MnemonicSignatory(
-			mnemonic,
-			await this.#identity.address().fromMnemonic(mnemonic, options),
-		);
-	}
-
-	public async secondaryMnemonic(
-		primary: string,
-		secondary: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SecondaryMnemonicSignatory> {
-		return new Signatories.SecondaryMnemonicSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromMnemonic(primary, options),
-		);
-	}
-
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatories.MultiMnemonicSignatory> {
-		return new Signatories.MultiMnemonicSignatory(
-			mnemonics,
-			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
-		);
-	}
-
-	public async wif(primary: string): Promise<Signatories.WIFSignatory> {
-		return new Signatories.WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
-	}
-
-	public async secondaryWif(primary: string, secondary: string): Promise<Signatories.SecondaryWIFSignatory> {
-		return new Signatories.SecondaryWIFSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromWIF(primary),
-		);
-	}
-
-	public async privateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.PrivateKeySignatory> {
-		return new Signatories.PrivateKeySignatory(
-			privateKey,
-			await this.#identity.address().fromPrivateKey(privateKey, options),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatories.SignatureSignatory> {
-		return new Signatories.SignatureSignatory(signature, senderPublicKey);
-	}
-
-	public async senderPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SenderPublicKeySignatory> {
-		return new Signatories.SenderPublicKeySignatory(
-			publicKey,
-			await this.#identity.address().fromPublicKey(publicKey, options),
-		);
-	}
-
-	public async multiSignature(min: number, publicKeys: string[]): Promise<Signatories.MultiSignatureSignatory> {
-		return new Signatories.MultiSignatureSignatory({ min, publicKeys });
 	}
 }

--- a/packages/platform-sdk-trx/src/services/signatory.ts
+++ b/packages/platform-sdk-trx/src/services/signatory.ts
@@ -1,88 +1,9 @@
-import { Coins, Contracts, Signatories } from "@arkecosystem/platform-sdk";
+import { Coins, Signatories } from "@arkecosystem/platform-sdk";
 
 import { IdentityService } from "./identity";
 
-export class SignatoryService implements Contracts.SignatoryService {
-	readonly #identity: IdentityService;
-
-	private constructor(identityService: IdentityService) {
-		this.#identity = identityService;
-	}
-
+export class SignatoryService extends Signatories.AbstractSignatoryService {
 	public static async __construct(config: Coins.Config): Promise<SignatoryService> {
 		return new SignatoryService(await IdentityService.__construct(config));
-	}
-
-	public async __destruct(): Promise<void> {
-		//
-	}
-
-	public async mnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.MnemonicSignatory> {
-		return new Signatories.MnemonicSignatory(
-			mnemonic,
-			await this.#identity.address().fromMnemonic(mnemonic, options),
-		);
-	}
-
-	public async secondaryMnemonic(
-		primary: string,
-		secondary: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SecondaryMnemonicSignatory> {
-		return new Signatories.SecondaryMnemonicSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromMnemonic(primary, options),
-		);
-	}
-
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatories.MultiMnemonicSignatory> {
-		return new Signatories.MultiMnemonicSignatory(
-			mnemonics,
-			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
-		);
-	}
-
-	public async wif(primary: string): Promise<Signatories.WIFSignatory> {
-		return new Signatories.WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
-	}
-
-	public async secondaryWif(primary: string, secondary: string): Promise<Signatories.SecondaryWIFSignatory> {
-		return new Signatories.SecondaryWIFSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromWIF(primary),
-		);
-	}
-
-	public async privateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.PrivateKeySignatory> {
-		return new Signatories.PrivateKeySignatory(
-			privateKey,
-			await this.#identity.address().fromPrivateKey(privateKey, options),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatories.SignatureSignatory> {
-		return new Signatories.SignatureSignatory(signature, senderPublicKey);
-	}
-
-	public async senderPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SenderPublicKeySignatory> {
-		return new Signatories.SenderPublicKeySignatory(
-			publicKey,
-			await this.#identity.address().fromPublicKey(publicKey, options),
-		);
-	}
-
-	public async multiSignature(min: number, publicKeys: string[]): Promise<Signatories.MultiSignatureSignatory> {
-		return new Signatories.MultiSignatureSignatory({ min, publicKeys });
 	}
 }

--- a/packages/platform-sdk-xlm/src/services/signatory.ts
+++ b/packages/platform-sdk-xlm/src/services/signatory.ts
@@ -1,88 +1,9 @@
-import { Coins, Contracts, Signatories } from "@arkecosystem/platform-sdk";
+import { Coins, Signatories } from "@arkecosystem/platform-sdk";
 
 import { IdentityService } from "./identity";
 
-export class SignatoryService implements Contracts.SignatoryService {
-	readonly #identity: IdentityService;
-
-	private constructor(identityService: IdentityService) {
-		this.#identity = identityService;
-	}
-
+export class SignatoryService extends Signatories.AbstractSignatoryService {
 	public static async __construct(config: Coins.Config): Promise<SignatoryService> {
 		return new SignatoryService(await IdentityService.__construct(config));
-	}
-
-	public async __destruct(): Promise<void> {
-		//
-	}
-
-	public async mnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.MnemonicSignatory> {
-		return new Signatories.MnemonicSignatory(
-			mnemonic,
-			await this.#identity.address().fromMnemonic(mnemonic, options),
-		);
-	}
-
-	public async secondaryMnemonic(
-		primary: string,
-		secondary: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SecondaryMnemonicSignatory> {
-		return new Signatories.SecondaryMnemonicSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromMnemonic(primary, options),
-		);
-	}
-
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatories.MultiMnemonicSignatory> {
-		return new Signatories.MultiMnemonicSignatory(
-			mnemonics,
-			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
-		);
-	}
-
-	public async wif(primary: string): Promise<Signatories.WIFSignatory> {
-		return new Signatories.WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
-	}
-
-	public async secondaryWif(primary: string, secondary: string): Promise<Signatories.SecondaryWIFSignatory> {
-		return new Signatories.SecondaryWIFSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromWIF(primary),
-		);
-	}
-
-	public async privateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.PrivateKeySignatory> {
-		return new Signatories.PrivateKeySignatory(
-			privateKey,
-			await this.#identity.address().fromPrivateKey(privateKey, options),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatories.SignatureSignatory> {
-		return new Signatories.SignatureSignatory(signature, senderPublicKey);
-	}
-
-	public async senderPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SenderPublicKeySignatory> {
-		return new Signatories.SenderPublicKeySignatory(
-			publicKey,
-			await this.#identity.address().fromPublicKey(publicKey, options),
-		);
-	}
-
-	public async multiSignature(min: number, publicKeys: string[]): Promise<Signatories.MultiSignatureSignatory> {
-		return new Signatories.MultiSignatureSignatory({ min, publicKeys });
 	}
 }

--- a/packages/platform-sdk-xrp/src/services/signatory.ts
+++ b/packages/platform-sdk-xrp/src/services/signatory.ts
@@ -1,88 +1,9 @@
-import { Coins, Contracts, Signatories } from "@arkecosystem/platform-sdk";
+import { Coins, Signatories } from "@arkecosystem/platform-sdk";
 
 import { IdentityService } from "./identity";
 
-export class SignatoryService implements Contracts.SignatoryService {
-	readonly #identity: IdentityService;
-
-	private constructor(identityService: IdentityService) {
-		this.#identity = identityService;
-	}
-
+export class SignatoryService extends Signatories.AbstractSignatoryService {
 	public static async __construct(config: Coins.Config): Promise<SignatoryService> {
 		return new SignatoryService(await IdentityService.__construct(config));
-	}
-
-	public async __destruct(): Promise<void> {
-		//
-	}
-
-	public async mnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.MnemonicSignatory> {
-		return new Signatories.MnemonicSignatory(
-			mnemonic,
-			await this.#identity.address().fromMnemonic(mnemonic, options),
-		);
-	}
-
-	public async secondaryMnemonic(
-		primary: string,
-		secondary: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SecondaryMnemonicSignatory> {
-		return new Signatories.SecondaryMnemonicSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromMnemonic(primary, options),
-		);
-	}
-
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatories.MultiMnemonicSignatory> {
-		return new Signatories.MultiMnemonicSignatory(
-			mnemonics,
-			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
-		);
-	}
-
-	public async wif(primary: string): Promise<Signatories.WIFSignatory> {
-		return new Signatories.WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
-	}
-
-	public async secondaryWif(primary: string, secondary: string): Promise<Signatories.SecondaryWIFSignatory> {
-		return new Signatories.SecondaryWIFSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromWIF(primary),
-		);
-	}
-
-	public async privateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.PrivateKeySignatory> {
-		return new Signatories.PrivateKeySignatory(
-			privateKey,
-			await this.#identity.address().fromPrivateKey(privateKey, options),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatories.SignatureSignatory> {
-		return new Signatories.SignatureSignatory(signature, senderPublicKey);
-	}
-
-	public async senderPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SenderPublicKeySignatory> {
-		return new Signatories.SenderPublicKeySignatory(
-			publicKey,
-			await this.#identity.address().fromPublicKey(publicKey, options),
-		);
-	}
-
-	public async multiSignature(min: number, publicKeys: string[]): Promise<Signatories.MultiSignatureSignatory> {
-		return new Signatories.MultiSignatureSignatory({ min, publicKeys });
 	}
 }

--- a/packages/platform-sdk-zil/src/services/signatory.ts
+++ b/packages/platform-sdk-zil/src/services/signatory.ts
@@ -1,88 +1,9 @@
-import { Coins, Contracts, Signatories } from "@arkecosystem/platform-sdk";
+import { Coins, Signatories } from "@arkecosystem/platform-sdk";
 
 import { IdentityService } from "./identity";
 
-export class SignatoryService implements Contracts.SignatoryService {
-	readonly #identity: IdentityService;
-
-	private constructor(identityService: IdentityService) {
-		this.#identity = identityService;
-	}
-
+export class SignatoryService extends Signatories.AbstractSignatoryService {
 	public static async __construct(config: Coins.Config): Promise<SignatoryService> {
 		return new SignatoryService(await IdentityService.__construct(config));
-	}
-
-	public async __destruct(): Promise<void> {
-		//
-	}
-
-	public async mnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.MnemonicSignatory> {
-		return new Signatories.MnemonicSignatory(
-			mnemonic,
-			await this.#identity.address().fromMnemonic(mnemonic, options),
-		);
-	}
-
-	public async secondaryMnemonic(
-		primary: string,
-		secondary: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SecondaryMnemonicSignatory> {
-		return new Signatories.SecondaryMnemonicSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromMnemonic(primary, options),
-		);
-	}
-
-	public async multiMnemonic(mnemonics: string[]): Promise<Signatories.MultiMnemonicSignatory> {
-		return new Signatories.MultiMnemonicSignatory(
-			mnemonics,
-			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
-		);
-	}
-
-	public async wif(primary: string): Promise<Signatories.WIFSignatory> {
-		return new Signatories.WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
-	}
-
-	public async secondaryWif(primary: string, secondary: string): Promise<Signatories.SecondaryWIFSignatory> {
-		return new Signatories.SecondaryWIFSignatory(
-			primary,
-			secondary,
-			await this.#identity.address().fromWIF(primary),
-		);
-	}
-
-	public async privateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.PrivateKeySignatory> {
-		return new Signatories.PrivateKeySignatory(
-			privateKey,
-			await this.#identity.address().fromPrivateKey(privateKey, options),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatories.SignatureSignatory> {
-		return new Signatories.SignatureSignatory(signature, senderPublicKey);
-	}
-
-	public async senderPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Signatories.SenderPublicKeySignatory> {
-		return new Signatories.SenderPublicKeySignatory(
-			publicKey,
-			await this.#identity.address().fromPublicKey(publicKey, options),
-		);
-	}
-
-	public async multiSignature(min: number, publicKeys: string[]): Promise<Signatories.MultiSignatureSignatory> {
-		return new Signatories.MultiSignatureSignatory({ min, publicKeys });
 	}
 }

--- a/packages/platform-sdk/src/signatories/abstract-signatory-service.ts
+++ b/packages/platform-sdk/src/signatories/abstract-signatory-service.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import { IdentityOptions, IdentityService, SignatoryService } from "../contracts";
 import { MnemonicSignatory, MultiMnemonicSignatory, MultiSignatureSignatory, PrivateKeySignatory, SecondaryMnemonicSignatory, SecondaryWIFSignatory, SenderPublicKeySignatory, SignatureSignatory, WIFSignatory } from ".";
 

--- a/packages/platform-sdk/src/signatories/abstract-signatory-service.ts
+++ b/packages/platform-sdk/src/signatories/abstract-signatory-service.ts
@@ -1,0 +1,83 @@
+import { IdentityOptions, IdentityService, SignatoryService } from "../contracts";
+import { MnemonicSignatory, MultiMnemonicSignatory, MultiSignatureSignatory, PrivateKeySignatory, SecondaryMnemonicSignatory, SecondaryWIFSignatory, SenderPublicKeySignatory, SignatureSignatory, WIFSignatory } from ".";
+
+export class AbstractSignatoryService implements SignatoryService {
+	readonly #identity: IdentityService;
+
+	public constructor(identityService: IdentityService) {
+		this.#identity = identityService;
+	}
+
+	public async __destruct(): Promise<void> {
+		//
+	}
+
+	public async mnemonic(
+		mnemonic: string,
+		options?: IdentityOptions,
+	): Promise<MnemonicSignatory> {
+		return new MnemonicSignatory(
+			mnemonic,
+			await this.#identity.address().fromMnemonic(mnemonic, options),
+		);
+	}
+
+	public async secondaryMnemonic(
+		primary: string,
+		secondary: string,
+		options?: IdentityOptions,
+	): Promise<SecondaryMnemonicSignatory> {
+		return new SecondaryMnemonicSignatory(
+			primary,
+			secondary,
+			await this.#identity.address().fromMnemonic(primary, options),
+		);
+	}
+
+	public async multiMnemonic(mnemonics: string[]): Promise<MultiMnemonicSignatory> {
+		return new MultiMnemonicSignatory(
+			mnemonics,
+			await Promise.all(mnemonics.map((mnemonic: string) => this.#identity.publicKey().fromMnemonic(mnemonic))),
+		);
+	}
+
+	public async wif(primary: string): Promise<WIFSignatory> {
+		return new WIFSignatory(primary, await this.#identity.address().fromWIF(primary));
+	}
+
+	public async secondaryWif(primary: string, secondary: string): Promise<SecondaryWIFSignatory> {
+		return new SecondaryWIFSignatory(
+			primary,
+			secondary,
+			await this.#identity.address().fromWIF(primary),
+		);
+	}
+
+	public async privateKey(
+		privateKey: string,
+		options?: IdentityOptions,
+	): Promise<PrivateKeySignatory> {
+		return new PrivateKeySignatory(
+			privateKey,
+			await this.#identity.address().fromPrivateKey(privateKey, options),
+		);
+	}
+
+	public async signature(signature: string, senderPublicKey: string): Promise<SignatureSignatory> {
+		return new SignatureSignatory(signature, senderPublicKey);
+	}
+
+	public async senderPublicKey(
+		publicKey: string,
+		options?: IdentityOptions,
+	): Promise<SenderPublicKeySignatory> {
+		return new SenderPublicKeySignatory(
+			publicKey,
+			await this.#identity.address().fromPublicKey(publicKey, options),
+		);
+	}
+
+	public async multiSignature(min: number, publicKeys: string[]): Promise<MultiSignatureSignatory> {
+		return new MultiSignatureSignatory({ min, publicKeys });
+	}
+}

--- a/packages/platform-sdk/src/signatories/index.ts
+++ b/packages/platform-sdk/src/signatories/index.ts
@@ -1,3 +1,4 @@
+import { AbstractSignatoryService } from "./abstract-signatory-service";
 import { MnemonicSignatory } from "./mnemonic";
 import { MultiMnemonicSignatory } from "./multi-mnemonic";
 import { MultiSignatureSignatory } from "./multi-signature";
@@ -11,15 +12,16 @@ import { SignatureSignatory } from "./signature";
 import { WIFSignatory } from "./wif";
 
 export {
-	Signatory,
+	AbstractSignatoryService,
 	MnemonicSignatory,
 	MultiMnemonicSignatory,
-	SecondaryMnemonicSignatory,
-	WIFSignatory,
-	SecondaryWIFSignatory,
+	MultiSignatureSignatory,
 	PrivateKeySignatory,
 	PrivateMultiSignatureSignatory,
-	SignatureSignatory,
+	SecondaryMnemonicSignatory,
+	SecondaryWIFSignatory,
 	SenderPublicKeySignatory,
-	MultiSignatureSignatory,
+	Signatory,
+	SignatureSignatory,
+	WIFSignatory,
 };


### PR DESCRIPTION
Most coins will share the majority of these behaviours but there's a few exceptions. For transaction/message signing for example some coins use the address as an identifier but others use a public key so we can create some defaults but coins can overwrite them as they need.