### PR TITLE
refactor: introduce abstract identity services

### DIFF
--- a/packages/platform-sdk-ada/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-ada/src/services/identity/address-list.ts
@@ -3,7 +3,7 @@ import { Bip32PrivateKey } from "@emurgo/cardano-serialization-lib-nodejs";
 
 import { deriveAccountKey, deriveRootKey, deriveSpendKey, deriveChangeKey, deriveStakeKey } from "./shelley";
 
-export class ExtendedAddressService implements Contracts.ExtendedAddressService {
+export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		pageSize: number,

--- a/packages/platform-sdk-ada/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-ada/src/services/identity/address-list.ts
@@ -1,4 +1,4 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 import { Bip32PrivateKey } from "@emurgo/cardano-serialization-lib-nodejs";
 
 import { deriveAccountKey, deriveRootKey, deriveSpendKey, deriveChangeKey, deriveStakeKey } from "./shelley";

--- a/packages/platform-sdk-ada/src/services/identity/address.ts
+++ b/packages/platform-sdk-ada/src/services/identity/address.ts
@@ -1,12 +1,14 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { bech32 } from "bech32";
 
 import { addressFromAccountExtPublicKey, addressFromMnemonic } from "./shelley";
 
-export class AddressService implements Contracts.AddressService {
+export class AddressService extends Services.AbstractAddressService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -25,10 +27,6 @@ export class AddressService implements Contracts.AddressService {
 		};
 	}
 
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
 	public async fromPublicKey(
 		publicKey: string,
 		options?: Contracts.IdentityOptions,
@@ -41,21 +39,6 @@ export class AddressService implements Contracts.AddressService {
 				this.#config.get("network.meta.networkId"),
 			),
 		};
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-ada/src/services/identity/keys.ts
+++ b/packages/platform-sdk-ada/src/services/identity/keys.ts
@@ -1,8 +1,8 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { deriveAccountKey, deriveRootKey } from "./shelley";
 
-export class KeyPairService implements Contracts.KeyPairService {
+export class KeyPairService extends Services.AbstractKeyPairService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -21,17 +21,5 @@ export class KeyPairService implements Contracts.KeyPairService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-ada/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-ada/src/services/identity/private-key.ts
@@ -1,8 +1,8 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { KeyPairService } from "./keys";
 
-export class PrivateKeyService implements Contracts.PrivateKeyService {
+export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -18,13 +18,5 @@ export class PrivateKeyService implements Contracts.PrivateKeyService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-ada/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-ada/src/services/identity/public-key.ts
@@ -1,8 +1,8 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { KeyPairService } from "./keys";
 
-export class PublicKeyService implements Contracts.PublicKeyService {
+export class PublicKeyService extends Services.AbstractPublicKeyService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -14,17 +14,5 @@ export class PublicKeyService implements Contracts.PublicKeyService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-ada/src/services/identity/wif.ts
+++ b/packages/platform-sdk-ada/src/services/identity/wif.ts
@@ -1,18 +1,5 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
-export class WIFService implements Contracts.WIFService {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMnemonic");
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
-	}
+export class WIFService extends Services.AbstractWIFService {
+	//
 }

--- a/packages/platform-sdk-ark/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-ark/src/services/identity/address-list.ts
@@ -1,17 +1,5 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 
 export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
-	public async fromMnemonic(
-		mnemonic: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
+	//
 }

--- a/packages/platform-sdk-ark/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-ark/src/services/identity/address-list.ts
@@ -1,6 +1,6 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
 
-export class ExtendedAddressService implements Contracts.ExtendedAddressService {
+export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		pageSize: number,

--- a/packages/platform-sdk-ark/src/services/identity/address.ts
+++ b/packages/platform-sdk-ark/src/services/identity/address.ts
@@ -4,10 +4,12 @@ import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { CryptoConfig } from "../../contracts";
 
 export class AddressService extends Services.AbstractAddressService {
-	readonly #configCrypto: CryptoConfig;
+	readonly #config: CryptoConfig;
 
-	public constructor(configCrypto: CryptoConfig) {
-		this.#configCrypto = configCrypto;
+	public constructor(config: CryptoConfig) {
+		super();
+
+		this.#config = config;
 	}
 
 	public async fromMnemonic(
@@ -16,7 +18,7 @@ export class AddressService extends Services.AbstractAddressService {
 	): Promise<Contracts.AddressDataTransferObject> {
 		try {
 			return {
-				address: BaseAddress.fromPassphrase(mnemonic, this.#configCrypto),
+				address: BaseAddress.fromPassphrase(mnemonic, this.#config),
 			};
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
@@ -26,7 +28,7 @@ export class AddressService extends Services.AbstractAddressService {
 	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.AddressDataTransferObject> {
 		try {
 			return {
-				address: BaseAddress.fromMultiSignatureAsset({ min, publicKeys }, this.#configCrypto),
+				address: BaseAddress.fromMultiSignatureAsset({ min, publicKeys }, this.#config),
 			};
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
@@ -39,7 +41,7 @@ export class AddressService extends Services.AbstractAddressService {
 	): Promise<Contracts.AddressDataTransferObject> {
 		try {
 			return {
-				address: BaseAddress.fromPublicKey(publicKey, this.#configCrypto),
+				address: BaseAddress.fromPublicKey(publicKey, this.#config),
 			};
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
@@ -52,7 +54,7 @@ export class AddressService extends Services.AbstractAddressService {
 	): Promise<Contracts.AddressDataTransferObject> {
 		try {
 			return {
-				address: BaseAddress.fromPrivateKey(Keys.fromPrivateKey(privateKey), this.#configCrypto),
+				address: BaseAddress.fromPrivateKey(Keys.fromPrivateKey(privateKey), this.#config),
 			};
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
@@ -62,7 +64,7 @@ export class AddressService extends Services.AbstractAddressService {
 	public async fromWIF(wif: string): Promise<Contracts.AddressDataTransferObject> {
 		try {
 			return {
-				address: BaseAddress.fromWIF(wif, this.#configCrypto),
+				address: BaseAddress.fromWIF(wif, this.#config),
 			};
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
@@ -71,7 +73,7 @@ export class AddressService extends Services.AbstractAddressService {
 
 	public async validate(address: string): Promise<boolean> {
 		try {
-			return BaseAddress.validate(address, this.#configCrypto);
+			return BaseAddress.validate(address, this.#config);
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}

--- a/packages/platform-sdk-ark/src/services/identity/address.ts
+++ b/packages/platform-sdk-ark/src/services/identity/address.ts
@@ -1,9 +1,9 @@
 import { Address as BaseAddress, Keys } from "@arkecosystem/crypto-identities";
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { CryptoConfig } from "../../contracts";
 
-export class AddressService implements Contracts.AddressService {
+export class AddressService extends Services.AbstractAddressService {
 	readonly #configCrypto: CryptoConfig;
 
 	public constructor(configCrypto: CryptoConfig) {
@@ -67,10 +67,6 @@ export class AddressService implements Contracts.AddressService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-ark/src/services/identity/keys.ts
+++ b/packages/platform-sdk-ark/src/services/identity/keys.ts
@@ -4,12 +4,12 @@ import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { CryptoConfig } from "../../contracts";
 
 export class KeyPairService extends Services.AbstractKeyPairService {
-	readonly #configCrypto: CryptoConfig;
+	readonly #config: CryptoConfig;
 
-	public constructor(configCrypto: CryptoConfig) {
+	public constructor(config: CryptoConfig) {
 		super();
 
-		this.#configCrypto = configCrypto;
+		this.#config = config;
 	}
 
 	public async fromMnemonic(
@@ -27,7 +27,7 @@ export class KeyPairService extends Services.AbstractKeyPairService {
 
 	public async fromWIF(wif: string): Promise<Contracts.KeyPairDataTransferObject> {
 		try {
-			const { publicKey, privateKey } = BaseKeys.fromWIF(wif, this.#configCrypto);
+			const { publicKey, privateKey } = BaseKeys.fromWIF(wif, this.#config);
 
 			return { publicKey, privateKey };
 		} catch (error) {

--- a/packages/platform-sdk-ark/src/services/identity/keys.ts
+++ b/packages/platform-sdk-ark/src/services/identity/keys.ts
@@ -1,12 +1,14 @@
 import { Keys as BaseKeys } from "@arkecosystem/crypto-identities";
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { CryptoConfig } from "../../contracts";
 
-export class KeyPairService implements Contracts.KeyPairService {
+export class KeyPairService extends Services.AbstractKeyPairService {
 	readonly #configCrypto: CryptoConfig;
 
 	public constructor(configCrypto: CryptoConfig) {
+		super();
+
 		this.#configCrypto = configCrypto;
 	}
 
@@ -23,10 +25,6 @@ export class KeyPairService implements Contracts.KeyPairService {
 		}
 	}
 
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
 	public async fromWIF(wif: string): Promise<Contracts.KeyPairDataTransferObject> {
 		try {
 			const { publicKey, privateKey } = BaseKeys.fromWIF(wif, this.#configCrypto);
@@ -35,9 +33,5 @@ export class KeyPairService implements Contracts.KeyPairService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-ark/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-ark/src/services/identity/private-key.ts
@@ -1,13 +1,15 @@
 import { PrivateKey as BasePrivateKey } from "@arkecosystem/crypto-identities";
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { CryptoConfig } from "../../contracts";
 
-export class PrivateKeyService implements Contracts.PrivateKeyService {
-	readonly #configCrypto: CryptoConfig;
+export class PrivateKeyService extends Services.AbstractPrivateKeyService {
+	readonly #config: CryptoConfig;
 
-	public constructor(configCrypto: CryptoConfig) {
-		this.#configCrypto = configCrypto;
+	public constructor(config: CryptoConfig) {
+		super();
+
+		this.#config = config;
 	}
 
 	public async fromMnemonic(
@@ -26,14 +28,10 @@ export class PrivateKeyService implements Contracts.PrivateKeyService {
 	public async fromWIF(wif: string): Promise<Contracts.PrivateKeyDataTransferObject> {
 		try {
 			return {
-				privateKey: BasePrivateKey.fromWIF(wif, this.#configCrypto),
+				privateKey: BasePrivateKey.fromWIF(wif, this.#config),
 			};
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-ark/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-ark/src/services/identity/public-key.ts
@@ -1,9 +1,9 @@
 import { PublicKey as BasePublicKey } from "@arkecosystem/crypto-identities";
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { CryptoConfig } from "../../contracts";
 
-export class PublicKeyService implements Contracts.PublicKeyService {
+export class PublicKeyService extends Services.AbstractPublicKeyService {
 	readonly #configCrypto: CryptoConfig;
 
 	public constructor(configCrypto: CryptoConfig) {
@@ -41,9 +41,5 @@ export class PublicKeyService implements Contracts.PublicKeyService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-ark/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-ark/src/services/identity/public-key.ts
@@ -4,10 +4,12 @@ import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { CryptoConfig } from "../../contracts";
 
 export class PublicKeyService extends Services.AbstractPublicKeyService {
-	readonly #configCrypto: CryptoConfig;
+	readonly #config: CryptoConfig;
 
-	public constructor(configCrypto: CryptoConfig) {
-		this.#configCrypto = configCrypto;
+	public constructor(config: CryptoConfig) {
+		super();
+
+		this.#config = config;
 	}
 
 	public async fromMnemonic(
@@ -36,7 +38,7 @@ export class PublicKeyService extends Services.AbstractPublicKeyService {
 	public async fromWIF(wif: string): Promise<Contracts.PublicKeyDataTransferObject> {
 		try {
 			return {
-				publicKey: BasePublicKey.fromWIF(wif, this.#configCrypto),
+				publicKey: BasePublicKey.fromWIF(wif, this.#config),
 			};
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);

--- a/packages/platform-sdk-ark/src/services/identity/wif.ts
+++ b/packages/platform-sdk-ark/src/services/identity/wif.ts
@@ -1,13 +1,15 @@
 import { WIF as BaseWIF } from "@arkecosystem/crypto-identities";
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { CryptoConfig } from "../../contracts";
 
-export class WIFService implements Contracts.WIFService {
-	readonly #configCrypto: CryptoConfig;
+export class WIFService extends Services.AbstractWIFService {
+	readonly #config: CryptoConfig;
 
-	public constructor(configCrypto: CryptoConfig) {
-		this.#configCrypto = configCrypto;
+	public constructor(config: CryptoConfig) {
+		super();
+
+		this.#config = config;
 	}
 
 	public async fromMnemonic(
@@ -16,7 +18,7 @@ export class WIFService implements Contracts.WIFService {
 	): Promise<Contracts.WIFDataTransferObject> {
 		try {
 			return {
-				wif: BaseWIF.fromPassphrase(mnemonic, this.#configCrypto),
+				wif: BaseWIF.fromPassphrase(mnemonic, this.#config),
 			};
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
@@ -27,14 +29,10 @@ export class WIFService implements Contracts.WIFService {
 		try {
 			return {
 				// @ts-ignore - We don't care about having a public key for this
-				wif: BaseWIF.fromKeys({ privateKey, compressed: true }, this.#configCrypto),
+				wif: BaseWIF.fromKeys({ privateKey, compressed: true }, this.#config),
 			};
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-atom/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-atom/src/services/identity/address-list.ts
@@ -1,17 +1,5 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 
 export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
-	public async fromMnemonic(
-		mnemonic: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
+	//
 }

--- a/packages/platform-sdk-atom/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-atom/src/services/identity/address-list.ts
@@ -1,6 +1,6 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
 
-export class ExtendedAddressService implements Contracts.ExtendedAddressService {
+export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		pageSize: number,

--- a/packages/platform-sdk-atom/src/services/identity/address.ts
+++ b/packages/platform-sdk-atom/src/services/identity/address.ts
@@ -1,11 +1,13 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP44 } from "@arkecosystem/platform-sdk-crypto";
 import { bech32 } from "bech32";
 
-export class AddressService implements Contracts.AddressService {
+export class AddressService extends Services.AbstractAddressService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -25,32 +27,6 @@ export class AddressService implements Contracts.AddressService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPublicKey");
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-atom/src/services/identity/keys.ts
+++ b/packages/platform-sdk-atom/src/services/identity/keys.ts
@@ -1,11 +1,13 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP44 } from "@arkecosystem/platform-sdk-crypto";
 import { secp256k1 } from "bcrypto";
 
-export class KeyPairService implements Contracts.KeyPairService {
+export class KeyPairService extends Services.AbstractKeyPairService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -30,17 +32,5 @@ export class KeyPairService implements Contracts.KeyPairService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-atom/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-atom/src/services/identity/private-key.ts
@@ -1,11 +1,13 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { KeyPairService } from "./keys";
 
-export class PrivateKeyService implements Contracts.PrivateKeyService {
+export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -25,13 +27,5 @@ export class PrivateKeyService implements Contracts.PrivateKeyService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-atom/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-atom/src/services/identity/public-key.ts
@@ -1,11 +1,13 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { KeyPairService } from "./keys";
 
-export class PublicKeyService implements Contracts.PublicKeyService {
+export class PublicKeyService extends Services.AbstractPublicKeyService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -25,17 +27,5 @@ export class PublicKeyService implements Contracts.PublicKeyService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-atom/src/services/identity/wif.ts
+++ b/packages/platform-sdk-atom/src/services/identity/wif.ts
@@ -1,18 +1,5 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
-export class WIFService implements Contracts.WIFService {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMnemonic");
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
-	}
+export class WIFService extends Services.AbstractWIFService {
+	//
 }

--- a/packages/platform-sdk-avax/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-avax/src/services/identity/address-list.ts
@@ -1,17 +1,5 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 
 export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
-	public async fromMnemonic(
-		mnemonic: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
+	//
 }

--- a/packages/platform-sdk-avax/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-avax/src/services/identity/address-list.ts
@@ -1,6 +1,6 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
 
-export class ExtendedAddressService implements Contracts.ExtendedAddressService {
+export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		pageSize: number,

--- a/packages/platform-sdk-avax/src/services/identity/address.ts
+++ b/packages/platform-sdk-avax/src/services/identity/address.ts
@@ -1,12 +1,14 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BinTools } from "avalanche";
 
 import { keyPairFromMnemonic, useKeychain } from "../helpers";
 
-export class AddressService implements Contracts.AddressService {
+export class AddressService extends Services.AbstractAddressService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -19,17 +21,6 @@ export class AddressService implements Contracts.AddressService {
 		};
 	}
 
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPublicKey");
-	}
-
 	public async fromPrivateKey(
 		privateKey: string,
 		options?: Contracts.IdentityOptions,
@@ -39,14 +30,6 @@ export class AddressService implements Contracts.AddressService {
 				.importKey(BinTools.getInstance().cb58Decode(privateKey))
 				.getAddressString(),
 		};
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-avax/src/services/identity/keys.ts
+++ b/packages/platform-sdk-avax/src/services/identity/keys.ts
@@ -1,12 +1,14 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BinTools } from "avalanche";
 
 import { cb58Encode, keyPairFromMnemonic, useKeychain } from "../helpers";
 
-export class KeyPairService implements Contracts.KeyPairService {
+export class KeyPairService extends Services.AbstractKeyPairService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -29,13 +31,5 @@ export class KeyPairService implements Contracts.KeyPairService {
 			publicKey: cb58Encode(keyPair.getPublicKey()),
 			privateKey: cb58Encode(keyPair.getPrivateKey()),
 		};
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-avax/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-avax/src/services/identity/private-key.ts
@@ -1,11 +1,13 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { cb58Encode, keyPairFromMnemonic } from "../helpers";
 
-export class PrivateKeyService implements Contracts.PrivateKeyService {
+export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -16,13 +18,5 @@ export class PrivateKeyService implements Contracts.PrivateKeyService {
 		return {
 			privateKey: cb58Encode(keyPairFromMnemonic(this.#config, mnemonic).getPrivateKey()),
 		};
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-avax/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-avax/src/services/identity/public-key.ts
@@ -1,11 +1,13 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { cb58Encode, keyPairFromMnemonic } from "../helpers";
 
-export class PublicKeyService implements Contracts.PublicKeyService {
+export class PublicKeyService extends Services.AbstractPublicKeyService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -16,17 +18,5 @@ export class PublicKeyService implements Contracts.PublicKeyService {
 		return {
 			publicKey: cb58Encode(keyPairFromMnemonic(this.#config, mnemonic).getPublicKey()),
 		};
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-avax/src/services/identity/wif.ts
+++ b/packages/platform-sdk-avax/src/services/identity/wif.ts
@@ -1,18 +1,5 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
-export class WIFService implements Contracts.WIFService {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMnemonic");
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
-	}
+export class WIFService extends Services.AbstractWIFService {
+	//
 }

--- a/packages/platform-sdk-btc/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-btc/src/services/identity/address-list.ts
@@ -1,17 +1,5 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 
 export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
-	public async fromMnemonic(
-		mnemonic: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
+	//
 }

--- a/packages/platform-sdk-btc/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-btc/src/services/identity/address-list.ts
@@ -1,6 +1,6 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
 
-export class ExtendedAddressService implements Contracts.ExtendedAddressService {
+export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		pageSize: number,

--- a/packages/platform-sdk-btc/src/services/identity/address.ts
+++ b/packages/platform-sdk-btc/src/services/identity/address.ts
@@ -1,12 +1,14 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import Bitcoin from "bitcore-lib";
 
 import { bip44, bip49, bip84 } from "./utils";
 
-export class AddressService implements Contracts.AddressService {
+export class AddressService extends Services.AbstractAddressService {
 	readonly #network: Record<string, any>;
 
 	public constructor(network: string) {
+		super();
+
 		this.#network = Bitcoin.Networks[network];
 	}
 
@@ -93,10 +95,6 @@ export class AddressService implements Contracts.AddressService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-btc/src/services/identity/keys.ts
+++ b/packages/platform-sdk-btc/src/services/identity/keys.ts
@@ -1,8 +1,8 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP32 } from "@arkecosystem/platform-sdk-crypto";
 import { PrivateKey, PublicKey } from "bitcore-lib";
 
-export class KeyPairService implements Contracts.KeyPairService {
+export class KeyPairService extends Services.AbstractKeyPairService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -28,10 +28,6 @@ export class KeyPairService implements Contracts.KeyPairService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 
 	private normalize(privateKey: Buffer): Contracts.KeyPairDataTransferObject {

--- a/packages/platform-sdk-btc/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-btc/src/services/identity/private-key.ts
@@ -1,8 +1,8 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP32 } from "@arkecosystem/platform-sdk-crypto";
 import Bitcoin from "bitcore-lib";
 
-export class PrivateKeyService implements Contracts.PrivateKeyService {
+export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -26,9 +26,5 @@ export class PrivateKeyService implements Contracts.PrivateKeyService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-btc/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-btc/src/services/identity/public-key.ts
@@ -1,8 +1,8 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP32 } from "@arkecosystem/platform-sdk-crypto";
 import Bitcoin from "bitcore-lib";
 
-export class PublicKeyService implements Contracts.PublicKeyService {
+export class PublicKeyService extends Services.AbstractPublicKeyService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -14,19 +14,11 @@ export class PublicKeyService implements Contracts.PublicKeyService {
 		}
 	}
 
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
 	public async fromWIF(wif: string): Promise<Contracts.PublicKeyDataTransferObject> {
 		try {
 			return { publicKey: Bitcoin.PrivateKey.fromWIF(wif).toPublicKey().toString() };
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-btc/src/services/identity/utils.ts
+++ b/packages/platform-sdk-btc/src/services/identity/utils.ts
@@ -1,4 +1,4 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 import { BIP32 } from "@arkecosystem/platform-sdk-crypto";
 import * as bitcoin from "bitcoinjs-lib";
 import BIP84 from "bip84";

--- a/packages/platform-sdk-btc/src/services/identity/wif.ts
+++ b/packages/platform-sdk-btc/src/services/identity/wif.ts
@@ -1,7 +1,7 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP32 } from "@arkecosystem/platform-sdk-crypto";
 
-export class WIFService implements Contracts.WIFService {
+export class WIFService extends Services.AbstractWIFService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -11,13 +11,5 @@ export class WIFService implements Contracts.WIFService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-dot/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-dot/src/services/identity/address-list.ts
@@ -1,17 +1,5 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 
 export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
-	public async fromMnemonic(
-		mnemonic: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
+	//
 }

--- a/packages/platform-sdk-dot/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-dot/src/services/identity/address-list.ts
@@ -1,6 +1,6 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
 
-export class ExtendedAddressService implements Contracts.ExtendedAddressService {
+export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		pageSize: number,

--- a/packages/platform-sdk-dot/src/services/identity/address.ts
+++ b/packages/platform-sdk-dot/src/services/identity/address.ts
@@ -1,12 +1,14 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { decodeAddress, encodeAddress, Keyring } from "@polkadot/keyring";
 import { hexToU8a, isHex } from "@polkadot/util";
 import { createKeyMulti } from "@polkadot/util-crypto";
 
-export class AddressService implements Contracts.AddressService {
+export class AddressService extends Services.AbstractAddressService {
 	readonly #keyring: Keyring;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#keyring = new Keyring({ type: "sr25519" });
 		this.#keyring.setSS58Format(config.get("network.meta.networkId"));
 	}
@@ -20,28 +22,6 @@ export class AddressService implements Contracts.AddressService {
 
 	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.AddressDataTransferObject> {
 		return { address: encodeAddress(createKeyMulti(publicKeys, min), 0) };
-	}
-
-	public async fromPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPublicKey");
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-dot/src/services/identity/keys.ts
+++ b/packages/platform-sdk-dot/src/services/identity/keys.ts
@@ -1,8 +1,8 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { u8aToHex } from "@polkadot/util";
 import { mnemonicToMiniSecret, naclKeypairFromSeed } from "@polkadot/util-crypto";
 
-export class KeyPairService implements Contracts.KeyPairService {
+export class KeyPairService extends Services.AbstractKeyPairService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -10,17 +10,5 @@ export class KeyPairService implements Contracts.KeyPairService {
 		const { publicKey, secretKey } = naclKeypairFromSeed(mnemonicToMiniSecret(mnemonic));
 
 		return { publicKey: u8aToHex(publicKey), privateKey: u8aToHex(secretKey) };
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-dot/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-dot/src/services/identity/private-key.ts
@@ -1,20 +1,12 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { u8aToHex } from "@polkadot/util";
 import { mnemonicToMiniSecret, naclKeypairFromSeed } from "@polkadot/util-crypto";
 
-export class PrivateKeyService implements Contracts.PrivateKeyService {
+export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
 	): Promise<Contracts.PrivateKeyDataTransferObject> {
 		return { privateKey: u8aToHex(naclKeypairFromSeed(mnemonicToMiniSecret(mnemonic)).secretKey) };
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-dot/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-dot/src/services/identity/public-key.ts
@@ -1,24 +1,12 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { u8aToHex } from "@polkadot/util";
 import { mnemonicToMiniSecret, naclKeypairFromSeed } from "@polkadot/util-crypto";
 
-export class PublicKeyService implements Contracts.PublicKeyService {
+export class PublicKeyService extends Services.AbstractPublicKeyService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
 	): Promise<Contracts.PublicKeyDataTransferObject> {
 		return { publicKey: u8aToHex(naclKeypairFromSeed(mnemonicToMiniSecret(mnemonic)).publicKey) };
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-dot/src/services/identity/wif.ts
+++ b/packages/platform-sdk-dot/src/services/identity/wif.ts
@@ -1,18 +1,5 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
-export class WIFService implements Contracts.WIFService {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMnemonic");
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
-	}
+export class WIFService extends Services.AbstractWIFService {
+	//
 }

--- a/packages/platform-sdk-egld/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-egld/src/services/identity/address-list.ts
@@ -1,17 +1,5 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 
 export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
-	public async fromMnemonic(
-		mnemonic: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
+	//
 }

--- a/packages/platform-sdk-egld/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-egld/src/services/identity/address-list.ts
@@ -1,6 +1,6 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
 
-export class ExtendedAddressService implements Contracts.ExtendedAddressService {
+export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		pageSize: number,

--- a/packages/platform-sdk-egld/src/services/identity/address.ts
+++ b/packages/platform-sdk-egld/src/services/identity/address.ts
@@ -1,9 +1,9 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { bech32 } from "bech32";
 
 import { makeAccount } from "../helpers";
 
-export class AddressService implements Contracts.AddressService {
+export class AddressService extends Services.AbstractAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -14,17 +14,6 @@ export class AddressService implements Contracts.AddressService {
 		return { address: account.address() };
 	}
 
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPublicKey");
-	}
-
 	public async fromPrivateKey(
 		privateKey: string,
 		options?: Contracts.IdentityOptions,
@@ -33,14 +22,6 @@ export class AddressService implements Contracts.AddressService {
 		account.loadFromHexPrivateKey(privateKey);
 
 		return { address: account.address() };
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-egld/src/services/identity/keys.ts
+++ b/packages/platform-sdk-egld/src/services/identity/keys.ts
@@ -1,8 +1,8 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { makeAccount } from "../helpers";
 
-export class KeyPairService implements Contracts.KeyPairService {
+export class KeyPairService extends Services.AbstractKeyPairService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -24,13 +24,5 @@ export class KeyPairService implements Contracts.KeyPairService {
 			publicKey: account.publicKeyAsString(),
 			privateKey: account.privateKeyAsString(),
 		};
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-egld/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-egld/src/services/identity/private-key.ts
@@ -1,8 +1,8 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { makeAccount } from "../helpers";
 
-export class PrivateKeyService implements Contracts.PrivateKeyService {
+export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -11,13 +11,5 @@ export class PrivateKeyService implements Contracts.PrivateKeyService {
 		account.loadFromMnemonic(mnemonic);
 
 		return { privateKey: account.privateKeyAsString() };
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-egld/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-egld/src/services/identity/public-key.ts
@@ -1,8 +1,8 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { makeAccount } from "../helpers";
 
-export class PublicKeyService implements Contracts.PublicKeyService {
+export class PublicKeyService extends Services.AbstractPublicKeyService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -11,17 +11,5 @@ export class PublicKeyService implements Contracts.PublicKeyService {
 		account.loadFromMnemonic(mnemonic);
 
 		return { publicKey: account.publicKeyAsString() };
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-egld/src/services/identity/wif.ts
+++ b/packages/platform-sdk-egld/src/services/identity/wif.ts
@@ -1,18 +1,5 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
-export class WIFService implements Contracts.WIFService {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMnemonic");
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
-	}
+export class WIFService extends Services.AbstractWIFService {
+	//
 }

--- a/packages/platform-sdk-eos/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-eos/src/services/identity/address-list.ts
@@ -1,17 +1,5 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 
 export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
-	public async fromMnemonic(
-		mnemonic: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
+	//
 }

--- a/packages/platform-sdk-eos/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-eos/src/services/identity/address-list.ts
@@ -1,6 +1,6 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
 
-export class ExtendedAddressService implements Contracts.ExtendedAddressService {
+export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		pageSize: number,

--- a/packages/platform-sdk-eos/src/services/identity/address.ts
+++ b/packages/platform-sdk-eos/src/services/identity/address.ts
@@ -1,37 +1,11 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
-export class AddressService implements Contracts.AddressService {
+export class AddressService extends Services.AbstractAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
 	): Promise<Contracts.AddressDataTransferObject> {
 		throw new Exceptions.NotSupported(this.constructor.name, "fromMnemonic");
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPublicKey");
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-eos/src/services/identity/keys.ts
+++ b/packages/platform-sdk-eos/src/services/identity/keys.ts
@@ -1,22 +1,5 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
-export class KeyPairService implements Contracts.KeyPairService {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMnemonic");
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
-	}
+export class KeyPairService extends Services.AbstractKeyPairService {
+	//
 }

--- a/packages/platform-sdk-eos/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-eos/src/services/identity/private-key.ts
@@ -1,18 +1,10 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
-export class PrivateKeyService implements Contracts.PrivateKeyService {
+export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
 	): Promise<Contracts.PrivateKeyDataTransferObject> {
 		throw new Exceptions.NotSupported(this.constructor.name, "fromMnemonic");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-eos/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-eos/src/services/identity/public-key.ts
@@ -1,8 +1,8 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { privateToPublic } from "../../crypto";
 
-export class PublicKeyService implements Contracts.PublicKeyService {
+export class PublicKeyService extends Services.AbstractPublicKeyService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -12,17 +12,5 @@ export class PublicKeyService implements Contracts.PublicKeyService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-eos/src/services/identity/wif.ts
+++ b/packages/platform-sdk-eos/src/services/identity/wif.ts
@@ -1,18 +1,5 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
-export class WIFService implements Contracts.WIFService {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMnemonic");
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
-	}
+export class WIFService extends Services.AbstractWIFService {
+	//
 }

--- a/packages/platform-sdk-eth/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-eth/src/services/identity/address-list.ts
@@ -1,17 +1,5 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 
 export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
-	public async fromMnemonic(
-		mnemonic: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
+	//
 }

--- a/packages/platform-sdk-eth/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-eth/src/services/identity/address-list.ts
@@ -1,6 +1,6 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
 
-export class ExtendedAddressService implements Contracts.ExtendedAddressService {
+export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		pageSize: number,

--- a/packages/platform-sdk-eth/src/services/identity/address.ts
+++ b/packages/platform-sdk-eth/src/services/identity/address.ts
@@ -1,13 +1,15 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { Buffoon } from "@arkecosystem/platform-sdk-crypto";
 import Wallet from "ethereumjs-wallet";
 
 import { createWallet, getAddress } from "./utils";
 
-export class AddressService implements Contracts.AddressService {
+export class AddressService extends Services.AbstractAddressService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -30,10 +32,6 @@ export class AddressService implements Contracts.AddressService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
 	}
 
 	public async fromPublicKey(
@@ -60,14 +58,6 @@ export class AddressService implements Contracts.AddressService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-eth/src/services/identity/keys.ts
+++ b/packages/platform-sdk-eth/src/services/identity/keys.ts
@@ -1,13 +1,15 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { Buffoon } from "@arkecosystem/platform-sdk-crypto";
 import Wallet from "ethereumjs-wallet";
 
 import { createWallet } from "./utils";
 
-export class KeyPairService implements Contracts.KeyPairService {
+export class KeyPairService extends Services.AbstractKeyPairService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -44,13 +46,5 @@ export class KeyPairService implements Contracts.KeyPairService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-eth/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-eth/src/services/identity/private-key.ts
@@ -1,11 +1,13 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { createWallet } from "./utils";
 
-export class PrivateKeyService implements Contracts.PrivateKeyService {
+export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -28,13 +30,5 @@ export class PrivateKeyService implements Contracts.PrivateKeyService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-eth/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-eth/src/services/identity/public-key.ts
@@ -1,13 +1,15 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { Buffoon } from "@arkecosystem/platform-sdk-crypto";
 import Wallet from "ethereumjs-wallet";
 
 import { PrivateKeyService } from "./private-key";
 
-export class PublicKeyService implements Contracts.PublicKeyService {
+export class PublicKeyService extends Services.AbstractPublicKeyService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -23,17 +25,5 @@ export class PublicKeyService implements Contracts.PublicKeyService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-eth/src/services/identity/wif.ts
+++ b/packages/platform-sdk-eth/src/services/identity/wif.ts
@@ -1,18 +1,5 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
-export class WIFService implements Contracts.WIFService {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMnemonic");
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
-	}
+export class WIFService extends Services.AbstractWIFService {
+	//
 }

--- a/packages/platform-sdk-lsk/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-lsk/src/services/identity/address-list.ts
@@ -1,17 +1,5 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 
 export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
-	public async fromMnemonic(
-		mnemonic: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
+	//
 }

--- a/packages/platform-sdk-lsk/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-lsk/src/services/identity/address-list.ts
@@ -1,6 +1,6 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
 
-export class ExtendedAddressService implements Contracts.ExtendedAddressService {
+export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		pageSize: number,

--- a/packages/platform-sdk-lsk/src/services/identity/address.ts
+++ b/packages/platform-sdk-lsk/src/services/identity/address.ts
@@ -1,8 +1,8 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import * as cryptography from "@liskhq/lisk-cryptography";
 import * as transactions from "@liskhq/lisk-transactions";
 
-export class AddressService implements Contracts.AddressService {
+export class AddressService extends Services.AbstractAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -14,10 +14,6 @@ export class AddressService implements Contracts.AddressService {
 		}
 	}
 
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
 	public async fromPublicKey(
 		publicKey: string,
 		options?: Contracts.IdentityOptions,
@@ -27,21 +23,6 @@ export class AddressService implements Contracts.AddressService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-lsk/src/services/identity/keys.ts
+++ b/packages/platform-sdk-lsk/src/services/identity/keys.ts
@@ -1,7 +1,7 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import * as cryptography from "@liskhq/lisk-cryptography";
 
-export class KeyPairService implements Contracts.KeyPairService {
+export class KeyPairService extends Services.AbstractKeyPairService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -13,17 +13,5 @@ export class KeyPairService implements Contracts.KeyPairService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-lsk/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-lsk/src/services/identity/private-key.ts
@@ -1,7 +1,7 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import * as cryptography from "@liskhq/lisk-cryptography";
 
-export class PrivateKeyService implements Contracts.PrivateKeyService {
+export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -13,13 +13,5 @@ export class PrivateKeyService implements Contracts.PrivateKeyService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-lsk/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-lsk/src/services/identity/public-key.ts
@@ -1,7 +1,7 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import * as cryptography from "@liskhq/lisk-cryptography";
 
-export class PublicKeyService implements Contracts.PublicKeyService {
+export class PublicKeyService extends Services.AbstractPublicKeyService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -13,17 +13,5 @@ export class PublicKeyService implements Contracts.PublicKeyService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-lsk/src/services/identity/wif.ts
+++ b/packages/platform-sdk-lsk/src/services/identity/wif.ts
@@ -1,18 +1,5 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
-export class WIFService implements Contracts.WIFService {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMnemonic");
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
-	}
+export class WIFService extends Services.AbstractWIFService {
+	//
 }

--- a/packages/platform-sdk-luna/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-luna/src/services/identity/address-list.ts
@@ -1,17 +1,5 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 
 export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
-	public async fromMnemonic(
-		mnemonic: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
+	//
 }

--- a/packages/platform-sdk-luna/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-luna/src/services/identity/address-list.ts
@@ -1,6 +1,6 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
 
-export class ExtendedAddressService implements Contracts.ExtendedAddressService {
+export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		pageSize: number,

--- a/packages/platform-sdk-luna/src/services/identity/address.ts
+++ b/packages/platform-sdk-luna/src/services/identity/address.ts
@@ -1,39 +1,13 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { deriveKey } from "./helpers";
 
-export class AddressService implements Contracts.AddressService {
+export class AddressService extends Services.AbstractAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
 	): Promise<Contracts.AddressDataTransferObject> {
 		return { address: deriveKey(mnemonic).accAddress };
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPublicKey");
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-luna/src/services/identity/keys.ts
+++ b/packages/platform-sdk-luna/src/services/identity/keys.ts
@@ -1,7 +1,7 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { deriveKey } from "./helpers";
 
-export class KeyPairService implements Contracts.KeyPairService {
+export class KeyPairService extends Services.AbstractKeyPairService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -16,17 +16,5 @@ export class KeyPairService implements Contracts.KeyPairService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-luna/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-luna/src/services/identity/private-key.ts
@@ -1,7 +1,7 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { deriveKey } from "./helpers";
 
-export class PrivateKeyService implements Contracts.PrivateKeyService {
+export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -11,13 +11,5 @@ export class PrivateKeyService implements Contracts.PrivateKeyService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-luna/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-luna/src/services/identity/public-key.ts
@@ -1,7 +1,7 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { deriveKey } from "./helpers";
 
-export class PublicKeyService implements Contracts.PublicKeyService {
+export class PublicKeyService extends Services.AbstractPublicKeyService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -11,17 +11,5 @@ export class PublicKeyService implements Contracts.PublicKeyService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-luna/src/services/identity/wif.ts
+++ b/packages/platform-sdk-luna/src/services/identity/wif.ts
@@ -1,18 +1,5 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
-export class WIFService implements Contracts.WIFService {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMnemonic");
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
-	}
+export class WIFService extends Services.AbstractWIFService {
+	//
 }

--- a/packages/platform-sdk-nano/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-nano/src/services/identity/address-list.ts
@@ -1,17 +1,5 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 
 export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
-	public async fromMnemonic(
-		mnemonic: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
+	//
 }

--- a/packages/platform-sdk-nano/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-nano/src/services/identity/address-list.ts
@@ -1,6 +1,6 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
 
-export class ExtendedAddressService implements Contracts.ExtendedAddressService {
+export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		pageSize: number,

--- a/packages/platform-sdk-nano/src/services/identity/address.ts
+++ b/packages/platform-sdk-nano/src/services/identity/address.ts
@@ -1,10 +1,10 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import * as nanocurrency from "nanocurrency";
 import { tools } from "nanocurrency-web";
 
 import { deriveAccount } from "./helpers";
 
-export class AddressService implements Contracts.AddressService {
+export class AddressService extends Services.AbstractAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -12,10 +12,6 @@ export class AddressService implements Contracts.AddressService {
 		return {
 			address: deriveAccount(mnemonic, options?.bip44?.account).address,
 		};
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
 	}
 
 	public async fromPublicKey(
@@ -34,14 +30,6 @@ export class AddressService implements Contracts.AddressService {
 		return {
 			address: nanocurrency.deriveAddress(nanocurrency.derivePublicKey(privateKey)),
 		};
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-nano/src/services/identity/keys.ts
+++ b/packages/platform-sdk-nano/src/services/identity/keys.ts
@@ -1,7 +1,7 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { deriveAccount } from "./helpers";
 
-export class KeyPairService implements Contracts.KeyPairService {
+export class KeyPairService extends Services.AbstractKeyPairService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -13,17 +13,5 @@ export class KeyPairService implements Contracts.KeyPairService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-nano/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-nano/src/services/identity/private-key.ts
@@ -1,7 +1,7 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { deriveAccount } from "./helpers";
 
-export class PrivateKeyService implements Contracts.PrivateKeyService {
+export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -9,13 +9,5 @@ export class PrivateKeyService implements Contracts.PrivateKeyService {
 		return {
 			privateKey: deriveAccount(mnemonic, options?.bip44?.account).privateKey,
 		};
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-nano/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-nano/src/services/identity/public-key.ts
@@ -1,7 +1,7 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { deriveAccount } from "./helpers";
 
-export class PublicKeyService implements Contracts.PublicKeyService {
+export class PublicKeyService extends Services.AbstractPublicKeyService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -9,17 +9,5 @@ export class PublicKeyService implements Contracts.PublicKeyService {
 		return {
 			publicKey: deriveAccount(mnemonic, options?.bip44?.account).publicKey,
 		};
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-nano/src/services/identity/wif.ts
+++ b/packages/platform-sdk-nano/src/services/identity/wif.ts
@@ -1,18 +1,5 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
-export class WIFService implements Contracts.WIFService {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMnemonic");
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
-	}
+export class WIFService extends Services.AbstractWIFService {
+	//
 }

--- a/packages/platform-sdk-nano/src/services/transaction.ts
+++ b/packages/platform-sdk-nano/src/services/transaction.ts
@@ -36,7 +36,7 @@ export class TransactionService implements Contracts.TransactionService {
 			toAddress: input.data.to,
 			representativeAddress: representative,
 			frontier,
-			amountRaw: tools.convert(input.data.amount, 'NANO', 'RAW'),
+			amountRaw: tools.convert(input.data.amount, "NANO", "RAW"),
 			work: (await computeWork(frontier))!,
 		};
 		const signedData = { ...data, timestamp: DateTime.make() };

--- a/packages/platform-sdk-neo/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-neo/src/services/identity/address-list.ts
@@ -1,17 +1,5 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 
 export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
-	public async fromMnemonic(
-		mnemonic: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
+	//
 }

--- a/packages/platform-sdk-neo/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-neo/src/services/identity/address-list.ts
@@ -1,6 +1,6 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
 
-export class ExtendedAddressService implements Contracts.ExtendedAddressService {
+export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		pageSize: number,

--- a/packages/platform-sdk-neo/src/services/identity/address.ts
+++ b/packages/platform-sdk-neo/src/services/identity/address.ts
@@ -1,11 +1,13 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { createWallet, deriveWallet } from "./utils";
 
-export class AddressService implements Contracts.AddressService {
+export class AddressService extends Services.AbstractAddressService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -26,10 +28,6 @@ export class AddressService implements Contracts.AddressService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
 	}
 
 	public async fromPublicKey(
@@ -66,10 +64,6 @@ export class AddressService implements Contracts.AddressService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-neo/src/services/identity/keys.ts
+++ b/packages/platform-sdk-neo/src/services/identity/keys.ts
@@ -1,11 +1,13 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { deriveKeyPair, deriveWallet } from "./utils";
 
-export class KeyPairService implements Contracts.KeyPairService {
+export class KeyPairService extends Services.AbstractKeyPairService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -42,9 +44,5 @@ export class KeyPairService implements Contracts.KeyPairService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-neo/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-neo/src/services/identity/private-key.ts
@@ -1,11 +1,13 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { createWallet, deriveWallet } from "./utils";
 
-export class PrivateKeyService implements Contracts.PrivateKeyService {
+export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -36,9 +38,5 @@ export class PrivateKeyService implements Contracts.PrivateKeyService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-neo/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-neo/src/services/identity/public-key.ts
@@ -1,11 +1,13 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { createWallet, deriveWallet } from "./utils";
 
-export class PublicKeyService implements Contracts.PublicKeyService {
+export class PublicKeyService extends Services.AbstractPublicKeyService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -28,10 +30,6 @@ export class PublicKeyService implements Contracts.PublicKeyService {
 		}
 	}
 
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
 	public async fromWIF(wif: string): Promise<Contracts.PublicKeyDataTransferObject> {
 		try {
 			return {
@@ -40,9 +38,5 @@ export class PublicKeyService implements Contracts.PublicKeyService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-neo/src/services/identity/wif.ts
+++ b/packages/platform-sdk-neo/src/services/identity/wif.ts
@@ -1,11 +1,13 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
 import { deriveWallet } from "./utils";
 
-export class WIFService implements Contracts.WIFService {
+export class WIFService extends Services.AbstractWIFService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -26,13 +28,5 @@ export class WIFService implements Contracts.WIFService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-sol/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-sol/src/services/identity/address-list.ts
@@ -1,17 +1,5 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 
 export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
-	public async fromMnemonic(
-		mnemonic: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
+	//
 }

--- a/packages/platform-sdk-sol/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-sol/src/services/identity/address-list.ts
@@ -1,6 +1,6 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
 
-export class ExtendedAddressService implements Contracts.ExtendedAddressService {
+export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		pageSize: number,

--- a/packages/platform-sdk-sol/src/services/identity/address.ts
+++ b/packages/platform-sdk-sol/src/services/identity/address.ts
@@ -1,13 +1,15 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP39 } from "@arkecosystem/platform-sdk-crypto";
 import { base58 } from "bstring";
 
 import { derivePrivateKey, derivePublicKey } from "./helpers";
 
-export class AddressService implements Contracts.AddressService {
+export class AddressService extends Services.AbstractAddressService {
 	readonly #slip44: number;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#slip44 = config.get<number>("network.constants.slip44");
 	}
 
@@ -33,10 +35,6 @@ export class AddressService implements Contracts.AddressService {
 		};
 	}
 
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
 	public async fromPublicKey(
 		publicKey: string,
 		options?: Contracts.IdentityOptions,
@@ -53,14 +51,6 @@ export class AddressService implements Contracts.AddressService {
 		return {
 			address: base58.encode(derivePublicKey(Buffer.from(privateKey, "hex"))),
 		};
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-sol/src/services/identity/keys.ts
+++ b/packages/platform-sdk-sol/src/services/identity/keys.ts
@@ -1,12 +1,14 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP39 } from "@arkecosystem/platform-sdk-crypto";
 
 import { derivePrivateKey, derivePublicKey } from "./helpers";
 
-export class KeyPairService implements Contracts.KeyPairService {
+export class KeyPairService extends Services.AbstractKeyPairService {
 	readonly #slip44: number;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#slip44 = config.get<number>("network.constants.slip44");
 	}
 
@@ -38,13 +40,5 @@ export class KeyPairService implements Contracts.KeyPairService {
 			publicKey: derivePublicKey(privateBuffer).toString("hex"),
 			privateKey: privateBuffer.toString("hex"),
 		};
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-sol/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-sol/src/services/identity/private-key.ts
@@ -7,6 +7,8 @@ export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 	readonly #slip44: number;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#slip44 = config.get<number>("network.constants.slip44");
 	}
 

--- a/packages/platform-sdk-sol/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-sol/src/services/identity/private-key.ts
@@ -1,9 +1,9 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP39 } from "@arkecosystem/platform-sdk-crypto";
 
 import { derivePrivateKey } from "./helpers";
 
-export class PrivateKeyService implements Contracts.PrivateKeyService {
+export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 	readonly #slip44: number;
 
 	public constructor(config: Coins.Config) {
@@ -26,13 +26,5 @@ export class PrivateKeyService implements Contracts.PrivateKeyService {
 				this.#slip44,
 			).toString("hex"),
 		};
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-sol/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-sol/src/services/identity/public-key.ts
@@ -1,12 +1,14 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP39 } from "@arkecosystem/platform-sdk-crypto";
 
 import { derivePrivateKey, derivePublicKey } from "./helpers";
 
-export class PublicKeyService implements Contracts.PublicKeyService {
+export class PublicKeyService extends Services.AbstractPublicKeyService {
 	readonly #slip44: number;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#slip44 = config.get<number>("network.constants.slip44");
 	}
 
@@ -28,17 +30,5 @@ export class PublicKeyService implements Contracts.PublicKeyService {
 				),
 			).toString("hex"),
 		};
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-sol/src/services/identity/wif.ts
+++ b/packages/platform-sdk-sol/src/services/identity/wif.ts
@@ -1,18 +1,5 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
-export class WIFService implements Contracts.WIFService {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMnemonic");
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
-	}
+export class WIFService extends Services.AbstractWIFService {
+	//
 }

--- a/packages/platform-sdk-trx/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-trx/src/services/identity/address-list.ts
@@ -1,17 +1,5 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 
 export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
-	public async fromMnemonic(
-		mnemonic: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
+	//
 }

--- a/packages/platform-sdk-trx/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-trx/src/services/identity/address-list.ts
@@ -1,6 +1,6 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
 
-export class ExtendedAddressService implements Contracts.ExtendedAddressService {
+export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		pageSize: number,

--- a/packages/platform-sdk-trx/src/services/identity/address.ts
+++ b/packages/platform-sdk-trx/src/services/identity/address.ts
@@ -1,11 +1,13 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP44 } from "@arkecosystem/platform-sdk-crypto";
 import TronWeb from "tronweb";
 
-export class AddressService implements Contracts.AddressService {
+export class AddressService extends Services.AbstractAddressService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -21,32 +23,6 @@ export class AddressService implements Contracts.AddressService {
 				}).privateKey!.toString("hex"),
 			),
 		};
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPublicKey");
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-trx/src/services/identity/keys.ts
+++ b/packages/platform-sdk-trx/src/services/identity/keys.ts
@@ -1,10 +1,12 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP44 } from "@arkecosystem/platform-sdk-crypto";
 
-export class KeyPairService implements Contracts.KeyPairService {
+export class KeyPairService extends Services.AbstractKeyPairService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -21,17 +23,5 @@ export class KeyPairService implements Contracts.KeyPairService {
 			publicKey: publicKey.toString("hex"),
 			privateKey: privateKey!.toString("hex"),
 		};
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-trx/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-trx/src/services/identity/private-key.ts
@@ -1,10 +1,12 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP44 } from "@arkecosystem/platform-sdk-crypto";
 
-export class PrivateKeyService implements Contracts.PrivateKeyService {
+export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -18,13 +20,5 @@ export class PrivateKeyService implements Contracts.PrivateKeyService {
 				index: options?.bip44?.addressIndex,
 			}).privateKey!.toString("hex"),
 		};
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-trx/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-trx/src/services/identity/public-key.ts
@@ -1,10 +1,12 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP44 } from "@arkecosystem/platform-sdk-crypto";
 
-export class PublicKeyService implements Contracts.PublicKeyService {
+export class PublicKeyService extends Services.AbstractPublicKeyService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -18,17 +20,5 @@ export class PublicKeyService implements Contracts.PublicKeyService {
 				index: options?.bip44?.addressIndex,
 			}).publicKey.toString("hex"),
 		};
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-trx/src/services/identity/wif.ts
+++ b/packages/platform-sdk-trx/src/services/identity/wif.ts
@@ -1,10 +1,12 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP44 } from "@arkecosystem/platform-sdk-crypto";
 
-export class WIFService implements Contracts.WIFService {
+export class WIFService extends Services.AbstractWIFService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -22,13 +24,5 @@ export class WIFService implements Contracts.WIFService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-xlm/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-xlm/src/services/identity/address-list.ts
@@ -1,17 +1,5 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 
 export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
-	public async fromMnemonic(
-		mnemonic: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
+	//
 }

--- a/packages/platform-sdk-xlm/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-xlm/src/services/identity/address-list.ts
@@ -1,6 +1,6 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
 
-export class ExtendedAddressService implements Contracts.ExtendedAddressService {
+export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		pageSize: number,

--- a/packages/platform-sdk-xlm/src/services/identity/address.ts
+++ b/packages/platform-sdk-xlm/src/services/identity/address.ts
@@ -1,8 +1,8 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import StellarHDWallet from "stellar-hd-wallet";
 import Stellar from "stellar-sdk";
 
-export class AddressService implements Contracts.AddressService {
+export class AddressService extends Services.AbstractAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -16,17 +16,6 @@ export class AddressService implements Contracts.AddressService {
 		}
 	}
 
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPublicKey");
-	}
-
 	public async fromPrivateKey(
 		privateKey: string,
 		options?: Contracts.IdentityOptions,
@@ -38,14 +27,6 @@ export class AddressService implements Contracts.AddressService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-xlm/src/services/identity/keys.ts
+++ b/packages/platform-sdk-xlm/src/services/identity/keys.ts
@@ -1,9 +1,9 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP39 } from "@arkecosystem/platform-sdk-crypto";
 import StellarHDWallet from "stellar-hd-wallet";
 import Stellar from "stellar-sdk";
 
-export class KeyPairService implements Contracts.KeyPairService {
+export class KeyPairService extends Services.AbstractKeyPairService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -31,13 +31,5 @@ export class KeyPairService implements Contracts.KeyPairService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-xlm/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-xlm/src/services/identity/private-key.ts
@@ -1,7 +1,7 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import StellarHDWallet from "stellar-hd-wallet";
 
-export class PrivateKeyService implements Contracts.PrivateKeyService {
+export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -13,13 +13,5 @@ export class PrivateKeyService implements Contracts.PrivateKeyService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-xlm/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-xlm/src/services/identity/public-key.ts
@@ -1,7 +1,7 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import StellarHDWallet from "stellar-hd-wallet";
 
-export class PublicKeyService implements Contracts.PublicKeyService {
+export class PublicKeyService extends Services.AbstractPublicKeyService {
 	public async fromMnemonic(
 		mnemonic: string,
 		options?: Contracts.IdentityOptions,
@@ -13,17 +13,5 @@ export class PublicKeyService implements Contracts.PublicKeyService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-xlm/src/services/identity/wif.ts
+++ b/packages/platform-sdk-xlm/src/services/identity/wif.ts
@@ -1,18 +1,5 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
-export class WIFService implements Contracts.WIFService {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMnemonic");
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
-	}
+export class WIFService extends Services.AbstractWIFService {
+	//
 }

--- a/packages/platform-sdk-xrp/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-xrp/src/services/identity/address-list.ts
@@ -1,17 +1,5 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 
 export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
-	public async fromMnemonic(
-		mnemonic: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
+	//
 }

--- a/packages/platform-sdk-xrp/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-xrp/src/services/identity/address-list.ts
@@ -1,6 +1,6 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
 
-export class ExtendedAddressService implements Contracts.ExtendedAddressService {
+export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		pageSize: number,

--- a/packages/platform-sdk-xrp/src/services/identity/address.ts
+++ b/packages/platform-sdk-xrp/src/services/identity/address.ts
@@ -1,11 +1,13 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP44 } from "@arkecosystem/platform-sdk-crypto";
 import { deriveAddress, deriveKeypair } from "ripple-keypairs";
 
-export class AddressService implements Contracts.AddressService {
+export class AddressService extends Services.AbstractAddressService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -21,10 +23,6 @@ export class AddressService implements Contracts.AddressService {
 		);
 	}
 
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
 	public async fromPublicKey(
 		publicKey: string,
 		options?: Contracts.IdentityOptions,
@@ -34,21 +32,6 @@ export class AddressService implements Contracts.AddressService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.AddressDataTransferObject> {
-		return { address: deriveAddress(deriveKeypair(secret).publicKey) };
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-xrp/src/services/identity/keys.ts
+++ b/packages/platform-sdk-xrp/src/services/identity/keys.ts
@@ -1,11 +1,13 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP44 } from "@arkecosystem/platform-sdk-crypto";
 import { deriveKeypair } from "ripple-keypairs";
 
-export class KeyPairService implements Contracts.KeyPairService {
+export class KeyPairService extends Services.AbstractKeyPairService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -22,14 +24,6 @@ export class KeyPairService implements Contracts.KeyPairService {
 			publicKey: publicKey.toString("hex"),
 			privateKey: privateKey!.toString("hex"),
 		};
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
 	}
 
 	public async fromSecret(secret: string): Promise<Contracts.KeyPairDataTransferObject> {

--- a/packages/platform-sdk-xrp/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-xrp/src/services/identity/private-key.ts
@@ -1,11 +1,13 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP44 } from "@arkecosystem/platform-sdk-crypto";
 import { deriveKeypair } from "ripple-keypairs";
 
-export class PrivateKeyService implements Contracts.PrivateKeyService {
+export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -19,10 +21,6 @@ export class PrivateKeyService implements Contracts.PrivateKeyService {
 				index: options?.bip44?.addressIndex,
 			}).privateKey?.toString("hex")!,
 		};
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
 	}
 
 	public async fromSecret(secret: string): Promise<Contracts.PrivateKeyDataTransferObject> {

--- a/packages/platform-sdk-xrp/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-xrp/src/services/identity/public-key.ts
@@ -1,11 +1,13 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP44 } from "@arkecosystem/platform-sdk-crypto";
 import { deriveKeypair } from "ripple-keypairs";
 
-export class PublicKeyService implements Contracts.PublicKeyService {
+export class PublicKeyService extends Services.AbstractPublicKeyService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -19,14 +21,6 @@ export class PublicKeyService implements Contracts.PublicKeyService {
 				index: options?.bip44?.addressIndex,
 			}).publicKey.toString("hex"),
 		};
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
 	}
 
 	public async fromSecret(secret: string): Promise<Contracts.PublicKeyDataTransferObject> {

--- a/packages/platform-sdk-xrp/src/services/identity/wif.ts
+++ b/packages/platform-sdk-xrp/src/services/identity/wif.ts
@@ -1,10 +1,12 @@
-import { Coins, Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Coins, Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { BIP44 } from "@arkecosystem/platform-sdk-crypto";
 
-export class WIFService implements Contracts.WIFService {
+export class WIFService extends Services.AbstractWIFService {
 	readonly #config: Coins.Config;
 
 	public constructor(config: Coins.Config) {
+		super();
+
 		this.#config = config;
 	}
 
@@ -22,13 +24,5 @@ export class WIFService implements Contracts.WIFService {
 		} catch (error) {
 			throw new Exceptions.CryptoException(error);
 		}
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-zil/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-zil/src/services/identity/address-list.ts
@@ -1,4 +1,4 @@
-import { Contracts } from "@arkecosystem/platform-sdk";
+import { Contracts, Services } from "@arkecosystem/platform-sdk";
 
 export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(

--- a/packages/platform-sdk-zil/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-zil/src/services/identity/address-list.ts
@@ -1,17 +1,5 @@
 import { Contracts, Services } from "@arkecosystem/platform-sdk";
 
 export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
-	public async fromMnemonic(
-		mnemonic: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
-
-	public async fromPrivateKey(
-		privateKey: string,
-		pageSize: number,
-	): Promise<Contracts.ExtendedAddressDataTransferObject[]> {
-		return [];
-	}
+	//
 }

--- a/packages/platform-sdk-zil/src/services/identity/address-list.ts
+++ b/packages/platform-sdk-zil/src/services/identity/address-list.ts
@@ -1,6 +1,6 @@
 import { Contracts } from "@arkecosystem/platform-sdk";
 
-export class ExtendedAddressService implements Contracts.ExtendedAddressService {
+export class ExtendedAddressService extends Services.AbstractExtendedAddressService {
 	public async fromMnemonic(
 		mnemonic: string,
 		pageSize: number,

--- a/packages/platform-sdk-zil/src/services/identity/address.ts
+++ b/packages/platform-sdk-zil/src/services/identity/address.ts
@@ -1,13 +1,15 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { Wallet } from "@zilliqa-js/account";
 import { validation } from "@zilliqa-js/zilliqa";
 
 import { accountFromMnemonic, accountFromPrivateKey } from "../../zilliqa";
 
-export class AddressService implements Contracts.AddressService {
+export class AddressService extends Services.AbstractAddressService {
 	readonly #wallet: Wallet;
 
 	public constructor(wallet: Wallet) {
+		super();
+
 		this.#wallet = wallet;
 	}
 
@@ -20,17 +22,6 @@ export class AddressService implements Contracts.AddressService {
 		};
 	}
 
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, this.fromMultiSignature.name);
-	}
-
-	public async fromPublicKey(
-		publicKey: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, this.fromPublicKey.name);
-	}
-
 	public async fromPrivateKey(
 		privateKey: string,
 		options?: Contracts.IdentityOptions,
@@ -38,14 +29,6 @@ export class AddressService implements Contracts.AddressService {
 		return {
 			address: (await accountFromPrivateKey(this.#wallet, privateKey)).bech32Address,
 		};
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, this.fromWIF.name);
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-zil/src/services/identity/keys.ts
+++ b/packages/platform-sdk-zil/src/services/identity/keys.ts
@@ -1,11 +1,14 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { Wallet } from "@zilliqa-js/account";
+
 import { accountFromMnemonic, accountFromPrivateKey } from "../../zilliqa";
 
-export class KeyPairService implements Contracts.KeyPairService {
+export class KeyPairService extends Services.AbstractKeyPairService {
 	readonly #wallet: Wallet;
 
 	public constructor(wallet: Wallet) {
+		super();
+
 		this.#wallet = wallet;
 	}
 
@@ -22,13 +25,5 @@ export class KeyPairService implements Contracts.KeyPairService {
 		const { publicKey } = await accountFromPrivateKey(this.#wallet, privateKey);
 
 		return { publicKey, privateKey };
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.KeyPairDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-zil/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-zil/src/services/identity/private-key.ts
@@ -1,11 +1,13 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { Wallet } from "@zilliqa-js/account";
 import { accountFromMnemonic } from "../../zilliqa";
 
-export class PrivateKeyService implements Contracts.PrivateKeyService {
+export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 	readonly #wallet: Wallet;
 
 	public constructor(wallet: Wallet) {
+		super();
+
 		this.#wallet = wallet;
 	}
 
@@ -16,13 +18,5 @@ export class PrivateKeyService implements Contracts.PrivateKeyService {
 		return {
 			privateKey: (await accountFromMnemonic(this.#wallet, mnemonic, options)).privateKey,
 		};
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-zil/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-zil/src/services/identity/public-key.ts
@@ -1,11 +1,13 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 import { Wallet } from "@zilliqa-js/account";
 import { accountFromMnemonic } from "../../zilliqa";
 
-export class PublicKeyService implements Contracts.PublicKeyService {
+export class PublicKeyService extends Services.AbstractPublicKeyService {
 	readonly #wallet: Wallet;
 
 	public constructor(wallet: Wallet) {
+		super();
+
 		this.#wallet = wallet;
 	}
 
@@ -16,17 +18,5 @@ export class PublicKeyService implements Contracts.PublicKeyService {
 		return {
 			publicKey: (await accountFromMnemonic(this.#wallet, mnemonic, options)).publicKey,
 		};
-	}
-
-	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMultiSignature");
-	}
-
-	public async fromWIF(wif: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromWIF");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.PublicKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
 	}
 }

--- a/packages/platform-sdk-zil/src/services/identity/wif.ts
+++ b/packages/platform-sdk-zil/src/services/identity/wif.ts
@@ -1,18 +1,5 @@
-import { Contracts, Exceptions } from "@arkecosystem/platform-sdk";
+import { Contracts, Exceptions, Services } from "@arkecosystem/platform-sdk";
 
-export class WIFService implements Contracts.WIFService {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: Contracts.IdentityOptions,
-	): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMnemonic");
-	}
-
-	public async fromPrivateKey(privateKey: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromPrivateKey");
-	}
-
-	public async fromSecret(secret: string): Promise<Contracts.WIFDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromSecret");
-	}
+export class WIFService extends Services.AbstractWIFService {
+	//
 }

--- a/packages/platform-sdk/src/services/identity/address.ts
+++ b/packages/platform-sdk/src/services/identity/address.ts
@@ -4,10 +4,7 @@ import { IdentityOptions, AddressService as Contract, AddressDataTransferObject 
 import { NotSupported } from "../../exceptions";
 
 export abstract class AbstractAddressService implements Contract {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: IdentityOptions,
-	): Promise<AddressDataTransferObject> {
+	public async fromMnemonic(mnemonic: string, options?: IdentityOptions): Promise<AddressDataTransferObject> {
 		throw new NotSupported(this.constructor.name, "fromMultiSignature");
 	}
 
@@ -15,17 +12,11 @@ export abstract class AbstractAddressService implements Contract {
 		throw new NotSupported(this.constructor.name, "fromMultiSignature");
 	}
 
-	public async fromPublicKey(
-		publicKey: string,
-		options?: IdentityOptions,
-	): Promise<AddressDataTransferObject> {
+	public async fromPublicKey(publicKey: string, options?: IdentityOptions): Promise<AddressDataTransferObject> {
 		throw new NotSupported(this.constructor.name, "fromMultiSignature");
 	}
 
-	public async fromPrivateKey(
-		privateKey: string,
-		options?: IdentityOptions,
-	): Promise<AddressDataTransferObject> {
+	public async fromPrivateKey(privateKey: string, options?: IdentityOptions): Promise<AddressDataTransferObject> {
 		throw new NotSupported(this.constructor.name, "fromPrivateKey");
 	}
 

--- a/packages/platform-sdk/src/services/identity/address.ts
+++ b/packages/platform-sdk/src/services/identity/address.ts
@@ -1,0 +1,43 @@
+/* istanbul ignore file */
+
+import { IdentityOptions, AddressService as Contract, AddressDataTransferObject } from "../../contracts";
+import { NotSupported } from "../../exceptions";
+
+export abstract class AbstractAddressService implements Contract {
+	public async fromMnemonic(
+		mnemonic: string,
+		options?: IdentityOptions,
+	): Promise<AddressDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromMultiSignature");
+	}
+
+	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<AddressDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromMultiSignature");
+	}
+
+	public async fromPublicKey(
+		publicKey: string,
+		options?: IdentityOptions,
+	): Promise<AddressDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromMultiSignature");
+	}
+
+	public async fromPrivateKey(
+		privateKey: string,
+		options?: IdentityOptions,
+	): Promise<AddressDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromPrivateKey");
+	}
+
+	public async fromWIF(wif: string): Promise<AddressDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromWIF");
+	}
+
+	public async fromSecret(secret: string): Promise<AddressDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromSecret");
+	}
+
+	public async validate(address: string): Promise<boolean> {
+		throw new NotSupported(this.constructor.name, "fromMultiSignature");
+	}
+}

--- a/packages/platform-sdk/src/services/identity/extended-address.ts
+++ b/packages/platform-sdk/src/services/identity/extended-address.ts
@@ -1,0 +1,20 @@
+/* istanbul ignore file */
+
+import { IdentityOptions, ExtendedAddressService as Contract, ExtendedAddressDataTransferObject } from "../../contracts";
+import { NotSupported } from "../../exceptions";
+
+export abstract class AbstractExtendedAddressService implements Contract {
+	public async fromMnemonic(
+		mnemonic: string,
+		pageSize: number,
+	): Promise<ExtendedAddressDataTransferObject[]> {
+		throw new NotSupported(this.constructor.name, "fromMultiSignature");
+	}
+
+	public async fromPrivateKey(
+		privateKey: string,
+		pageSize: number,
+	): Promise<ExtendedAddressDataTransferObject[]> {
+		throw new NotSupported(this.constructor.name, "fromMultiSignature");
+	}
+}

--- a/packages/platform-sdk/src/services/identity/extended-address.ts
+++ b/packages/platform-sdk/src/services/identity/extended-address.ts
@@ -1,20 +1,18 @@
 /* istanbul ignore file */
 
-import { IdentityOptions, ExtendedAddressService as Contract, ExtendedAddressDataTransferObject } from "../../contracts";
+import {
+	IdentityOptions,
+	ExtendedAddressService as Contract,
+	ExtendedAddressDataTransferObject,
+} from "../../contracts";
 import { NotSupported } from "../../exceptions";
 
 export abstract class AbstractExtendedAddressService implements Contract {
-	public async fromMnemonic(
-		mnemonic: string,
-		pageSize: number,
-	): Promise<ExtendedAddressDataTransferObject[]> {
+	public async fromMnemonic(mnemonic: string, pageSize: number): Promise<ExtendedAddressDataTransferObject[]> {
 		throw new NotSupported(this.constructor.name, "fromMultiSignature");
 	}
 
-	public async fromPrivateKey(
-		privateKey: string,
-		pageSize: number,
-	): Promise<ExtendedAddressDataTransferObject[]> {
+	public async fromPrivateKey(privateKey: string, pageSize: number): Promise<ExtendedAddressDataTransferObject[]> {
 		throw new NotSupported(this.constructor.name, "fromMultiSignature");
 	}
 }

--- a/packages/platform-sdk/src/services/identity/identity.ts
+++ b/packages/platform-sdk/src/services/identity/identity.ts
@@ -8,7 +8,7 @@ import {
 	PrivateKeyService,
 	PublicKeyService,
 	WIFService,
-} from "../contracts";
+} from "../../contracts";
 
 interface Services {
 	address: AddressService;

--- a/packages/platform-sdk/src/services/identity/index.ts
+++ b/packages/platform-sdk/src/services/identity/index.ts
@@ -1,0 +1,7 @@
+export * from "./address";
+export * from "./extended-address";
+export * from "./identity";
+export * from "./keys";
+export * from "./private-key";
+export * from "./public-key";
+export * from "./wif";

--- a/packages/platform-sdk/src/services/identity/keys.ts
+++ b/packages/platform-sdk/src/services/identity/keys.ts
@@ -4,10 +4,7 @@ import { IdentityOptions, KeyPairService as Contract, KeyPairDataTransferObject 
 import { NotSupported } from "../../exceptions";
 
 export abstract class AbstractKeyPairService implements Contract {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: IdentityOptions,
-	): Promise<KeyPairDataTransferObject> {
+	public async fromMnemonic(mnemonic: string, options?: IdentityOptions): Promise<KeyPairDataTransferObject> {
 		throw new NotSupported(this.constructor.name, "fromMultiSignature");
 	}
 

--- a/packages/platform-sdk/src/services/identity/keys.ts
+++ b/packages/platform-sdk/src/services/identity/keys.ts
@@ -1,0 +1,25 @@
+/* istanbul ignore file */
+
+import { IdentityOptions, KeyPairService as Contract, KeyPairDataTransferObject } from "../../contracts";
+import { NotSupported } from "../../exceptions";
+
+export abstract class AbstractKeyPairService implements Contract {
+	public async fromMnemonic(
+		mnemonic: string,
+		options?: IdentityOptions,
+	): Promise<KeyPairDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromMultiSignature");
+	}
+
+	public async fromPrivateKey(privateKey: string): Promise<KeyPairDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromPrivateKey");
+	}
+
+	public async fromWIF(wif: string): Promise<KeyPairDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromWIF");
+	}
+
+	public async fromSecret(secret: string): Promise<KeyPairDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromSecret");
+	}
+}

--- a/packages/platform-sdk/src/services/identity/private-key.ts
+++ b/packages/platform-sdk/src/services/identity/private-key.ts
@@ -1,0 +1,21 @@
+/* istanbul ignore file */
+
+import { IdentityOptions, PrivateKeyService as Contract, PrivateKeyDataTransferObject } from "../../contracts";
+import { NotSupported } from "../../exceptions";
+
+export abstract class AbstractPrivateKeyService implements Contract {
+	public async fromMnemonic(
+		mnemonic: string,
+		options?: IdentityOptions,
+	): Promise<PrivateKeyDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromMultiSignature");
+	}
+
+	public async fromWIF(wif: string): Promise<PrivateKeyDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromWIF");
+	}
+
+	public async fromSecret(secret: string): Promise<PrivateKeyDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromSecret");
+	}
+}

--- a/packages/platform-sdk/src/services/identity/private-key.ts
+++ b/packages/platform-sdk/src/services/identity/private-key.ts
@@ -4,10 +4,7 @@ import { IdentityOptions, PrivateKeyService as Contract, PrivateKeyDataTransferO
 import { NotSupported } from "../../exceptions";
 
 export abstract class AbstractPrivateKeyService implements Contract {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: IdentityOptions,
-	): Promise<PrivateKeyDataTransferObject> {
+	public async fromMnemonic(mnemonic: string, options?: IdentityOptions): Promise<PrivateKeyDataTransferObject> {
 		throw new NotSupported(this.constructor.name, "fromMultiSignature");
 	}
 

--- a/packages/platform-sdk/src/services/identity/public-key.ts
+++ b/packages/platform-sdk/src/services/identity/public-key.ts
@@ -4,10 +4,7 @@ import { IdentityOptions, PublicKeyService as Contract, PublicKeyDataTransferObj
 import { NotSupported } from "../../exceptions";
 
 export abstract class AbstractPublicKeyService implements Contract {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: IdentityOptions,
-	): Promise<PublicKeyDataTransferObject> {
+	public async fromMnemonic(mnemonic: string, options?: IdentityOptions): Promise<PublicKeyDataTransferObject> {
 		throw new NotSupported(this.constructor.name, "fromMultiSignature");
 	}
 

--- a/packages/platform-sdk/src/services/identity/public-key.ts
+++ b/packages/platform-sdk/src/services/identity/public-key.ts
@@ -1,0 +1,25 @@
+/* istanbul ignore file */
+
+import { IdentityOptions, PublicKeyService as Contract, PublicKeyDataTransferObject } from "../../contracts";
+import { NotSupported } from "../../exceptions";
+
+export abstract class AbstractPublicKeyService implements Contract {
+	public async fromMnemonic(
+		mnemonic: string,
+		options?: IdentityOptions,
+	): Promise<PublicKeyDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromMultiSignature");
+	}
+
+	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<PublicKeyDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromMultiSignature");
+	}
+
+	public async fromWIF(wif: string): Promise<PublicKeyDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromWIF");
+	}
+
+	public async fromSecret(secret: string): Promise<PublicKeyDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromSecret");
+	}
+}

--- a/packages/platform-sdk/src/services/identity/wif.ts
+++ b/packages/platform-sdk/src/services/identity/wif.ts
@@ -4,10 +4,7 @@ import { IdentityOptions, WIFService as Contract, WIFDataTransferObject } from "
 import { NotSupported } from "../../exceptions";
 
 export abstract class AbstractWIFService implements Contract {
-	public async fromMnemonic(
-		mnemonic: string,
-		options?: IdentityOptions,
-	): Promise<WIFDataTransferObject> {
+	public async fromMnemonic(mnemonic: string, options?: IdentityOptions): Promise<WIFDataTransferObject> {
 		throw new NotSupported(this.constructor.name, "fromPrivateKey");
 	}
 

--- a/packages/platform-sdk/src/services/identity/wif.ts
+++ b/packages/platform-sdk/src/services/identity/wif.ts
@@ -1,0 +1,21 @@
+/* istanbul ignore file */
+
+import { IdentityOptions, WIFService as Contract, WIFDataTransferObject } from "../../contracts";
+import { NotSupported } from "../../exceptions";
+
+export abstract class AbstractWIFService implements Contract {
+	public async fromMnemonic(
+		mnemonic: string,
+		options?: IdentityOptions,
+	): Promise<WIFDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromPrivateKey");
+	}
+
+	public async fromPrivateKey(privateKey: string): Promise<WIFDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromPrivateKey");
+	}
+
+	public async fromSecret(secret: string): Promise<WIFDataTransferObject> {
+		throw new NotSupported(this.constructor.name, "fromSecret");
+	}
+}


### PR DESCRIPTION
Reduces a lot of the noise in coin implementations by keeping methods that are not implemented in an abstract with a default implementation. The behaviour will be the same but there'll be a lot less noise to look at.