### PR TITLE
feat(support): add `BigNumber#sum` method

### DIFF
--- a/packages/platform-sdk-support/src/bignumber.test.ts
+++ b/packages/platform-sdk-support/src/bignumber.test.ts
@@ -28,6 +28,10 @@ test("#times", () => {
 	expect(BigNumber.make(10).times(2).valueOf()).toBe("20");
 });
 
+test("#sum", () => {
+	expect(BigNumber.sum([BigNumber.ONE, 1, "2", 3.0, 5]).valueOf()).toBe("12");
+});
+
 test("#isNaN", () => {
 	expect(BigNumber.make(NaN).isNaN()).toBeTrue();
 	expect(subject.isNaN()).toBeFalse();

--- a/packages/platform-sdk-support/src/bignumber.ts
+++ b/packages/platform-sdk-support/src/bignumber.ts
@@ -141,7 +141,7 @@ export class BigNumber {
 	 * @memberof BigNumber
 	 */
 	public static sum(values: NumberLike[]): BigNumber {
-		return values.reduce((accumulator: BigNumber, currentValue: NumberLike) => carry.plus(value), BigNumber.ZERO);
+		return values.reduce((accumulator: BigNumber, currentValue: NumberLike) => accumulator.plus(currentValue), BigNumber.ZERO);
 	}
 
 	/**

--- a/packages/platform-sdk-support/src/bignumber.ts
+++ b/packages/platform-sdk-support/src/bignumber.ts
@@ -137,7 +137,7 @@ export class BigNumber {
 	 * Returns the sum of the different values.
 	 *
 	 * @param {NumberLike[]} values
-	 * @returns {string}
+	 * @returns {BigNumber}
 	 * @memberof BigNumber
 	 */
 	public static sum(values: NumberLike[]): BigNumber {

--- a/packages/platform-sdk-support/src/bignumber.ts
+++ b/packages/platform-sdk-support/src/bignumber.ts
@@ -134,6 +134,17 @@ export class BigNumber {
 	}
 
 	/**
+	 * Returns the sum of the different values.
+	 *
+	 * @param {NumberLike[]} values
+	 * @returns {string}
+	 * @memberof BigNumber
+	 */
+	public static sum(values: NumberLike[]): BigNumber {
+		return values.reduce((carry: BigNumber, value) => carry.plus(value), BigNumber.ZERO);
+	}
+
+	/**
 	 * Determines if the current value is NaN.
 	 *
 	 * @returns {boolean}

--- a/packages/platform-sdk-support/src/bignumber.ts
+++ b/packages/platform-sdk-support/src/bignumber.ts
@@ -141,7 +141,7 @@ export class BigNumber {
 	 * @memberof BigNumber
 	 */
 	public static sum(values: NumberLike[]): BigNumber {
-		return values.reduce((carry: BigNumber, value) => carry.plus(value), BigNumber.ZERO);
+		return values.reduce((accumulator: BigNumber, currentValue: NumberLike) => carry.plus(value), BigNumber.ZERO);
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

Array#reduce is considered harmful when the underlying intent is simply to do a sum or a string concat.

https://betterprogramming.pub/think-again-before-you-use-array-reduce-28f785b5aea9

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
