### PR TITLE
refactor(sdk): further DRY the `LinkService`

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -5,6 +5,7 @@ importers:
     dependencies:
       '@arkecosystem/platform-sdk-intl': link:../platform-sdk-intl
       '@arkecosystem/platform-sdk-support': link:../platform-sdk-support
+      '@arkecosystem/utils': 1.3.0
       bad-words: 3.0.4
       bent: 7.3.12
       bignumber.js: 9.0.1
@@ -48,6 +49,7 @@ importers:
     specifiers:
       '@arkecosystem/platform-sdk-intl': workspace:*
       '@arkecosystem/platform-sdk-support': workspace:*
+      '@arkecosystem/utils': ^1.3.0
       '@sindresorhus/tsconfig': ^1.0.2
       '@types/eslint': ^7.2.10
       '@types/eslint-plugin-prettier': ^3.1.0
@@ -5461,7 +5463,7 @@ packages:
     dependencies:
       chalk: 4.1.1
       fs-extra: 10.0.0
-      lowdb: 1.0.0
+      lowdb: 2.1.0
       rotating-file-stream: 2.1.5
       strip-ansi: 7.0.0
     dev: false
@@ -10795,10 +10797,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
-  /is-promise/2.2.2:
-    dev: false
-    resolution:
-      integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
   /is-regex/1.1.2:
     dependencies:
       call-bind: 1.0.2
@@ -12092,18 +12090,14 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
-  /lowdb/1.0.0:
+  /lowdb/2.1.0:
     dependencies:
-      graceful-fs: 4.2.6
-      is-promise: 2.2.2
-      lodash: 4.17.21
-      pify: 3.0.0
-      steno: 0.4.4
+      steno: 1.0.0
     dev: false
     engines:
-      node: '>=4'
+      node: ^12.20.0 || ^14.13.1 || >=16.0.0
     resolution:
-      integrity: sha512-2+x8esE/Wb9SQ1F9IHaYWfsC9FIecLOPrK4g17FGEayjUWH172H6nwicRovGvSE2CPZouc2MCIqCI7h9d+GftQ==
+      integrity: sha512-F4Go8/V37gAidTR3c5poyjprOpZSDNSLJVOmI0ny4D4q9rC37OkBhlzX0bqj7LZlT3UIj4FchmZrrSw7qY+eGQ==
   /lowercase-keys/1.0.1:
     engines:
       node: '>=0.10.0'
@@ -13479,12 +13473,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
-  /pify/3.0.0:
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
   /pino-pretty/4.7.1:
     dependencies:
       '@hapi/bourne': 2.0.0
@@ -14972,12 +14960,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-crZSONO1lDEg2TP2wsslB7kcBopP6r2jzA5fC7JNvFZMMf0yq14fGDOwQerWI9XaxzpXOJxuQ1ZP3yB93Ds0+Q==
-  /steno/0.4.4:
-    dependencies:
-      graceful-fs: 4.2.6
+  /steno/1.0.0:
     dev: false
     resolution:
-      integrity: sha1-BxEFvfwobmYVwEA8J+nXtdy4Vcs=
+      integrity: sha512-C/KgCvEa1yWnpHmaPjAXrz1yWxh6hs+HvhqqPa71euaQmNi1wr4+WFo57VQxjKKuFl2KqS7gtlrN0oxj2noQLw==
   /store2/2.11.0:
     dev: false
     resolution:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "6d960ef7eaa91b138e804e14643e504fd2e3821b",
+  "pnpmShrinkwrapHash": "9085e2a2fc61c8417419c3d0b161d8c3ad4e74ae",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/packages/platform-sdk-ada/src/services/link.ts
+++ b/packages/platform-sdk-ada/src/services/link.ts
@@ -2,10 +2,10 @@ import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(Helpers.randomHostFromConfig(config, "explorer"), {
-			block: (id: string) => `block/${id}`,
-			transaction: (id: string) => `tx/${id}`,
-			wallet: (id: string) => `address/${id}`,
+		return new LinkService(config, {
+			block: "block/{0}",
+			transaction: "tx/{0}",
+			wallet: "address/{0}",
 		});
 	}
 }

--- a/packages/platform-sdk-ada/src/services/link.ts
+++ b/packages/platform-sdk-ada/src/services/link.ts
@@ -1,4 +1,4 @@
-import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
+import { Coins, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {

--- a/packages/platform-sdk-ark/src/services/link.ts
+++ b/packages/platform-sdk-ark/src/services/link.ts
@@ -1,4 +1,4 @@
-import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
+import { Coins, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {

--- a/packages/platform-sdk-ark/src/services/link.ts
+++ b/packages/platform-sdk-ark/src/services/link.ts
@@ -2,10 +2,10 @@ import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(Helpers.randomHostFromConfig(config, "explorer"), {
-			block: (id: string) => `block/${id}`,
-			transaction: (id: string) => `transaction/${id}`,
-			wallet: (id: string) => `wallets/${id}`,
+		return new LinkService(config, {
+			block: "block/{0}",
+			transaction: "transaction/{0}",
+			wallet: "wallets/{0}",
 		});
 	}
 }

--- a/packages/platform-sdk-atom/src/services/link.ts
+++ b/packages/platform-sdk-atom/src/services/link.ts
@@ -2,10 +2,10 @@ import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(Helpers.randomHostFromConfig(config, "explorer"), {
-			block: (id: string) => `blocks/${id}`,
-			transaction: (id: string) => `transactions/${id}`,
-			wallet: (id: string) => `account/${id}`,
+		return new LinkService(config, {
+			block: "blocks/{0}",
+			transaction: "transactions/{0}",
+			wallet: "account/{0}",
 		});
 	}
 }

--- a/packages/platform-sdk-atom/src/services/link.ts
+++ b/packages/platform-sdk-atom/src/services/link.ts
@@ -1,4 +1,4 @@
-import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
+import { Coins, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {

--- a/packages/platform-sdk-avax/src/services/link.ts
+++ b/packages/platform-sdk-avax/src/services/link.ts
@@ -2,10 +2,10 @@ import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(Helpers.randomHostFromConfig(config, "explorer"), {
-			block: (id: string) => `block/${id}`,
-			transaction: (id: string) => `tx/${id}`,
-			wallet: (id: string) => `address/${id}`,
+		return new LinkService(config, {
+			block: "block/{0}",
+			transaction: "tx/{0}",
+			wallet: "address/{0}",
 		});
 	}
 }

--- a/packages/platform-sdk-avax/src/services/link.ts
+++ b/packages/platform-sdk-avax/src/services/link.ts
@@ -1,4 +1,4 @@
-import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
+import { Coins, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {

--- a/packages/platform-sdk-btc/src/services/link.ts
+++ b/packages/platform-sdk-btc/src/services/link.ts
@@ -2,10 +2,10 @@ import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(Helpers.randomHostFromConfig(config, "explorer"), {
-			block: (id: string) => `block/${id}`,
-			transaction: (id: string) => `tx/${id}`,
-			wallet: (id: string) => `address/${id}`,
+		return new LinkService(config, {
+			block: "block/{0}",
+			transaction: "tx/{0}",
+			wallet: "address/{0}",
 		});
 	}
 }

--- a/packages/platform-sdk-btc/src/services/link.ts
+++ b/packages/platform-sdk-btc/src/services/link.ts
@@ -1,4 +1,4 @@
-import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
+import { Coins, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {

--- a/packages/platform-sdk-dot/src/services/link.ts
+++ b/packages/platform-sdk-dot/src/services/link.ts
@@ -2,10 +2,10 @@ import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(Helpers.randomHostFromConfig(config, "explorer"), {
-			block: (id: string) => `block/${id}`,
-			transaction: (id: string) => `tx/${id}`,
-			wallet: (id: string) => `address/${id}`,
+		return new LinkService(config, {
+			block: "block/{0}",
+			transaction: "tx/{0}",
+			wallet: "address/{0}",
 		});
 	}
 }

--- a/packages/platform-sdk-dot/src/services/link.ts
+++ b/packages/platform-sdk-dot/src/services/link.ts
@@ -1,4 +1,4 @@
-import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
+import { Coins, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {

--- a/packages/platform-sdk-egld/src/services/link.ts
+++ b/packages/platform-sdk-egld/src/services/link.ts
@@ -2,10 +2,10 @@ import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(Helpers.randomHostFromConfig(config, "explorer"), {
-			block: (id: string) => `miniblocks/${id}`,
-			transaction: (id: string) => `transactions/${id}`,
-			wallet: (id: string) => `accounts/${id}`,
+		return new LinkService(config, {
+			block: "miniblocks/{0}",
+			transaction: "transactions/{0}",
+			wallet: "accounts/{0}",
 		});
 	}
 }

--- a/packages/platform-sdk-egld/src/services/link.ts
+++ b/packages/platform-sdk-egld/src/services/link.ts
@@ -1,4 +1,4 @@
-import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
+import { Coins, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {

--- a/packages/platform-sdk-eos/src/services/link.ts
+++ b/packages/platform-sdk-eos/src/services/link.ts
@@ -2,10 +2,10 @@ import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(Helpers.randomHostFromConfig(config, "explorer"), {
-			block: (id: string) => `block/${id}`,
-			transaction: (id: string) => `transaction/${id}`,
-			wallet: (id: string) => `account/${id}`,
+		return new LinkService(config, {
+			block: "block/{0}",
+			transaction: "transaction/{0}",
+			wallet: "account/{0}",
 		});
 	}
 }

--- a/packages/platform-sdk-eos/src/services/link.ts
+++ b/packages/platform-sdk-eos/src/services/link.ts
@@ -1,4 +1,4 @@
-import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
+import { Coins, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {

--- a/packages/platform-sdk-eth/src/services/link.ts
+++ b/packages/platform-sdk-eth/src/services/link.ts
@@ -2,10 +2,10 @@ import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(Helpers.randomHostFromConfig(config, "explorer"), {
-			block: (id: string) => `block/${id}`,
-			transaction: (id: string) => `tx/${id}`,
-			wallet: (id: string) => `address/${id}`,
+		return new LinkService(config, {
+			block: "block/{0}",
+			transaction: "tx/{0}",
+			wallet: "address/{0}",
 		});
 	}
 }

--- a/packages/platform-sdk-eth/src/services/link.ts
+++ b/packages/platform-sdk-eth/src/services/link.ts
@@ -1,4 +1,4 @@
-import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
+import { Coins, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {

--- a/packages/platform-sdk-lsk/src/services/link.ts
+++ b/packages/platform-sdk-lsk/src/services/link.ts
@@ -2,10 +2,10 @@ import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(Helpers.randomHostFromConfig(config, "explorer"), {
-			block: (id: string) => `block/${id}`,
-			transaction: (id: string) => `tx/${id}`,
-			wallet: (id: string) => `address/${id}`,
+		return new LinkService(config, {
+			block: "block/{0}",
+			transaction: "tx/{0}",
+			wallet: "address/{0}",
 		});
 	}
 }

--- a/packages/platform-sdk-lsk/src/services/link.ts
+++ b/packages/platform-sdk-lsk/src/services/link.ts
@@ -1,4 +1,4 @@
-import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
+import { Coins, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {

--- a/packages/platform-sdk-luna/src/services/link.ts
+++ b/packages/platform-sdk-luna/src/services/link.ts
@@ -1,4 +1,4 @@
-import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
+import { Coins, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {

--- a/packages/platform-sdk-luna/src/services/link.ts
+++ b/packages/platform-sdk-luna/src/services/link.ts
@@ -2,10 +2,10 @@ import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(Helpers.randomHostFromConfig(config, "explorer"), {
-			block: (id: string) => `blocks/${id}`,
-			transaction: (id: string) => `txs/${id}`,
-			wallet: (id: string) => `address/${id}`,
+		return new LinkService(config, {
+			block: "blocks/{0}",
+			transaction: "txs/{0}",
+			wallet: "address/{0}",
 		});
 	}
 }

--- a/packages/platform-sdk-nano/src/services/link.ts
+++ b/packages/platform-sdk-nano/src/services/link.ts
@@ -1,4 +1,4 @@
-import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
+import { Coins, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {

--- a/packages/platform-sdk-nano/src/services/link.ts
+++ b/packages/platform-sdk-nano/src/services/link.ts
@@ -2,10 +2,10 @@ import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(Helpers.randomHostFromConfig(config, "explorer"), {
-			block: (id: string) => `explorer/block/${id}`,
-			transaction: (id: string) => `explorer/block/${id}`,
-			wallet: (id: string) => `explorer/account/${id}`,
+		return new LinkService(config, {
+			block: "explorer/block/{0}",
+			transaction: "explorer/block/{0}",
+			wallet: "explorer/account/{0}",
 		});
 	}
 }

--- a/packages/platform-sdk-neo/src/services/link.ts
+++ b/packages/platform-sdk-neo/src/services/link.ts
@@ -1,4 +1,4 @@
-import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
+import { Coins, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {

--- a/packages/platform-sdk-neo/src/services/link.ts
+++ b/packages/platform-sdk-neo/src/services/link.ts
@@ -2,10 +2,10 @@ import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(Helpers.randomHostFromConfig(config, "explorer"), {
-			block: (id: string) => `block/height/${id}`,
-			transaction: (id: string) => `tx/${id}`,
-			wallet: (id: string) => `address/${id}`,
+		return new LinkService(config, {
+			block: "block/height/{0}",
+			transaction: "tx/{0}",
+			wallet: "address/{0}",
 		});
 	}
 }

--- a/packages/platform-sdk-profiles/src/drivers/memory/wallets/__snapshots__/wallet.test.ts.snap
+++ b/packages/platform-sdk-profiles/src/drivers/memory/wallets/__snapshots__/wallet.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`should have a network 1`] = `
 Object {
-  "coin": "DARK",
+  "coin": "ARK",
   "constants": Object {
     "slip44": 1,
   },

--- a/packages/platform-sdk-profiles/src/environment/__snapshots__/env.test.ts.snap
+++ b/packages/platform-sdk-profiles/src/environment/__snapshots__/env.test.ts.snap
@@ -162,7 +162,7 @@ Object {
 
 exports[`should have available networks 2`] = `
 Object {
-  "coin": "DARK",
+  "coin": "ARK",
   "constants": Object {
     "slip44": 1,
   },

--- a/packages/platform-sdk-sol/src/services/link.ts
+++ b/packages/platform-sdk-sol/src/services/link.ts
@@ -2,10 +2,10 @@ import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(Helpers.randomHostFromConfig(config, "explorer"), {
-			block: (id: string) => `block/${id}`,
-			transaction: (id: string) => `tx/${id}`,
-			wallet: (id: string) => `address/${id}`,
+		return new LinkService(config, {
+			block: "block/{0}",
+			transaction: "tx/{0}",
+			wallet: "address/{0}",
 		});
 	}
 }

--- a/packages/platform-sdk-sol/src/services/link.ts
+++ b/packages/platform-sdk-sol/src/services/link.ts
@@ -1,4 +1,4 @@
-import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
+import { Coins, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {

--- a/packages/platform-sdk-trx/src/services/link.ts
+++ b/packages/platform-sdk-trx/src/services/link.ts
@@ -1,4 +1,4 @@
-import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
+import { Coins, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {

--- a/packages/platform-sdk-trx/src/services/link.ts
+++ b/packages/platform-sdk-trx/src/services/link.ts
@@ -2,10 +2,10 @@ import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(Helpers.randomHostFromConfig(config, "explorer"), {
-			block: (id: string) => `block/${id}`,
-			transaction: (id: string) => `transaction/${id}`,
-			wallet: (id: string) => `address/${id}`,
+		return new LinkService(config, {
+			block: "block/{0}",
+			transaction: "transaction/{0}",
+			wallet: "address/{0}",
 		});
 	}
 }

--- a/packages/platform-sdk-xlm/src/services/link.ts
+++ b/packages/platform-sdk-xlm/src/services/link.ts
@@ -1,4 +1,4 @@
-import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
+import { Coins, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {

--- a/packages/platform-sdk-xlm/src/services/link.ts
+++ b/packages/platform-sdk-xlm/src/services/link.ts
@@ -2,10 +2,10 @@ import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(Helpers.randomHostFromConfig(config, "explorer"), {
-			block: (id: string) => `ledger/${id}`,
-			transaction: (id: string) => `tx/${id}`,
-			wallet: (id: string) => `account/${id}`,
+		return new LinkService(config, {
+			block: "ledger/{0}",
+			transaction: "tx/{0}",
+			wallet: "account/{0}",
 		});
 	}
 }

--- a/packages/platform-sdk-xrp/src/services/link.ts
+++ b/packages/platform-sdk-xrp/src/services/link.ts
@@ -1,4 +1,4 @@
-import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
+import { Coins, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {

--- a/packages/platform-sdk-xrp/src/services/link.ts
+++ b/packages/platform-sdk-xrp/src/services/link.ts
@@ -2,10 +2,10 @@ import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(Helpers.randomHostFromConfig(config, "explorer"), {
-			block: (id: string) => `ledgers/${id}`,
-			transaction: (id: string) => `transactions/${id}`,
-			wallet: (id: string) => `accounts/${id}`,
+		return new LinkService(config, {
+			block: "ledgers/{0}",
+			transaction: "transactions/{0}",
+			wallet: "accounts/{0}",
 		});
 	}
 }

--- a/packages/platform-sdk-zil/src/services/link.ts
+++ b/packages/platform-sdk-zil/src/services/link.ts
@@ -2,10 +2,10 @@ import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {
-		return new LinkService(Helpers.randomHostFromConfig(config, "explorer"), {
-			block: (id: string) => `block/${id}`,
-			transaction: (id: string) => `tx/${id}`,
-			wallet: (id: string) => `address/${id}`,
+		return new LinkService(config, {
+			block: "block/{0}",
+			transaction: "tx/{0}",
+			wallet: "address/{0}",
 		});
 	}
 }

--- a/packages/platform-sdk-zil/src/services/link.ts
+++ b/packages/platform-sdk-zil/src/services/link.ts
@@ -1,4 +1,4 @@
-import { Coins, Helpers, Services } from "@arkecosystem/platform-sdk";
+import { Coins, Services } from "@arkecosystem/platform-sdk";
 
 export class LinkService extends Services.AbstractLinkService {
 	public static async __construct(config: Coins.Config): Promise<LinkService> {

--- a/packages/platform-sdk/package.json
+++ b/packages/platform-sdk/package.json
@@ -37,7 +37,8 @@
 		"dot-prop": "^6.0.0",
 		"joi": "^17.4.0",
 		"node-emoji": "^1.10.0",
-		"type-fest": "^1.0.2"
+		"type-fest": "^1.0.2",
+		"@arkecosystem/utils": "^1.3.0"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^1.0.2",

--- a/packages/platform-sdk/src/services/link.ts
+++ b/packages/platform-sdk/src/services/link.ts
@@ -1,22 +1,24 @@
 /* istanbul ignore file */
 
+import { formatString } from "@arkecosystem/utils";
 import { URL } from "url";
 
-import { NetworkHost } from "../coins";
+import { Config, NetworkHost } from "../coins";
 import { LinkService } from "../contracts/coins";
+import { randomHostFromConfig } from "../helpers";
 
 export interface LinkServiceSchema {
-	block: (id: string) => string;
-	transaction: (id: string) => string;
-	wallet: (id: string) => string;
+	block: string;
+	transaction: string;
+	wallet: string;
 }
 
 export abstract class AbstractLinkService implements LinkService {
 	readonly #host: NetworkHost;
 	readonly #schema: LinkServiceSchema;
 
-	public constructor(host: NetworkHost, schema: LinkServiceSchema) {
-		this.#host = host;
+	public constructor(config: Config, schema: LinkServiceSchema) {
+		this.#host = randomHostFromConfig(config, "explorer");
 		this.#schema = schema;
 	}
 
@@ -25,19 +27,19 @@ export abstract class AbstractLinkService implements LinkService {
 	}
 
 	public block(id: string): string {
-		return this.buildURL(this.#schema.block(id));
+		return this.buildURL(this.#schema.block, id);
 	}
 
 	public transaction(id: string): string {
-		return this.buildURL(this.#schema.transaction(id));
+		return this.buildURL(this.#schema.transaction, id);
 	}
 
 	public wallet(id: string): string {
-		return this.buildURL(this.#schema.wallet(id));
+		return this.buildURL(this.#schema.wallet, id);
 	}
 
-	private buildURL(schema: string): string {
-		const url: URL = new URL(schema, this.#host.host);
+	private buildURL(schema: string, id: string): string {
+		const url: URL = new URL(formatString(schema, id), this.#host.host);
 
 		if (this.#host.query) {
 			url.search = new URLSearchParams(this.#host.query).toString();


### PR DESCRIPTION
Use string formatting instead of templates to reduce duplication even further.