### PR TITLE
refactor: remove `IContactAddress#name`

### DIFF
--- a/packages/platform-sdk-profiles/src/contracts/contacts/contact-address.ts
+++ b/packages/platform-sdk-profiles/src/contracts/contacts/contact-address.ts
@@ -7,7 +7,6 @@
 export interface IContactAddressInput {
 	coin: string;
 	network: string;
-	name: string;
 	address: string;
 }
 
@@ -21,7 +20,6 @@ export interface IContactAddressData {
 	id: string;
 	coin: string;
 	network: string;
-	name: string;
 	address: string;
 }
 
@@ -55,14 +53,6 @@ export interface IContactAddress {
 	 * @memberof IContactAddress
 	 */
 	network(): string;
-
-	/**
-	 *
-	 *
-	 * @returns {string}
-	 * @memberof IContactAddress
-	 */
-	name(): string;
 
 	/**
 	 *
@@ -147,18 +137,10 @@ export interface IContactAddress {
 	/**
 	 *
 	 *
-	 * @param {string} value
+	 * @param {string} address
 	 * @memberof IContactAddress
 	 */
-	setName(value: string): void;
-
-	/**
-	 *
-	 *
-	 * @param {string} name
-	 * @memberof IContactAddress
-	 */
-	setAddress(name: string): void;
+	setAddress(address: string): void;
 
 	/**
 	 *

--- a/packages/platform-sdk-profiles/src/drivers/memory/contacts/contact-address.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/contacts/contact-address.test.ts
@@ -37,7 +37,6 @@ beforeEach(async () => {
 			id: "uuid",
 			coin: "ARK",
 			network: "ark.devnet",
-			name: "John Doe",
 			address: "D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib",
 		},
 		coin,
@@ -59,10 +58,6 @@ it("should have a coin", () => {
 
 it("should have a network", () => {
 	expect(subject.network()).toBe("ark.devnet");
-});
-
-it("should have a name", () => {
-	expect(subject.name()).toBe("John Doe");
 });
 
 it("should have an address", () => {
@@ -96,7 +91,6 @@ it("should turn into an object", () => {
 		address: "D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib",
 		coin: "ARK",
 		id: "uuid",
-		name: "John Doe",
 		network: "ark.devnet",
 	});
 });
@@ -126,7 +120,6 @@ describe("when contact has not been synchronized yet", () => {
 				id: "uuid",
 				coin: "ARK",
 				network: "ark.devnet",
-				name: "John Doe",
 				address: "D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib",
 			},
 			coin,
@@ -167,11 +160,6 @@ it("should determine if the wallet is owned by an exchange", () => {
 
 it("should determine if the wallet is owned by a team", () => {
 	expect(subject.isOwnedByTeam()).toBeFalse();
-});
-
-it("should change the name", () => {
-	subject.setName("new name");
-	expect(subject.name()).toBe("new name");
 });
 
 it("should change the address", () => {

--- a/packages/platform-sdk-profiles/src/drivers/memory/contacts/contact-address.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/contacts/contact-address.ts
@@ -32,11 +32,6 @@ export class ContactAddress implements IContactAddress {
 		return this.#data.network;
 	}
 
-	/** {@inheritDoc IContactAddress.name} */
-	public name(): string {
-		return this.#data.name;
-	}
-
 	/** {@inheritDoc IContactAddress.address} */
 	public address(): string {
 		return this.#data.address;
@@ -110,21 +105,13 @@ export class ContactAddress implements IContactAddress {
 			id: this.id(),
 			coin: this.coin(),
 			network: this.network(),
-			name: this.name(),
 			address: this.address(),
 		};
 	}
 
-	/** {@inheritDoc IContactAddress.setName} */
-	public setName(value: string): void {
-		this.#data.name = value;
-
-		this.#profile.status().markAsDirty();
-	}
-
 	/** {@inheritDoc IContactAddress.setAddress} */
-	public setAddress(name: string): void {
-		this.#data.address = name;
+	public setAddress(address: string): void {
+		this.#data.address = address;
 
 		this.#profile.status().markAsDirty();
 	}

--- a/packages/platform-sdk-profiles/src/drivers/memory/repositories/contact-address-repository.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/repositories/contact-address-repository.test.ts
@@ -13,7 +13,6 @@ let subject: ContactAddressRepository;
 const stubData = {
 	coin: "ARK",
 	network: "ark.devnet",
-	name: "John Doe",
 	address: "D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib",
 };
 
@@ -98,24 +97,7 @@ test("#find", async () => {
 });
 
 test("#update invalid", async () => {
-	expect(() => subject.update("invalid", { name: "Jane Doe" })).toThrowError("Failed to find");
-});
-
-test("#update both", async () => {
-	const address = await subject.create(stubData);
-
-	subject.update(address.id(), { name: "Jane Doe", address: "new address" });
-
-	expect(subject.findById(address.id()).name()).toEqual("Jane Doe");
-	expect(subject.findByAddress("new address")[0].name()).toEqual("Jane Doe");
-});
-
-test("#update name", async () => {
-	const address = await subject.create(stubData);
-
-	subject.update(address.id(), { name: "Jane Doe" });
-
-	expect(subject.findById(address.id()).name()).toEqual("Jane Doe");
+	expect(() => subject.update("invalid", { address: stubData.address })).toThrowError("Failed to find");
 });
 
 test("#update address", async () => {
@@ -123,7 +105,7 @@ test("#update address", async () => {
 
 	subject.update(address.id(), { address: "new address" });
 
-	expect(subject.findByAddress("new address")[0].name()).toEqual("John Doe");
+	expect(subject.findByAddress("new address")[0].address()).toEqual("new address");
 });
 
 test("#forget", async () => {

--- a/packages/platform-sdk-profiles/src/drivers/memory/repositories/contact-address-repository.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/repositories/contact-address-repository.ts
@@ -94,10 +94,6 @@ export class ContactAddressRepository implements IContactAddressRepository {
 	public update(id: string, data: Record<string, string>): void {
 		const address = this.findById(id);
 
-		if (data.name) {
-			address.setName(data.name);
-		}
-
 		if (data.address) {
 			address.setAddress(data.address);
 		}

--- a/packages/platform-sdk-profiles/src/drivers/memory/repositories/contact-repository.test.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/repositories/contact-repository.test.ts
@@ -12,7 +12,7 @@ import { ContactRepository } from "./contact-repository";
 let subject: ContactRepository;
 
 const name = "John Doe";
-const addr = { name: "JDB", coin: "ARK", network: "ark.devnet", address: "D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib" };
+const addr = { coin: "ARK", network: "ark.devnet", address: "D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib" };
 
 beforeAll(() => bootContainer());
 
@@ -100,7 +100,6 @@ test("#update with addresses", async () => {
 			{
 				coin: "ARK",
 				network: "ark.devnet",
-				name: "John Doe",
 				address: "D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib",
 			},
 		],


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Since contacts should not have more than one address for each individual network there is no need for the additional name.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
