### PR TITLE
chore: use method name property when throwing exception

### DIFF
--- a/packages/platform-sdk-ada/src/dto/wallet.ts
+++ b/packages/platform-sdk-ada/src/dto/wallet.ts
@@ -11,7 +11,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public publicKey(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "publicKey");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.publicKey.name);
 	}
 
 	public balance(): Contracts.WalletBalance {
@@ -22,23 +22,23 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public nonce(): BigNumber {
-		throw new Exceptions.NotImplemented(this.constructor.name, "nonce");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.nonce.name);
 	}
 
 	public secondPublicKey(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.secondPublicKey.name);
 	}
 
 	public username(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "username");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.username.name);
 	}
 
 	public rank(): number | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "rank");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.rank.name);
 	}
 
 	public votes(): BigNumber | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "votes");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.votes.name);
 	}
 
 	public entities(): Contracts.Entity[] {
@@ -46,7 +46,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public multiSignature(): Contracts.WalletMultiSignature {
-		throw new Exceptions.NotImplemented(this.constructor.name, "multiSignature");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.multiSignature.name);
 	}
 
 	public isDelegate(): boolean {

--- a/packages/platform-sdk-ada/src/services/client.ts
+++ b/packages/platform-sdk-ada/src/services/client.ts
@@ -27,7 +27,7 @@ export class ClientService extends Services.AbstractClientService {
 
 	public async transactions(query: Services.ClientTransactionsInput): Promise<Coins.TransactionDataCollection> {
 		if (query.senderPublicKey === undefined) {
-			throw new Exceptions.MissingArgument(this.constructor.name, "transactions", "senderPublicKey");
+			throw new Exceptions.MissingArgument(this.constructor.name, this.transactions.name, "senderPublicKey");
 		}
 
 		const { usedSpendAddresses, usedChangeAddresses } = await usedAddressesForAccount(

--- a/packages/platform-sdk-atom/src/dto/signed-transaction.ts
+++ b/packages/platform-sdk-atom/src/dto/signed-transaction.ts
@@ -6,19 +6,19 @@ export class SignedTransactionData
 	extends DTO.AbstractSignedTransactionData
 	implements Contracts.SignedTransactionData {
 	public sender(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "sender");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.sender.name);
 	}
 
 	public recipient(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "recipient");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.recipient.name);
 	}
 
 	public amount(): BigNumber {
-		throw new Exceptions.NotImplemented(this.constructor.name, "amount");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.amount.name);
 	}
 
 	public fee(): BigNumber {
-		throw new Exceptions.NotImplemented(this.constructor.name, "fee");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.fee.name);
 	}
 
 	public timestamp(): DateTime {
@@ -30,6 +30,6 @@ export class SignedTransactionData
 	}
 
 	public isMultiSignatureRegistration(): boolean {
-		throw new Exceptions.NotImplemented(this.constructor.name, "isMultiSignatureRegistration");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.isMultiSignatureRegistration.name);
 	}
 }

--- a/packages/platform-sdk-atom/src/dto/transactions/delegate-registration.ts
+++ b/packages/platform-sdk-atom/src/dto/transactions/delegate-registration.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class DelegateRegistrationData extends TransactionData implements Contracts.DelegateRegistrationData {
 	public username(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "username");
+		throw new Exceptions.NotSupported(this.constructor.name, this.username.name);
 	}
 }

--- a/packages/platform-sdk-atom/src/dto/transactions/htlc-claim.ts
+++ b/packages/platform-sdk-atom/src/dto/transactions/htlc-claim.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class HtlcClaimData extends TransactionData implements Contracts.HtlcClaimData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 
 	public unlockSecret(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "unlockSecret");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unlockSecret.name);
 	}
 }

--- a/packages/platform-sdk-atom/src/dto/transactions/htlc-lock.ts
+++ b/packages/platform-sdk-atom/src/dto/transactions/htlc-lock.ts
@@ -4,14 +4,14 @@ import { TransactionData } from "../transaction";
 
 export class HtlcLockData extends TransactionData implements Contracts.HtlcLockData {
 	public secretHash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secretHash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secretHash.name);
 	}
 
 	public expirationType(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationType");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationType.name);
 	}
 
 	public expirationValue(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationValue");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationValue.name);
 	}
 }

--- a/packages/platform-sdk-atom/src/dto/transactions/htlc-refund.ts
+++ b/packages/platform-sdk-atom/src/dto/transactions/htlc-refund.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class HtlcRefundData extends TransactionData implements Contracts.HtlcRefundData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 }

--- a/packages/platform-sdk-atom/src/dto/transactions/ipfs.ts
+++ b/packages/platform-sdk-atom/src/dto/transactions/ipfs.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class IpfsData extends TransactionData implements Contracts.IpfsData {
 	public hash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "hash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.hash.name);
 	}
 }

--- a/packages/platform-sdk-atom/src/dto/transactions/multi-payment.ts
+++ b/packages/platform-sdk-atom/src/dto/transactions/multi-payment.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiPaymentData extends TransactionData implements Contracts.MultiPaymentData {
 	public memo(): string | undefined {
-		throw new Exceptions.NotSupported(this.constructor.name, "memo");
+		throw new Exceptions.NotSupported(this.constructor.name, this.memo.name);
 	}
 
 	public payments(): { recipientId: string; amount: string }[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "payments");
+		throw new Exceptions.NotSupported(this.constructor.name, this.payments.name);
 	}
 }

--- a/packages/platform-sdk-atom/src/dto/transactions/multi-signature.ts
+++ b/packages/platform-sdk-atom/src/dto/transactions/multi-signature.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiSignatureData extends TransactionData implements Contracts.MultiSignatureData {
 	public publicKeys(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "publicKeys");
+		throw new Exceptions.NotSupported(this.constructor.name, this.publicKeys.name);
 	}
 
 	public min(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "min");
+		throw new Exceptions.NotSupported(this.constructor.name, this.min.name);
 	}
 }

--- a/packages/platform-sdk-atom/src/dto/transactions/second-signature.ts
+++ b/packages/platform-sdk-atom/src/dto/transactions/second-signature.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class SecondSignatureData extends TransactionData implements Contracts.SecondSignatureData {
 	public secondPublicKey(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secondPublicKey.name);
 	}
 }

--- a/packages/platform-sdk-atom/src/dto/transactions/vote.ts
+++ b/packages/platform-sdk-atom/src/dto/transactions/vote.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class VoteData extends TransactionData implements Contracts.VoteData {
 	public votes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "votes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.votes.name);
 	}
 
 	public unvotes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "unvotes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unvotes.name);
 	}
 }

--- a/packages/platform-sdk-atom/src/dto/wallet.ts
+++ b/packages/platform-sdk-atom/src/dto/wallet.ts
@@ -46,7 +46,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public multiSignature(): Contracts.WalletMultiSignature {
-		throw new Exceptions.NotImplemented(this.constructor.name, "multiSignature");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.multiSignature.name);
 	}
 
 	public isDelegate(): boolean {

--- a/packages/platform-sdk-avax/src/dto/transactions/delegate-registration.ts
+++ b/packages/platform-sdk-avax/src/dto/transactions/delegate-registration.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class DelegateRegistrationData extends TransactionData implements Contracts.DelegateRegistrationData {
 	public username(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "username");
+		throw new Exceptions.NotSupported(this.constructor.name, this.username.name);
 	}
 }

--- a/packages/platform-sdk-avax/src/dto/transactions/htlc-claim.ts
+++ b/packages/platform-sdk-avax/src/dto/transactions/htlc-claim.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class HtlcClaimData extends TransactionData implements Contracts.HtlcClaimData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 
 	public unlockSecret(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "unlockSecret");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unlockSecret.name);
 	}
 }

--- a/packages/platform-sdk-avax/src/dto/transactions/htlc-lock.ts
+++ b/packages/platform-sdk-avax/src/dto/transactions/htlc-lock.ts
@@ -4,14 +4,14 @@ import { TransactionData } from "../transaction";
 
 export class HtlcLockData extends TransactionData implements Contracts.HtlcLockData {
 	public secretHash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secretHash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secretHash.name);
 	}
 
 	public expirationType(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationType");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationType.name);
 	}
 
 	public expirationValue(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationValue");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationValue.name);
 	}
 }

--- a/packages/platform-sdk-avax/src/dto/transactions/htlc-refund.ts
+++ b/packages/platform-sdk-avax/src/dto/transactions/htlc-refund.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class HtlcRefundData extends TransactionData implements Contracts.HtlcRefundData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 }

--- a/packages/platform-sdk-avax/src/dto/transactions/ipfs.ts
+++ b/packages/platform-sdk-avax/src/dto/transactions/ipfs.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class IpfsData extends TransactionData implements Contracts.IpfsData {
 	public hash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "hash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.hash.name);
 	}
 }

--- a/packages/platform-sdk-avax/src/dto/transactions/multi-payment.ts
+++ b/packages/platform-sdk-avax/src/dto/transactions/multi-payment.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiPaymentData extends TransactionData implements Contracts.MultiPaymentData {
 	public memo(): string | undefined {
-		throw new Exceptions.NotSupported(this.constructor.name, "memo");
+		throw new Exceptions.NotSupported(this.constructor.name, this.memo.name);
 	}
 
 	public payments(): { recipientId: string; amount: string }[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "payments");
+		throw new Exceptions.NotSupported(this.constructor.name, this.payments.name);
 	}
 }

--- a/packages/platform-sdk-avax/src/dto/transactions/multi-signature.ts
+++ b/packages/platform-sdk-avax/src/dto/transactions/multi-signature.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiSignatureData extends TransactionData implements Contracts.MultiSignatureData {
 	public publicKeys(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "publicKeys");
+		throw new Exceptions.NotSupported(this.constructor.name, this.publicKeys.name);
 	}
 
 	public min(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "min");
+		throw new Exceptions.NotSupported(this.constructor.name, this.min.name);
 	}
 }

--- a/packages/platform-sdk-avax/src/dto/transactions/second-signature.ts
+++ b/packages/platform-sdk-avax/src/dto/transactions/second-signature.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class SecondSignatureData extends TransactionData implements Contracts.SecondSignatureData {
 	public secondPublicKey(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secondPublicKey.name);
 	}
 }

--- a/packages/platform-sdk-avax/src/dto/transactions/vote.ts
+++ b/packages/platform-sdk-avax/src/dto/transactions/vote.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class VoteData extends TransactionData implements Contracts.VoteData {
 	public votes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "votes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.votes.name);
 	}
 
 	public unvotes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "unvotes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unvotes.name);
 	}
 }

--- a/packages/platform-sdk-avax/src/services/transaction.ts
+++ b/packages/platform-sdk-avax/src/services/transaction.ts
@@ -34,7 +34,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		if (input.signatory.signingKey() === undefined) {
-			throw new Exceptions.MissingArgument(this.constructor.name, "transfer", "input.signatory");
+			throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "input.signatory");
 		}
 
 		try {
@@ -79,7 +79,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		if (input.signatory.signingKey() === undefined) {
-			throw new Exceptions.MissingArgument(this.constructor.name, "vote", "input.signatory");
+			throw new Exceptions.MissingArgument(this.constructor.name, this.vote.name, "input.signatory");
 		}
 
 		try {

--- a/packages/platform-sdk-btc/src/dto/signed-transaction.ts
+++ b/packages/platform-sdk-btc/src/dto/signed-transaction.ts
@@ -6,19 +6,19 @@ export class SignedTransactionData
 	extends DTO.AbstractSignedTransactionData
 	implements Contracts.SignedTransactionData {
 	public sender(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "sender");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.sender.name);
 	}
 
 	public recipient(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "recipient");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.recipient.name);
 	}
 
 	public amount(): BigNumber {
-		throw new Exceptions.NotImplemented(this.constructor.name, "amount");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.amount.name);
 	}
 
 	public fee(): BigNumber {
-		throw new Exceptions.NotImplemented(this.constructor.name, "fee");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.fee.name);
 	}
 
 	public timestamp(): DateTime {
@@ -30,6 +30,6 @@ export class SignedTransactionData
 	}
 
 	public isMultiSignatureRegistration(): boolean {
-		throw new Exceptions.NotImplemented(this.constructor.name, "isMultiSignatureRegistration");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.isMultiSignatureRegistration.name);
 	}
 }

--- a/packages/platform-sdk-btc/src/dto/transaction.ts
+++ b/packages/platform-sdk-btc/src/dto/transaction.ts
@@ -20,11 +20,11 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 	}
 
 	public sender(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "sender");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.sender.name);
 	}
 
 	public recipient(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "recipient");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.recipient.name);
 	}
 
 	public recipients(): Contracts.MultiPaymentRecipient[] {

--- a/packages/platform-sdk-btc/src/dto/transactions/delegate-registration.ts
+++ b/packages/platform-sdk-btc/src/dto/transactions/delegate-registration.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class DelegateRegistrationData extends TransactionData implements Contracts.DelegateRegistrationData {
 	public username(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "username");
+		throw new Exceptions.NotSupported(this.constructor.name, this.username.name);
 	}
 }

--- a/packages/platform-sdk-btc/src/dto/transactions/htlc-claim.ts
+++ b/packages/platform-sdk-btc/src/dto/transactions/htlc-claim.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class HtlcClaimData extends TransactionData implements Contracts.HtlcClaimData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 
 	public unlockSecret(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "unlockSecret");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unlockSecret.name);
 	}
 }

--- a/packages/platform-sdk-btc/src/dto/transactions/htlc-lock.ts
+++ b/packages/platform-sdk-btc/src/dto/transactions/htlc-lock.ts
@@ -4,14 +4,14 @@ import { TransactionData } from "../transaction";
 
 export class HtlcLockData extends TransactionData implements Contracts.HtlcLockData {
 	public secretHash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secretHash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secretHash.name);
 	}
 
 	public expirationType(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationType");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationType.name);
 	}
 
 	public expirationValue(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationValue");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationValue.name);
 	}
 }

--- a/packages/platform-sdk-btc/src/dto/transactions/htlc-refund.ts
+++ b/packages/platform-sdk-btc/src/dto/transactions/htlc-refund.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class HtlcRefundData extends TransactionData implements Contracts.HtlcRefundData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 }

--- a/packages/platform-sdk-btc/src/dto/transactions/ipfs.ts
+++ b/packages/platform-sdk-btc/src/dto/transactions/ipfs.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class IpfsData extends TransactionData implements Contracts.IpfsData {
 	public hash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "hash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.hash.name);
 	}
 }

--- a/packages/platform-sdk-btc/src/dto/transactions/multi-payment.ts
+++ b/packages/platform-sdk-btc/src/dto/transactions/multi-payment.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiPaymentData extends TransactionData implements Contracts.MultiPaymentData {
 	public memo(): string | undefined {
-		throw new Exceptions.NotSupported(this.constructor.name, "memo");
+		throw new Exceptions.NotSupported(this.constructor.name, this.memo.name);
 	}
 
 	public payments(): { recipientId: string; amount: string }[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "payments");
+		throw new Exceptions.NotSupported(this.constructor.name, this.payments.name);
 	}
 }

--- a/packages/platform-sdk-btc/src/dto/transactions/multi-signature.ts
+++ b/packages/platform-sdk-btc/src/dto/transactions/multi-signature.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiSignatureData extends TransactionData implements Contracts.MultiSignatureData {
 	public publicKeys(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "publicKeys");
+		throw new Exceptions.NotSupported(this.constructor.name, this.publicKeys.name);
 	}
 
 	public min(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "min");
+		throw new Exceptions.NotSupported(this.constructor.name, this.min.name);
 	}
 }

--- a/packages/platform-sdk-btc/src/dto/transactions/second-signature.ts
+++ b/packages/platform-sdk-btc/src/dto/transactions/second-signature.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class SecondSignatureData extends TransactionData implements Contracts.SecondSignatureData {
 	public secondPublicKey(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secondPublicKey.name);
 	}
 }

--- a/packages/platform-sdk-btc/src/dto/transactions/vote.ts
+++ b/packages/platform-sdk-btc/src/dto/transactions/vote.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class VoteData extends TransactionData implements Contracts.VoteData {
 	public votes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "votes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.votes.name);
 	}
 
 	public unvotes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "unvotes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unvotes.name);
 	}
 }

--- a/packages/platform-sdk-btc/src/dto/wallet.ts
+++ b/packages/platform-sdk-btc/src/dto/wallet.ts
@@ -26,19 +26,19 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public secondPublicKey(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.secondPublicKey.name);
 	}
 
 	public username(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "username");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.username.name);
 	}
 
 	public rank(): number | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "rank");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.rank.name);
 	}
 
 	public votes(): BigNumber | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "votes");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.votes.name);
 	}
 
 	public entities(): Contracts.Entity[] {
@@ -46,7 +46,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public multiSignature(): Contracts.WalletMultiSignature {
-		throw new Exceptions.NotImplemented(this.constructor.name, "multiSignature");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.multiSignature.name);
 	}
 
 	public isDelegate(): boolean {

--- a/packages/platform-sdk-coincap/src/index.ts
+++ b/packages/platform-sdk-coincap/src/index.ts
@@ -98,7 +98,7 @@ export class PriceTracker implements Contracts.PriceTracker {
 
 	/** {@inheritDoc Contracts.PriceTracker.historicalVolume} */
 	public async historicalVolume(options: Contracts.HistoricalVolumeOptions): Promise<Contracts.HistoricalData> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "historicalVolume");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.historicalVolume.name);
 	}
 
 	/** {@inheritDoc Contracts.PriceTracker.dailyAverage} */

--- a/packages/platform-sdk-dot/src/dto/wallet.ts
+++ b/packages/platform-sdk-dot/src/dto/wallet.ts
@@ -46,7 +46,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public multiSignature(): Contracts.WalletMultiSignature {
-		throw new Exceptions.NotImplemented(this.constructor.name, "multiSignature");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.multiSignature.name);
 	}
 
 	public isDelegate(): boolean {

--- a/packages/platform-sdk-dot/src/services/transaction.ts
+++ b/packages/platform-sdk-dot/src/services/transaction.ts
@@ -35,7 +35,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		if (input.signatory.signingKey() === undefined) {
-			throw new Exceptions.MissingArgument(this.constructor.name, "transfer", "input.signatory");
+			throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "input.signatory");
 		}
 
 		const amount = Coins.toRawUnit(input.data.amount, this.#config).toString();

--- a/packages/platform-sdk-egld/src/dto/wallet.ts
+++ b/packages/platform-sdk-egld/src/dto/wallet.ts
@@ -46,7 +46,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public multiSignature(): Contracts.WalletMultiSignature {
-		throw new Exceptions.NotImplemented(this.constructor.name, "multiSignature");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.multiSignature.name);
 	}
 
 	public isDelegate(): boolean {

--- a/packages/platform-sdk-egld/src/services/transaction.ts
+++ b/packages/platform-sdk-egld/src/services/transaction.ts
@@ -28,19 +28,19 @@ export class TransactionService extends Services.AbstractTransactionService {
 		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		if (input.signatory.signingKey() === undefined) {
-			throw new Exceptions.MissingArgument(this.constructor.name, "transfer", "sign.mnemonic");
+			throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "sign.mnemonic");
 		}
 
 		if (input.fee === undefined) {
-			throw new Exceptions.MissingArgument(this.constructor.name, "transfer", "fee");
+			throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "fee");
 		}
 
 		if (input.feeLimit === undefined) {
-			throw new Exceptions.MissingArgument(this.constructor.name, "transfer", "feeLimit");
+			throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "feeLimit");
 		}
 
 		if (input.nonce === undefined) {
-			throw new Exceptions.MissingArgument(this.constructor.name, "transfer", "nonce");
+			throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "nonce");
 		}
 
 		const unsignedTransaction = {

--- a/packages/platform-sdk-eos/src/dto/signed-transaction.ts
+++ b/packages/platform-sdk-eos/src/dto/signed-transaction.ts
@@ -6,19 +6,19 @@ export class SignedTransactionData
 	extends DTO.AbstractSignedTransactionData
 	implements Contracts.SignedTransactionData {
 	public sender(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "sender");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.sender.name);
 	}
 
 	public recipient(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "recipient");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.recipient.name);
 	}
 
 	public amount(): BigNumber {
-		throw new Exceptions.NotImplemented(this.constructor.name, "amount");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.amount.name);
 	}
 
 	public fee(): BigNumber {
-		throw new Exceptions.NotImplemented(this.constructor.name, "fee");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.fee.name);
 	}
 
 	public timestamp(): DateTime {
@@ -30,6 +30,6 @@ export class SignedTransactionData
 	}
 
 	public isMultiSignatureRegistration(): boolean {
-		throw new Exceptions.NotImplemented(this.constructor.name, "isMultiSignatureRegistration");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.isMultiSignatureRegistration.name);
 	}
 }

--- a/packages/platform-sdk-eos/src/dto/transactions/delegate-registration.ts
+++ b/packages/platform-sdk-eos/src/dto/transactions/delegate-registration.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class DelegateRegistrationData extends TransactionData implements Contracts.DelegateRegistrationData {
 	public username(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "username");
+		throw new Exceptions.NotSupported(this.constructor.name, this.username.name);
 	}
 }

--- a/packages/platform-sdk-eos/src/dto/transactions/htlc-claim.ts
+++ b/packages/platform-sdk-eos/src/dto/transactions/htlc-claim.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class HtlcClaimData extends TransactionData implements Contracts.HtlcClaimData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 
 	public unlockSecret(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "unlockSecret");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unlockSecret.name);
 	}
 }

--- a/packages/platform-sdk-eos/src/dto/transactions/htlc-lock.ts
+++ b/packages/platform-sdk-eos/src/dto/transactions/htlc-lock.ts
@@ -4,14 +4,14 @@ import { TransactionData } from "../transaction";
 
 export class HtlcLockData extends TransactionData implements Contracts.HtlcLockData {
 	public secretHash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secretHash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secretHash.name);
 	}
 
 	public expirationType(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationType");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationType.name);
 	}
 
 	public expirationValue(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationValue");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationValue.name);
 	}
 }

--- a/packages/platform-sdk-eos/src/dto/transactions/htlc-refund.ts
+++ b/packages/platform-sdk-eos/src/dto/transactions/htlc-refund.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class HtlcRefundData extends TransactionData implements Contracts.HtlcRefundData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 }

--- a/packages/platform-sdk-eos/src/dto/transactions/ipfs.ts
+++ b/packages/platform-sdk-eos/src/dto/transactions/ipfs.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class IpfsData extends TransactionData implements Contracts.IpfsData {
 	public hash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "hash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.hash.name);
 	}
 }

--- a/packages/platform-sdk-eos/src/dto/transactions/multi-payment.ts
+++ b/packages/platform-sdk-eos/src/dto/transactions/multi-payment.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiPaymentData extends TransactionData implements Contracts.MultiPaymentData {
 	public memo(): string | undefined {
-		throw new Exceptions.NotSupported(this.constructor.name, "memo");
+		throw new Exceptions.NotSupported(this.constructor.name, this.memo.name);
 	}
 
 	public payments(): { recipientId: string; amount: string }[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "payments");
+		throw new Exceptions.NotSupported(this.constructor.name, this.payments.name);
 	}
 }

--- a/packages/platform-sdk-eos/src/dto/transactions/multi-signature.ts
+++ b/packages/platform-sdk-eos/src/dto/transactions/multi-signature.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiSignatureData extends TransactionData implements Contracts.MultiSignatureData {
 	public publicKeys(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "publicKeys");
+		throw new Exceptions.NotSupported(this.constructor.name, this.publicKeys.name);
 	}
 
 	public min(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "min");
+		throw new Exceptions.NotSupported(this.constructor.name, this.min.name);
 	}
 }

--- a/packages/platform-sdk-eos/src/dto/transactions/second-signature.ts
+++ b/packages/platform-sdk-eos/src/dto/transactions/second-signature.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class SecondSignatureData extends TransactionData implements Contracts.SecondSignatureData {
 	public secondPublicKey(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secondPublicKey.name);
 	}
 }

--- a/packages/platform-sdk-eos/src/dto/transactions/vote.ts
+++ b/packages/platform-sdk-eos/src/dto/transactions/vote.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class VoteData extends TransactionData implements Contracts.VoteData {
 	public votes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "votes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.votes.name);
 	}
 
 	public unvotes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "unvotes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unvotes.name);
 	}
 }

--- a/packages/platform-sdk-eos/src/dto/wallet.ts
+++ b/packages/platform-sdk-eos/src/dto/wallet.ts
@@ -26,19 +26,19 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public secondPublicKey(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.secondPublicKey.name);
 	}
 
 	public username(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "username");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.username.name);
 	}
 
 	public rank(): number | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "rank");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.rank.name);
 	}
 
 	public votes(): BigNumber | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "votes");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.votes.name);
 	}
 
 	public entities(): Contracts.Entity[] {
@@ -46,7 +46,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public multiSignature(): Contracts.WalletMultiSignature {
-		throw new Exceptions.NotImplemented(this.constructor.name, "multiSignature");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.multiSignature.name);
 	}
 
 	public isDelegate(): boolean {

--- a/packages/platform-sdk-eos/src/services/client.ts
+++ b/packages/platform-sdk-eos/src/services/client.ts
@@ -32,7 +32,7 @@ export class ClientService extends Services.AbstractClientService {
 
 	// https://developers.eos.io/manuals/eosjs/latest/how-to-guides/how-to-get-table-information
 	public async transactions(query: Services.ClientTransactionsInput): Promise<Coins.TransactionDataCollection> {
-		throw new Exceptions.NotImplemented(this.constructor.name, "transactions");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.transactions.name);
 	}
 
 	public async wallet(id: string): Promise<Contracts.WalletData> {
@@ -68,6 +68,6 @@ export class ClientService extends Services.AbstractClientService {
 			},
 		);
 
-		throw new Exceptions.NotImplemented(this.constructor.name, "broadcast");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.broadcast.name);
 	}
 }

--- a/packages/platform-sdk-eos/src/services/identity/address.ts
+++ b/packages/platform-sdk-eos/src/services/identity/address.ts
@@ -5,7 +5,7 @@ export class AddressService extends Services.AbstractAddressService {
 		mnemonic: string,
 		options?: Services.IdentityOptions,
 	): Promise<Services.AddressDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMnemonic");
+		throw new Exceptions.NotSupported(this.constructor.name, this.fromMnemonic.name);
 	}
 
 	public async validate(address: string): Promise<boolean> {

--- a/packages/platform-sdk-eos/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-eos/src/services/identity/private-key.ts
@@ -5,6 +5,6 @@ export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 		mnemonic: string,
 		options?: Services.IdentityOptions,
 	): Promise<Services.PrivateKeyDataTransferObject> {
-		throw new Exceptions.NotSupported(this.constructor.name, "fromMnemonic");
+		throw new Exceptions.NotSupported(this.constructor.name, this.fromMnemonic.name);
 	}
 }

--- a/packages/platform-sdk-eth/src/dto/signed-transaction.ts
+++ b/packages/platform-sdk-eth/src/dto/signed-transaction.ts
@@ -6,19 +6,19 @@ export class SignedTransactionData
 	extends DTO.AbstractSignedTransactionData
 	implements Contracts.SignedTransactionData {
 	public sender(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "sender");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.sender.name);
 	}
 
 	public recipient(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "recipient");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.recipient.name);
 	}
 
 	public amount(): BigNumber {
-		throw new Exceptions.NotImplemented(this.constructor.name, "amount");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.amount.name);
 	}
 
 	public fee(): BigNumber {
-		throw new Exceptions.NotImplemented(this.constructor.name, "fee");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.fee.name);
 	}
 
 	public timestamp(): DateTime {
@@ -30,6 +30,6 @@ export class SignedTransactionData
 	}
 
 	public isMultiSignatureRegistration(): boolean {
-		throw new Exceptions.NotImplemented(this.constructor.name, "isMultiSignatureRegistration");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.isMultiSignatureRegistration.name);
 	}
 }

--- a/packages/platform-sdk-eth/src/dto/transactions/delegate-registration.ts
+++ b/packages/platform-sdk-eth/src/dto/transactions/delegate-registration.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class DelegateRegistrationData extends TransactionData implements Contracts.DelegateRegistrationData {
 	public username(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "username");
+		throw new Exceptions.NotSupported(this.constructor.name, this.username.name);
 	}
 }

--- a/packages/platform-sdk-eth/src/dto/transactions/htlc-claim.ts
+++ b/packages/platform-sdk-eth/src/dto/transactions/htlc-claim.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class HtlcClaimData extends TransactionData implements Contracts.HtlcClaimData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 
 	public unlockSecret(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "unlockSecret");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unlockSecret.name);
 	}
 }

--- a/packages/platform-sdk-eth/src/dto/transactions/htlc-lock.ts
+++ b/packages/platform-sdk-eth/src/dto/transactions/htlc-lock.ts
@@ -4,14 +4,14 @@ import { TransactionData } from "../transaction";
 
 export class HtlcLockData extends TransactionData implements Contracts.HtlcLockData {
 	public secretHash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secretHash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secretHash.name);
 	}
 
 	public expirationType(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationType");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationType.name);
 	}
 
 	public expirationValue(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationValue");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationValue.name);
 	}
 }

--- a/packages/platform-sdk-eth/src/dto/transactions/htlc-refund.ts
+++ b/packages/platform-sdk-eth/src/dto/transactions/htlc-refund.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class HtlcRefundData extends TransactionData implements Contracts.HtlcRefundData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 }

--- a/packages/platform-sdk-eth/src/dto/transactions/ipfs.ts
+++ b/packages/platform-sdk-eth/src/dto/transactions/ipfs.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class IpfsData extends TransactionData implements Contracts.IpfsData {
 	public hash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "hash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.hash.name);
 	}
 }

--- a/packages/platform-sdk-eth/src/dto/transactions/multi-payment.ts
+++ b/packages/platform-sdk-eth/src/dto/transactions/multi-payment.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiPaymentData extends TransactionData implements Contracts.MultiPaymentData {
 	public memo(): string | undefined {
-		throw new Exceptions.NotSupported(this.constructor.name, "memo");
+		throw new Exceptions.NotSupported(this.constructor.name, this.memo.name);
 	}
 
 	public payments(): { recipientId: string; amount: string }[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "payments");
+		throw new Exceptions.NotSupported(this.constructor.name, this.payments.name);
 	}
 }

--- a/packages/platform-sdk-eth/src/dto/transactions/multi-signature.ts
+++ b/packages/platform-sdk-eth/src/dto/transactions/multi-signature.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiSignatureData extends TransactionData implements Contracts.MultiSignatureData {
 	public publicKeys(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "publicKeys");
+		throw new Exceptions.NotSupported(this.constructor.name, this.publicKeys.name);
 	}
 
 	public min(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "min");
+		throw new Exceptions.NotSupported(this.constructor.name, this.min.name);
 	}
 }

--- a/packages/platform-sdk-eth/src/dto/transactions/second-signature.ts
+++ b/packages/platform-sdk-eth/src/dto/transactions/second-signature.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class SecondSignatureData extends TransactionData implements Contracts.SecondSignatureData {
 	public secondPublicKey(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secondPublicKey.name);
 	}
 }

--- a/packages/platform-sdk-eth/src/dto/transactions/vote.ts
+++ b/packages/platform-sdk-eth/src/dto/transactions/vote.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class VoteData extends TransactionData implements Contracts.VoteData {
 	public votes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "votes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.votes.name);
 	}
 
 	public unvotes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "unvotes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unvotes.name);
 	}
 }

--- a/packages/platform-sdk-eth/src/dto/wallet.ts
+++ b/packages/platform-sdk-eth/src/dto/wallet.ts
@@ -27,19 +27,19 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public secondPublicKey(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.secondPublicKey.name);
 	}
 
 	public username(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "username");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.username.name);
 	}
 
 	public rank(): number | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "rank");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.rank.name);
 	}
 
 	public votes(): BigNumber | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "votes");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.votes.name);
 	}
 
 	public entities(): Contracts.Entity[] {
@@ -47,7 +47,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public multiSignature(): Contracts.WalletMultiSignature {
-		throw new Exceptions.NotImplemented(this.constructor.name, "multiSignature");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.multiSignature.name);
 	}
 
 	public isDelegate(): boolean {

--- a/packages/platform-sdk-lsk/src/dto/transactions/delegate-registration.ts
+++ b/packages/platform-sdk-lsk/src/dto/transactions/delegate-registration.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class DelegateRegistrationData extends TransactionData implements Contracts.DelegateRegistrationData {
 	public username(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "username");
+		throw new Exceptions.NotSupported(this.constructor.name, this.username.name);
 	}
 }

--- a/packages/platform-sdk-lsk/src/dto/transactions/htlc-claim.ts
+++ b/packages/platform-sdk-lsk/src/dto/transactions/htlc-claim.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class HtlcClaimData extends TransactionData implements Contracts.HtlcClaimData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 
 	public unlockSecret(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "unlockSecret");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unlockSecret.name);
 	}
 }

--- a/packages/platform-sdk-lsk/src/dto/transactions/htlc-lock.ts
+++ b/packages/platform-sdk-lsk/src/dto/transactions/htlc-lock.ts
@@ -4,14 +4,14 @@ import { TransactionData } from "../transaction";
 
 export class HtlcLockData extends TransactionData implements Contracts.HtlcLockData {
 	public secretHash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secretHash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secretHash.name);
 	}
 
 	public expirationType(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationType");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationType.name);
 	}
 
 	public expirationValue(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationValue");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationValue.name);
 	}
 }

--- a/packages/platform-sdk-lsk/src/dto/transactions/htlc-refund.ts
+++ b/packages/platform-sdk-lsk/src/dto/transactions/htlc-refund.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class HtlcRefundData extends TransactionData implements Contracts.HtlcRefundData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 }

--- a/packages/platform-sdk-lsk/src/dto/transactions/ipfs.ts
+++ b/packages/platform-sdk-lsk/src/dto/transactions/ipfs.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class IpfsData extends TransactionData implements Contracts.IpfsData {
 	public hash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "hash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.hash.name);
 	}
 }

--- a/packages/platform-sdk-lsk/src/dto/transactions/multi-payment.ts
+++ b/packages/platform-sdk-lsk/src/dto/transactions/multi-payment.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiPaymentData extends TransactionData implements Contracts.MultiPaymentData {
 	public memo(): string | undefined {
-		throw new Exceptions.NotSupported(this.constructor.name, "memo");
+		throw new Exceptions.NotSupported(this.constructor.name, this.memo.name);
 	}
 
 	public payments(): { recipientId: string; amount: string }[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "payments");
+		throw new Exceptions.NotSupported(this.constructor.name, this.payments.name);
 	}
 }

--- a/packages/platform-sdk-lsk/src/dto/transactions/multi-signature.ts
+++ b/packages/platform-sdk-lsk/src/dto/transactions/multi-signature.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiSignatureData extends TransactionData implements Contracts.MultiSignatureData {
 	public publicKeys(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "publicKeys");
+		throw new Exceptions.NotSupported(this.constructor.name, this.publicKeys.name);
 	}
 
 	public min(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "min");
+		throw new Exceptions.NotSupported(this.constructor.name, this.min.name);
 	}
 }

--- a/packages/platform-sdk-lsk/src/dto/transactions/second-signature.ts
+++ b/packages/platform-sdk-lsk/src/dto/transactions/second-signature.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class SecondSignatureData extends TransactionData implements Contracts.SecondSignatureData {
 	public secondPublicKey(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secondPublicKey.name);
 	}
 }

--- a/packages/platform-sdk-lsk/src/dto/transactions/vote.ts
+++ b/packages/platform-sdk-lsk/src/dto/transactions/vote.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class VoteData extends TransactionData implements Contracts.VoteData {
 	public votes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "votes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.votes.name);
 	}
 
 	public unvotes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "unvotes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unvotes.name);
 	}
 }

--- a/packages/platform-sdk-luna/src/dto/wallet.ts
+++ b/packages/platform-sdk-luna/src/dto/wallet.ts
@@ -11,7 +11,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public publicKey(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "publicKey");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.publicKey.name);
 	}
 
 	public balance(): Contracts.WalletBalance {
@@ -22,23 +22,23 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public nonce(): BigNumber {
-		throw new Exceptions.NotImplemented(this.constructor.name, "nonce");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.nonce.name);
 	}
 
 	public secondPublicKey(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.secondPublicKey.name);
 	}
 
 	public username(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "username");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.username.name);
 	}
 
 	public rank(): number | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "rank");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.rank.name);
 	}
 
 	public votes(): BigNumber | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "votes");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.votes.name);
 	}
 
 	public entities(): Contracts.Entity[] {
@@ -46,7 +46,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public multiSignature(): Contracts.WalletMultiSignature {
-		throw new Exceptions.NotImplemented(this.constructor.name, "multiSignature");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.multiSignature.name);
 	}
 
 	public isDelegate(): boolean {

--- a/packages/platform-sdk-nano/src/dto/transactions/delegate-registration.ts
+++ b/packages/platform-sdk-nano/src/dto/transactions/delegate-registration.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class DelegateRegistrationData extends TransactionData implements Contracts.DelegateRegistrationData {
 	public username(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "username");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.username.name);
 	}
 }

--- a/packages/platform-sdk-nano/src/dto/transactions/htlc-claim.ts
+++ b/packages/platform-sdk-nano/src/dto/transactions/htlc-claim.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class HtlcClaimData extends TransactionData implements Contracts.HtlcClaimData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.lockTransactionId.name);
 	}
 
 	public unlockSecret(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "unlockSecret");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.unlockSecret.name);
 	}
 }

--- a/packages/platform-sdk-nano/src/dto/transactions/htlc-lock.ts
+++ b/packages/platform-sdk-nano/src/dto/transactions/htlc-lock.ts
@@ -4,14 +4,14 @@ import { TransactionData } from "../transaction";
 
 export class HtlcLockData extends TransactionData implements Contracts.HtlcLockData {
 	public secretHash(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "secretHash");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.secretHash.name);
 	}
 
 	public expirationType(): number {
-		throw new Exceptions.NotImplemented(this.constructor.name, "expirationType");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.expirationType.name);
 	}
 
 	public expirationValue(): number {
-		throw new Exceptions.NotImplemented(this.constructor.name, "expirationValue");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.expirationValue.name);
 	}
 }

--- a/packages/platform-sdk-nano/src/dto/transactions/htlc-refund.ts
+++ b/packages/platform-sdk-nano/src/dto/transactions/htlc-refund.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class HtlcRefundData extends TransactionData implements Contracts.HtlcRefundData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.lockTransactionId.name);
 	}
 }

--- a/packages/platform-sdk-nano/src/dto/transactions/ipfs.ts
+++ b/packages/platform-sdk-nano/src/dto/transactions/ipfs.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class IpfsData extends TransactionData implements Contracts.IpfsData {
 	public hash(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "hash");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.hash.name);
 	}
 }

--- a/packages/platform-sdk-nano/src/dto/transactions/multi-payment.ts
+++ b/packages/platform-sdk-nano/src/dto/transactions/multi-payment.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiPaymentData extends TransactionData implements Contracts.MultiPaymentData {
 	public memo(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "memo");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.memo.name);
 	}
 
 	public payments(): { recipientId: string; amount: string }[] {
-		throw new Exceptions.NotImplemented(this.constructor.name, "payments");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.payments.name);
 	}
 }

--- a/packages/platform-sdk-nano/src/dto/transactions/multi-signature.ts
+++ b/packages/platform-sdk-nano/src/dto/transactions/multi-signature.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiSignatureData extends TransactionData implements Contracts.MultiSignatureData {
 	public publicKeys(): string[] {
-		throw new Exceptions.NotImplemented(this.constructor.name, "publicKeys");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.publicKeys.name);
 	}
 
 	public min(): number {
-		throw new Exceptions.NotImplemented(this.constructor.name, "min");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.min.name);
 	}
 }

--- a/packages/platform-sdk-nano/src/dto/transactions/second-signature.ts
+++ b/packages/platform-sdk-nano/src/dto/transactions/second-signature.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class SecondSignatureData extends TransactionData implements Contracts.SecondSignatureData {
 	public secondPublicKey(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.secondPublicKey.name);
 	}
 }

--- a/packages/platform-sdk-nano/src/dto/transactions/vote.ts
+++ b/packages/platform-sdk-nano/src/dto/transactions/vote.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class VoteData extends TransactionData implements Contracts.VoteData {
 	public votes(): string[] {
-		throw new Exceptions.NotImplemented(this.constructor.name, "votes");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.votes.name);
 	}
 
 	public unvotes(): string[] {
-		throw new Exceptions.NotImplemented(this.constructor.name, "unvotes");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.unvotes.name);
 	}
 }

--- a/packages/platform-sdk-nano/src/dto/wallet.ts
+++ b/packages/platform-sdk-nano/src/dto/wallet.ts
@@ -49,7 +49,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public multiSignature(): Contracts.WalletMultiSignature {
-		throw new Exceptions.NotImplemented(this.constructor.name, "multiSignature");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.multiSignature.name);
 	}
 
 	public isDelegate(): boolean {

--- a/packages/platform-sdk-neo/src/dto/signed-transaction.ts
+++ b/packages/platform-sdk-neo/src/dto/signed-transaction.ts
@@ -6,19 +6,19 @@ export class SignedTransactionData
 	extends DTO.AbstractSignedTransactionData
 	implements Contracts.SignedTransactionData {
 	public sender(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "sender");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.sender.name);
 	}
 
 	public recipient(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "recipient");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.recipient.name);
 	}
 
 	public amount(): BigNumber {
-		throw new Exceptions.NotImplemented(this.constructor.name, "amount");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.amount.name);
 	}
 
 	public fee(): BigNumber {
-		throw new Exceptions.NotImplemented(this.constructor.name, "fee");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.fee.name);
 	}
 
 	public timestamp(): DateTime {
@@ -30,6 +30,6 @@ export class SignedTransactionData
 	}
 
 	public isMultiSignatureRegistration(): boolean {
-		throw new Exceptions.NotImplemented(this.constructor.name, "isMultiSignatureRegistration");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.isMultiSignatureRegistration.name);
 	}
 }

--- a/packages/platform-sdk-neo/src/dto/transactions/delegate-registration.ts
+++ b/packages/platform-sdk-neo/src/dto/transactions/delegate-registration.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class DelegateRegistrationData extends TransactionData implements Contracts.DelegateRegistrationData {
 	public username(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "username");
+		throw new Exceptions.NotSupported(this.constructor.name, this.username.name);
 	}
 }

--- a/packages/platform-sdk-neo/src/dto/transactions/htlc-claim.ts
+++ b/packages/platform-sdk-neo/src/dto/transactions/htlc-claim.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class HtlcClaimData extends TransactionData implements Contracts.HtlcClaimData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 
 	public unlockSecret(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "unlockSecret");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unlockSecret.name);
 	}
 }

--- a/packages/platform-sdk-neo/src/dto/transactions/htlc-lock.ts
+++ b/packages/platform-sdk-neo/src/dto/transactions/htlc-lock.ts
@@ -4,14 +4,14 @@ import { TransactionData } from "../transaction";
 
 export class HtlcLockData extends TransactionData implements Contracts.HtlcLockData {
 	public secretHash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secretHash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secretHash.name);
 	}
 
 	public expirationType(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationType");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationType.name);
 	}
 
 	public expirationValue(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationValue");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationValue.name);
 	}
 }

--- a/packages/platform-sdk-neo/src/dto/transactions/htlc-refund.ts
+++ b/packages/platform-sdk-neo/src/dto/transactions/htlc-refund.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class HtlcRefundData extends TransactionData implements Contracts.HtlcRefundData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 }

--- a/packages/platform-sdk-neo/src/dto/transactions/ipfs.ts
+++ b/packages/platform-sdk-neo/src/dto/transactions/ipfs.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class IpfsData extends TransactionData implements Contracts.IpfsData {
 	public hash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "hash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.hash.name);
 	}
 }

--- a/packages/platform-sdk-neo/src/dto/transactions/multi-payment.ts
+++ b/packages/platform-sdk-neo/src/dto/transactions/multi-payment.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiPaymentData extends TransactionData implements Contracts.MultiPaymentData {
 	public memo(): string | undefined {
-		throw new Exceptions.NotSupported(this.constructor.name, "memo");
+		throw new Exceptions.NotSupported(this.constructor.name, this.memo.name);
 	}
 
 	public payments(): { recipientId: string; amount: string }[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "payments");
+		throw new Exceptions.NotSupported(this.constructor.name, this.payments.name);
 	}
 }

--- a/packages/platform-sdk-neo/src/dto/transactions/multi-signature.ts
+++ b/packages/platform-sdk-neo/src/dto/transactions/multi-signature.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiSignatureData extends TransactionData implements Contracts.MultiSignatureData {
 	public publicKeys(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "publicKeys");
+		throw new Exceptions.NotSupported(this.constructor.name, this.publicKeys.name);
 	}
 
 	public min(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "min");
+		throw new Exceptions.NotSupported(this.constructor.name, this.min.name);
 	}
 }

--- a/packages/platform-sdk-neo/src/dto/transactions/second-signature.ts
+++ b/packages/platform-sdk-neo/src/dto/transactions/second-signature.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class SecondSignatureData extends TransactionData implements Contracts.SecondSignatureData {
 	public secondPublicKey(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secondPublicKey.name);
 	}
 }

--- a/packages/platform-sdk-neo/src/dto/transactions/vote.ts
+++ b/packages/platform-sdk-neo/src/dto/transactions/vote.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class VoteData extends TransactionData implements Contracts.VoteData {
 	public votes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "votes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.votes.name);
 	}
 
 	public unvotes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "unvotes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unvotes.name);
 	}
 }

--- a/packages/platform-sdk-neo/src/dto/wallet.ts
+++ b/packages/platform-sdk-neo/src/dto/wallet.ts
@@ -11,7 +11,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public publicKey(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "publicKey");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.publicKey.name);
 	}
 
 	public balance(): Contracts.WalletBalance {
@@ -26,19 +26,19 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public secondPublicKey(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.secondPublicKey.name);
 	}
 
 	public username(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "username");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.username.name);
 	}
 
 	public rank(): number | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "rank");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.rank.name);
 	}
 
 	public votes(): BigNumber | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "votes");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.votes.name);
 	}
 
 	public entities(): Contracts.Entity[] {
@@ -46,7 +46,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public multiSignature(): Contracts.WalletMultiSignature {
-		throw new Exceptions.NotImplemented(this.constructor.name, "multiSignature");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.multiSignature.name);
 	}
 
 	public isDelegate(): boolean {

--- a/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet.ts
@@ -189,7 +189,7 @@ export class Wallet implements IReadWriteWallet {
 	/** {@inheritDoc IReadWriteWallet.connect} */
 	public async connect(): Promise<void> {
 		if (!this.hasCoin()) {
-			throw new Exceptions.BadVariableDependencyException(this.constructor.name, "connect", "coin");
+			throw new Exceptions.BadVariableDependencyException(this.constructor.name, this.connect.name, "coin");
 		}
 
 		await this.#attributes.get<Coins.Coin>("coin").__construct();

--- a/packages/platform-sdk-sol/src/dto/wallet.ts
+++ b/packages/platform-sdk-sol/src/dto/wallet.ts
@@ -11,7 +11,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public publicKey(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "publicKey");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.publicKey.name);
 	}
 
 	public balance(): Contracts.WalletBalance {
@@ -22,23 +22,23 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public nonce(): BigNumber {
-		throw new Exceptions.NotImplemented(this.constructor.name, "nonce");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.nonce.name);
 	}
 
 	public secondPublicKey(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.secondPublicKey.name);
 	}
 
 	public username(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "username");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.username.name);
 	}
 
 	public rank(): number | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "rank");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.rank.name);
 	}
 
 	public votes(): BigNumber | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "votes");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.votes.name);
 	}
 
 	public entities(): Contracts.Entity[] {
@@ -46,7 +46,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public multiSignature(): Contracts.WalletMultiSignature {
-		throw new Exceptions.NotImplemented(this.constructor.name, "multiSignature");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.multiSignature.name);
 	}
 
 	public isDelegate(): boolean {

--- a/packages/platform-sdk-sol/src/services/identity/address.ts
+++ b/packages/platform-sdk-sol/src/services/identity/address.ts
@@ -18,7 +18,7 @@ export class AddressService extends Services.AbstractAddressService {
 		options?: Services.IdentityOptions,
 	): Promise<Services.AddressDataTransferObject> {
 		if (!BIP39.validate(mnemonic)) {
-			throw new Exceptions.InvalidArguments(this.constructor.name, "fromMnemonic");
+			throw new Exceptions.InvalidArguments(this.constructor.name, this.fromMnemonic.name);
 		}
 
 		return {

--- a/packages/platform-sdk-sol/src/services/identity/keys.ts
+++ b/packages/platform-sdk-sol/src/services/identity/keys.ts
@@ -17,7 +17,7 @@ export class KeyPairService extends Services.AbstractKeyPairService {
 		options?: Services.IdentityOptions,
 	): Promise<Services.KeyPairDataTransferObject> {
 		if (!BIP39.validate(mnemonic)) {
-			throw new Exceptions.InvalidArguments(this.constructor.name, "fromMnemonic");
+			throw new Exceptions.InvalidArguments(this.constructor.name, this.fromMnemonic.name);
 		}
 
 		const privateBuffer: Buffer = derivePrivateKey(

--- a/packages/platform-sdk-sol/src/services/identity/private-key.ts
+++ b/packages/platform-sdk-sol/src/services/identity/private-key.ts
@@ -17,7 +17,7 @@ export class PrivateKeyService extends Services.AbstractPrivateKeyService {
 		options?: Services.IdentityOptions,
 	): Promise<Services.PrivateKeyDataTransferObject> {
 		if (!BIP39.validate(mnemonic)) {
-			throw new Exceptions.InvalidArguments(this.constructor.name, "fromMnemonic");
+			throw new Exceptions.InvalidArguments(this.constructor.name, this.fromMnemonic.name);
 		}
 
 		return {

--- a/packages/platform-sdk-sol/src/services/identity/public-key.ts
+++ b/packages/platform-sdk-sol/src/services/identity/public-key.ts
@@ -17,7 +17,7 @@ export class PublicKeyService extends Services.AbstractPublicKeyService {
 		options?: Services.IdentityOptions,
 	): Promise<Services.PublicKeyDataTransferObject> {
 		if (!BIP39.validate(mnemonic)) {
-			throw new Exceptions.InvalidArguments(this.constructor.name, "fromMnemonic");
+			throw new Exceptions.InvalidArguments(this.constructor.name, this.fromMnemonic.name);
 		}
 
 		return {

--- a/packages/platform-sdk-trx/src/dto/transactions/delegate-registration.ts
+++ b/packages/platform-sdk-trx/src/dto/transactions/delegate-registration.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class DelegateRegistrationData extends TransactionData implements Contracts.DelegateRegistrationData {
 	public username(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "username");
+		throw new Exceptions.NotSupported(this.constructor.name, this.username.name);
 	}
 }

--- a/packages/platform-sdk-trx/src/dto/transactions/htlc-claim.ts
+++ b/packages/platform-sdk-trx/src/dto/transactions/htlc-claim.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class HtlcClaimData extends TransactionData implements Contracts.HtlcClaimData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 
 	public unlockSecret(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "unlockSecret");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unlockSecret.name);
 	}
 }

--- a/packages/platform-sdk-trx/src/dto/transactions/htlc-lock.ts
+++ b/packages/platform-sdk-trx/src/dto/transactions/htlc-lock.ts
@@ -4,14 +4,14 @@ import { TransactionData } from "../transaction";
 
 export class HtlcLockData extends TransactionData implements Contracts.HtlcLockData {
 	public secretHash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secretHash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secretHash.name);
 	}
 
 	public expirationType(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationType");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationType.name);
 	}
 
 	public expirationValue(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationValue");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationValue.name);
 	}
 }

--- a/packages/platform-sdk-trx/src/dto/transactions/htlc-refund.ts
+++ b/packages/platform-sdk-trx/src/dto/transactions/htlc-refund.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class HtlcRefundData extends TransactionData implements Contracts.HtlcRefundData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 }

--- a/packages/platform-sdk-trx/src/dto/transactions/ipfs.ts
+++ b/packages/platform-sdk-trx/src/dto/transactions/ipfs.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class IpfsData extends TransactionData implements Contracts.IpfsData {
 	public hash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "hash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.hash.name);
 	}
 }

--- a/packages/platform-sdk-trx/src/dto/transactions/multi-payment.ts
+++ b/packages/platform-sdk-trx/src/dto/transactions/multi-payment.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiPaymentData extends TransactionData implements Contracts.MultiPaymentData {
 	public memo(): string | undefined {
-		throw new Exceptions.NotSupported(this.constructor.name, "memo");
+		throw new Exceptions.NotSupported(this.constructor.name, this.memo.name);
 	}
 
 	public payments(): { recipientId: string; amount: string }[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "payments");
+		throw new Exceptions.NotSupported(this.constructor.name, this.payments.name);
 	}
 }

--- a/packages/platform-sdk-trx/src/dto/transactions/multi-signature.ts
+++ b/packages/platform-sdk-trx/src/dto/transactions/multi-signature.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiSignatureData extends TransactionData implements Contracts.MultiSignatureData {
 	public publicKeys(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "publicKeys");
+		throw new Exceptions.NotSupported(this.constructor.name, this.publicKeys.name);
 	}
 
 	public min(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "min");
+		throw new Exceptions.NotSupported(this.constructor.name, this.min.name);
 	}
 }

--- a/packages/platform-sdk-trx/src/dto/transactions/second-signature.ts
+++ b/packages/platform-sdk-trx/src/dto/transactions/second-signature.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class SecondSignatureData extends TransactionData implements Contracts.SecondSignatureData {
 	public secondPublicKey(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secondPublicKey.name);
 	}
 }

--- a/packages/platform-sdk-trx/src/dto/transactions/vote.ts
+++ b/packages/platform-sdk-trx/src/dto/transactions/vote.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class VoteData extends TransactionData implements Contracts.VoteData {
 	public votes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "votes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.votes.name);
 	}
 
 	public unvotes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "unvotes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unvotes.name);
 	}
 }

--- a/packages/platform-sdk-trx/src/dto/wallet.ts
+++ b/packages/platform-sdk-trx/src/dto/wallet.ts
@@ -42,19 +42,19 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public secondPublicKey(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.secondPublicKey.name);
 	}
 
 	public username(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "username");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.username.name);
 	}
 
 	public rank(): number | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "rank");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.rank.name);
 	}
 
 	public votes(): BigNumber | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "votes");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.votes.name);
 	}
 
 	public entities(): Contracts.Entity[] {
@@ -62,7 +62,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public multiSignature(): Contracts.WalletMultiSignature {
-		throw new Exceptions.NotImplemented(this.constructor.name, "multiSignature");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.multiSignature.name);
 	}
 
 	public isDelegate(): boolean {

--- a/packages/platform-sdk-xlm/src/dto/transaction.ts
+++ b/packages/platform-sdk-xlm/src/dto/transaction.ts
@@ -16,7 +16,7 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 	}
 
 	public confirmations(): BigNumber {
-		throw new Exceptions.NotImplemented(this.constructor.name, "confirmations");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.confirmations.name);
 	}
 
 	public sender(): string {

--- a/packages/platform-sdk-xlm/src/dto/transactions/delegate-registration.ts
+++ b/packages/platform-sdk-xlm/src/dto/transactions/delegate-registration.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class DelegateRegistrationData extends TransactionData implements Contracts.DelegateRegistrationData {
 	public username(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "username");
+		throw new Exceptions.NotSupported(this.constructor.name, this.username.name);
 	}
 }

--- a/packages/platform-sdk-xlm/src/dto/transactions/htlc-claim.ts
+++ b/packages/platform-sdk-xlm/src/dto/transactions/htlc-claim.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class HtlcClaimData extends TransactionData implements Contracts.HtlcClaimData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 
 	public unlockSecret(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "unlockSecret");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unlockSecret.name);
 	}
 }

--- a/packages/platform-sdk-xlm/src/dto/transactions/htlc-lock.ts
+++ b/packages/platform-sdk-xlm/src/dto/transactions/htlc-lock.ts
@@ -4,14 +4,14 @@ import { TransactionData } from "../transaction";
 
 export class HtlcLockData extends TransactionData implements Contracts.HtlcLockData {
 	public secretHash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secretHash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secretHash.name);
 	}
 
 	public expirationType(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationType");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationType.name);
 	}
 
 	public expirationValue(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationValue");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationValue.name);
 	}
 }

--- a/packages/platform-sdk-xlm/src/dto/transactions/htlc-refund.ts
+++ b/packages/platform-sdk-xlm/src/dto/transactions/htlc-refund.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class HtlcRefundData extends TransactionData implements Contracts.HtlcRefundData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 }

--- a/packages/platform-sdk-xlm/src/dto/transactions/ipfs.ts
+++ b/packages/platform-sdk-xlm/src/dto/transactions/ipfs.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class IpfsData extends TransactionData implements Contracts.IpfsData {
 	public hash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "hash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.hash.name);
 	}
 }

--- a/packages/platform-sdk-xlm/src/dto/transactions/multi-payment.ts
+++ b/packages/platform-sdk-xlm/src/dto/transactions/multi-payment.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiPaymentData extends TransactionData implements Contracts.MultiPaymentData {
 	public memo(): string | undefined {
-		throw new Exceptions.NotSupported(this.constructor.name, "memo");
+		throw new Exceptions.NotSupported(this.constructor.name, this.memo.name);
 	}
 
 	public payments(): { recipientId: string; amount: string }[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "payments");
+		throw new Exceptions.NotSupported(this.constructor.name, this.payments.name);
 	}
 }

--- a/packages/platform-sdk-xlm/src/dto/transactions/multi-signature.ts
+++ b/packages/platform-sdk-xlm/src/dto/transactions/multi-signature.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiSignatureData extends TransactionData implements Contracts.MultiSignatureData {
 	public publicKeys(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "publicKeys");
+		throw new Exceptions.NotSupported(this.constructor.name, this.publicKeys.name);
 	}
 
 	public min(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "min");
+		throw new Exceptions.NotSupported(this.constructor.name, this.min.name);
 	}
 }

--- a/packages/platform-sdk-xlm/src/dto/transactions/second-signature.ts
+++ b/packages/platform-sdk-xlm/src/dto/transactions/second-signature.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class SecondSignatureData extends TransactionData implements Contracts.SecondSignatureData {
 	public secondPublicKey(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secondPublicKey.name);
 	}
 }

--- a/packages/platform-sdk-xlm/src/dto/transactions/vote.ts
+++ b/packages/platform-sdk-xlm/src/dto/transactions/vote.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class VoteData extends TransactionData implements Contracts.VoteData {
 	public votes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "votes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.votes.name);
 	}
 
 	public unvotes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "unvotes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unvotes.name);
 	}
 }

--- a/packages/platform-sdk-xlm/src/dto/wallet.ts
+++ b/packages/platform-sdk-xlm/src/dto/wallet.ts
@@ -26,19 +26,19 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public secondPublicKey(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.secondPublicKey.name);
 	}
 
 	public username(): string | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "username");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.username.name);
 	}
 
 	public rank(): number | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "rank");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.rank.name);
 	}
 
 	public votes(): BigNumber | undefined {
-		throw new Exceptions.NotImplemented(this.constructor.name, "votes");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.votes.name);
 	}
 
 	public entities(): Contracts.Entity[] {
@@ -46,7 +46,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public multiSignature(): Contracts.WalletMultiSignature {
-		throw new Exceptions.NotImplemented(this.constructor.name, "multiSignature");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.multiSignature.name);
 	}
 
 	public isDelegate(): boolean {

--- a/packages/platform-sdk-xrp/src/dto/signed-transaction.ts
+++ b/packages/platform-sdk-xrp/src/dto/signed-transaction.ts
@@ -6,19 +6,19 @@ export class SignedTransactionData
 	extends DTO.AbstractSignedTransactionData
 	implements Contracts.SignedTransactionData {
 	public sender(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "sender");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.sender.name);
 	}
 
 	public recipient(): string {
-		throw new Exceptions.NotImplemented(this.constructor.name, "recipient");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.recipient.name);
 	}
 
 	public amount(): BigNumber {
-		throw new Exceptions.NotImplemented(this.constructor.name, "amount");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.amount.name);
 	}
 
 	public fee(): BigNumber {
-		throw new Exceptions.NotImplemented(this.constructor.name, "fee");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.fee.name);
 	}
 
 	public timestamp(): DateTime {
@@ -30,6 +30,6 @@ export class SignedTransactionData
 	}
 
 	public isMultiSignatureRegistration(): boolean {
-		throw new Exceptions.NotImplemented(this.constructor.name, "isMultiSignatureRegistration");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.isMultiSignatureRegistration.name);
 	}
 }

--- a/packages/platform-sdk-xrp/src/dto/transactions/delegate-registration.ts
+++ b/packages/platform-sdk-xrp/src/dto/transactions/delegate-registration.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class DelegateRegistrationData extends TransactionData implements Contracts.DelegateRegistrationData {
 	public username(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "username");
+		throw new Exceptions.NotSupported(this.constructor.name, this.username.name);
 	}
 }

--- a/packages/platform-sdk-xrp/src/dto/transactions/htlc-claim.ts
+++ b/packages/platform-sdk-xrp/src/dto/transactions/htlc-claim.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class HtlcClaimData extends TransactionData implements Contracts.HtlcClaimData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 
 	public unlockSecret(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "unlockSecret");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unlockSecret.name);
 	}
 }

--- a/packages/platform-sdk-xrp/src/dto/transactions/htlc-lock.ts
+++ b/packages/platform-sdk-xrp/src/dto/transactions/htlc-lock.ts
@@ -4,14 +4,14 @@ import { TransactionData } from "../transaction";
 
 export class HtlcLockData extends TransactionData implements Contracts.HtlcLockData {
 	public secretHash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secretHash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secretHash.name);
 	}
 
 	public expirationType(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationType");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationType.name);
 	}
 
 	public expirationValue(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "expirationValue");
+		throw new Exceptions.NotSupported(this.constructor.name, this.expirationValue.name);
 	}
 }

--- a/packages/platform-sdk-xrp/src/dto/transactions/htlc-refund.ts
+++ b/packages/platform-sdk-xrp/src/dto/transactions/htlc-refund.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class HtlcRefundData extends TransactionData implements Contracts.HtlcRefundData {
 	public lockTransactionId(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "lockTransactionId");
+		throw new Exceptions.NotSupported(this.constructor.name, this.lockTransactionId.name);
 	}
 }

--- a/packages/platform-sdk-xrp/src/dto/transactions/ipfs.ts
+++ b/packages/platform-sdk-xrp/src/dto/transactions/ipfs.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class IpfsData extends TransactionData implements Contracts.IpfsData {
 	public hash(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "hash");
+		throw new Exceptions.NotSupported(this.constructor.name, this.hash.name);
 	}
 }

--- a/packages/platform-sdk-xrp/src/dto/transactions/multi-payment.ts
+++ b/packages/platform-sdk-xrp/src/dto/transactions/multi-payment.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiPaymentData extends TransactionData implements Contracts.MultiPaymentData {
 	public memo(): string | undefined {
-		throw new Exceptions.NotSupported(this.constructor.name, "memo");
+		throw new Exceptions.NotSupported(this.constructor.name, this.memo.name);
 	}
 
 	public payments(): { recipientId: string; amount: string }[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "payments");
+		throw new Exceptions.NotSupported(this.constructor.name, this.payments.name);
 	}
 }

--- a/packages/platform-sdk-xrp/src/dto/transactions/multi-signature.ts
+++ b/packages/platform-sdk-xrp/src/dto/transactions/multi-signature.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class MultiSignatureData extends TransactionData implements Contracts.MultiSignatureData {
 	public publicKeys(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "publicKeys");
+		throw new Exceptions.NotSupported(this.constructor.name, this.publicKeys.name);
 	}
 
 	public min(): number {
-		throw new Exceptions.NotSupported(this.constructor.name, "min");
+		throw new Exceptions.NotSupported(this.constructor.name, this.min.name);
 	}
 }

--- a/packages/platform-sdk-xrp/src/dto/transactions/second-signature.ts
+++ b/packages/platform-sdk-xrp/src/dto/transactions/second-signature.ts
@@ -4,6 +4,6 @@ import { TransactionData } from "../transaction";
 
 export class SecondSignatureData extends TransactionData implements Contracts.SecondSignatureData {
 	public secondPublicKey(): string {
-		throw new Exceptions.NotSupported(this.constructor.name, "secondPublicKey");
+		throw new Exceptions.NotSupported(this.constructor.name, this.secondPublicKey.name);
 	}
 }

--- a/packages/platform-sdk-xrp/src/dto/transactions/vote.ts
+++ b/packages/platform-sdk-xrp/src/dto/transactions/vote.ts
@@ -4,10 +4,10 @@ import { TransactionData } from "../transaction";
 
 export class VoteData extends TransactionData implements Contracts.VoteData {
 	public votes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "votes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.votes.name);
 	}
 
 	public unvotes(): string[] {
-		throw new Exceptions.NotSupported(this.constructor.name, "unvotes");
+		throw new Exceptions.NotSupported(this.constructor.name, this.unvotes.name);
 	}
 }

--- a/packages/platform-sdk-xrp/src/dto/wallet.ts
+++ b/packages/platform-sdk-xrp/src/dto/wallet.ts
@@ -46,7 +46,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 	}
 
 	public multiSignature(): Contracts.WalletMultiSignature {
-		throw new Exceptions.NotImplemented(this.constructor.name, "multiSignature");
+		throw new Exceptions.NotImplemented(this.constructor.name, this.multiSignature.name);
 	}
 
 	public isDelegate(): boolean {

--- a/packages/platform-sdk/src/coins/coin.ts
+++ b/packages/platform-sdk/src/coins/coin.ts
@@ -54,7 +54,7 @@ export class Coin {
 
 	public async __destruct(): Promise<void> {
 		if (!this.hasBeenSynchronized()) {
-			throw new BadMethodDependencyException(this.constructor.name, "__destruct", "__construct");
+			throw new BadMethodDependencyException(this.constructor.name, this.__destruct.name, "__construct");
 		}
 
 		await Promise.all([
@@ -90,7 +90,7 @@ export class Coin {
 
 	public client(): ClientService {
 		if (!this.hasBeenSynchronized()) {
-			throw new BadMethodDependencyException(this.constructor.name, "client", "__construct");
+			throw new BadMethodDependencyException(this.constructor.name, this.client.name, "__construct");
 		}
 
 		return this.#services!.client;
@@ -98,7 +98,7 @@ export class Coin {
 
 	public dataTransferObject(): DataTransferObjectService {
 		if (!this.hasBeenSynchronized()) {
-			throw new BadMethodDependencyException(this.constructor.name, "dataTransferObject", "__construct");
+			throw new BadMethodDependencyException(this.constructor.name, this.dataTransferObject.name, "__construct");
 		}
 
 		return this.#services!.dataTransferObject;
@@ -106,7 +106,7 @@ export class Coin {
 
 	public fee(): FeeService {
 		if (!this.hasBeenSynchronized()) {
-			throw new BadMethodDependencyException(this.constructor.name, "fee", "__construct");
+			throw new BadMethodDependencyException(this.constructor.name, this.fee.name, "__construct");
 		}
 
 		return this.#services!.fee;
@@ -114,7 +114,7 @@ export class Coin {
 
 	public identity(): IdentityService {
 		if (!this.hasBeenSynchronized()) {
-			throw new BadMethodDependencyException(this.constructor.name, "identity", "__construct");
+			throw new BadMethodDependencyException(this.constructor.name, this.identity.name, "__construct");
 		}
 
 		return this.#services!.identity;
@@ -122,7 +122,7 @@ export class Coin {
 
 	public knownWallets(): KnownWalletService {
 		if (!this.hasBeenSynchronized()) {
-			throw new BadMethodDependencyException(this.constructor.name, "knownWallets", "__construct");
+			throw new BadMethodDependencyException(this.constructor.name, this.knownWallets.name, "__construct");
 		}
 
 		return this.#services!.knownWallets;
@@ -130,7 +130,7 @@ export class Coin {
 
 	public ledger(): LedgerService {
 		if (!this.hasBeenSynchronized()) {
-			throw new BadMethodDependencyException(this.constructor.name, "ledger", "__construct");
+			throw new BadMethodDependencyException(this.constructor.name, this.ledger.name, "__construct");
 		}
 
 		return this.#services!.ledger;
@@ -138,7 +138,7 @@ export class Coin {
 
 	public link(): LinkService {
 		if (!this.hasBeenSynchronized()) {
-			throw new BadMethodDependencyException(this.constructor.name, "link", "__construct");
+			throw new BadMethodDependencyException(this.constructor.name, this.link.name, "__construct");
 		}
 
 		return this.#services!.link;
@@ -146,7 +146,7 @@ export class Coin {
 
 	public message(): MessageService {
 		if (!this.hasBeenSynchronized()) {
-			throw new BadMethodDependencyException(this.constructor.name, "message", "__construct");
+			throw new BadMethodDependencyException(this.constructor.name, this.message.name, "__construct");
 		}
 
 		return this.#services!.message;
@@ -154,7 +154,7 @@ export class Coin {
 
 	public multiSignature(): MultiSignatureService {
 		if (!this.hasBeenSynchronized()) {
-			throw new BadMethodDependencyException(this.constructor.name, "multiSignature", "__construct");
+			throw new BadMethodDependencyException(this.constructor.name, this.multiSignature.name, "__construct");
 		}
 
 		return this.#services!.multiSignature;
@@ -162,7 +162,7 @@ export class Coin {
 
 	public signatory(): SignatoryService {
 		if (!this.hasBeenSynchronized()) {
-			throw new BadMethodDependencyException(this.constructor.name, "signatory", "__construct");
+			throw new BadMethodDependencyException(this.constructor.name, this.signatory.name, "__construct");
 		}
 
 		return this.#services!.signatory;
@@ -170,7 +170,7 @@ export class Coin {
 
 	public transaction(): TransactionService {
 		if (!this.hasBeenSynchronized()) {
-			throw new BadMethodDependencyException(this.constructor.name, "transaction", "__construct");
+			throw new BadMethodDependencyException(this.constructor.name, this.transaction.name, "__construct");
 		}
 
 		return this.#services!.transaction;
@@ -178,7 +178,7 @@ export class Coin {
 
 	public walletDiscovery(): WalletDiscoveryService {
 		if (!this.hasBeenSynchronized()) {
-			throw new BadMethodDependencyException(this.constructor.name, "walletDiscovery", "__construct");
+			throw new BadMethodDependencyException(this.constructor.name, this.walletDiscovery.name, "__construct");
 		}
 
 		return this.#services!.walletDiscovery;

--- a/packages/platform-sdk/src/exceptions.test.ts
+++ b/packages/platform-sdk/src/exceptions.test.ts
@@ -11,7 +11,7 @@ import {
 
 test("NotImplemented", () => {
 	expect(() => {
-		throw new NotImplemented("klass", this.method.name);
+		throw new NotImplemented("klass", "method");
 	}).toThrow(`Method klass#method is not implemented.`);
 });
 

--- a/packages/platform-sdk/src/exceptions.test.ts
+++ b/packages/platform-sdk/src/exceptions.test.ts
@@ -11,7 +11,7 @@ import {
 
 test("NotImplemented", () => {
 	expect(() => {
-		throw new NotImplemented("klass", "method");
+		throw new NotImplemented("klass", this.method.name);
 	}).toThrow(`Method klass#method is not implemented.`);
 });
 

--- a/packages/platform-sdk/src/services/address.service.ts
+++ b/packages/platform-sdk/src/services/address.service.ts
@@ -6,30 +6,30 @@ import { IdentityOptions } from "./shared.contract";
 
 export abstract class AbstractAddressService implements AddressService {
 	public async fromMnemonic(mnemonic: string, options?: IdentityOptions): Promise<AddressDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromMultiSignature");
+		throw new NotImplemented(this.constructor.name, this.fromMultiSignature.name);
 	}
 
 	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<AddressDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromMultiSignature");
+		throw new NotImplemented(this.constructor.name, this.fromMultiSignature.name);
 	}
 
 	public async fromPublicKey(publicKey: string, options?: IdentityOptions): Promise<AddressDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromMultiSignature");
+		throw new NotImplemented(this.constructor.name, this.fromMultiSignature.name);
 	}
 
 	public async fromPrivateKey(privateKey: string, options?: IdentityOptions): Promise<AddressDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromPrivateKey");
+		throw new NotImplemented(this.constructor.name, this.fromPrivateKey.name);
 	}
 
 	public async fromWIF(wif: string): Promise<AddressDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromWIF");
+		throw new NotImplemented(this.constructor.name, this.fromWIF.name);
 	}
 
 	public async fromSecret(secret: string): Promise<AddressDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromSecret");
+		throw new NotImplemented(this.constructor.name, this.fromSecret.name);
 	}
 
 	public async validate(address: string): Promise<boolean> {
-		throw new NotImplemented(this.constructor.name, "fromMultiSignature");
+		throw new NotImplemented(this.constructor.name, this.fromMultiSignature.name);
 	}
 }

--- a/packages/platform-sdk/src/services/extended-address.service.ts
+++ b/packages/platform-sdk/src/services/extended-address.service.ts
@@ -5,10 +5,10 @@ import { ExtendedAddressDataTransferObject, ExtendedAddressService } from "./ext
 
 export abstract class AbstractExtendedAddressService implements ExtendedAddressService {
 	public async fromMnemonic(mnemonic: string, pageSize: number): Promise<ExtendedAddressDataTransferObject[]> {
-		throw new NotImplemented(this.constructor.name, "fromMultiSignature");
+		throw new NotImplemented(this.constructor.name, this.fromMultiSignature.name);
 	}
 
 	public async fromPrivateKey(privateKey: string, pageSize: number): Promise<ExtendedAddressDataTransferObject[]> {
-		throw new NotImplemented(this.constructor.name, "fromMultiSignature");
+		throw new NotImplemented(this.constructor.name, this.fromMultiSignature.name);
 	}
 }

--- a/packages/platform-sdk/src/services/extended-address.service.ts
+++ b/packages/platform-sdk/src/services/extended-address.service.ts
@@ -5,10 +5,10 @@ import { ExtendedAddressDataTransferObject, ExtendedAddressService } from "./ext
 
 export abstract class AbstractExtendedAddressService implements ExtendedAddressService {
 	public async fromMnemonic(mnemonic: string, pageSize: number): Promise<ExtendedAddressDataTransferObject[]> {
-		throw new NotImplemented(this.constructor.name, this.fromMultiSignature.name);
+		throw new NotImplemented(this.constructor.name, this.fromMnemonic.name);
 	}
 
 	public async fromPrivateKey(privateKey: string, pageSize: number): Promise<ExtendedAddressDataTransferObject[]> {
-		throw new NotImplemented(this.constructor.name, this.fromMultiSignature.name);
+		throw new NotImplemented(this.constructor.name, this.fromPrivateKey.name);
 	}
 }

--- a/packages/platform-sdk/src/services/key-pair.service.ts
+++ b/packages/platform-sdk/src/services/key-pair.service.ts
@@ -6,18 +6,18 @@ import { IdentityOptions } from "./shared.contract";
 
 export abstract class AbstractKeyPairService implements KeyPairService {
 	public async fromMnemonic(mnemonic: string, options?: IdentityOptions): Promise<KeyPairDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromMultiSignature");
+		throw new NotImplemented(this.constructor.name, this.fromMultiSignature.name);
 	}
 
 	public async fromPrivateKey(privateKey: string): Promise<KeyPairDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromPrivateKey");
+		throw new NotImplemented(this.constructor.name, this.fromPrivateKey.name);
 	}
 
 	public async fromWIF(wif: string): Promise<KeyPairDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromWIF");
+		throw new NotImplemented(this.constructor.name, this.fromWIF.name);
 	}
 
 	public async fromSecret(secret: string): Promise<KeyPairDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromSecret");
+		throw new NotImplemented(this.constructor.name, this.fromSecret.name);
 	}
 }

--- a/packages/platform-sdk/src/services/key-pair.service.ts
+++ b/packages/platform-sdk/src/services/key-pair.service.ts
@@ -6,7 +6,7 @@ import { IdentityOptions } from "./shared.contract";
 
 export abstract class AbstractKeyPairService implements KeyPairService {
 	public async fromMnemonic(mnemonic: string, options?: IdentityOptions): Promise<KeyPairDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, this.fromMultiSignature.name);
+		throw new NotImplemented(this.constructor.name, this.fromMnemonic.name);
 	}
 
 	public async fromPrivateKey(privateKey: string): Promise<KeyPairDataTransferObject> {

--- a/packages/platform-sdk/src/services/private-key.service.ts
+++ b/packages/platform-sdk/src/services/private-key.service.ts
@@ -6,14 +6,14 @@ import { IdentityOptions } from "./shared.contract";
 
 export abstract class AbstractPrivateKeyService implements PrivateKeyService {
 	public async fromMnemonic(mnemonic: string, options?: IdentityOptions): Promise<PrivateKeyDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromMultiSignature");
+		throw new NotImplemented(this.constructor.name, this.fromMultiSignature.name);
 	}
 
 	public async fromWIF(wif: string): Promise<PrivateKeyDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromWIF");
+		throw new NotImplemented(this.constructor.name, this.fromWIF.name);
 	}
 
 	public async fromSecret(secret: string): Promise<PrivateKeyDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromSecret");
+		throw new NotImplemented(this.constructor.name, this.fromSecret.name);
 	}
 }

--- a/packages/platform-sdk/src/services/private-key.service.ts
+++ b/packages/platform-sdk/src/services/private-key.service.ts
@@ -6,7 +6,7 @@ import { IdentityOptions } from "./shared.contract";
 
 export abstract class AbstractPrivateKeyService implements PrivateKeyService {
 	public async fromMnemonic(mnemonic: string, options?: IdentityOptions): Promise<PrivateKeyDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, this.fromMultiSignature.name);
+		throw new NotImplemented(this.constructor.name, this.fromMnemonic.name);
 	}
 
 	public async fromWIF(wif: string): Promise<PrivateKeyDataTransferObject> {

--- a/packages/platform-sdk/src/services/public-key.service.ts
+++ b/packages/platform-sdk/src/services/public-key.service.ts
@@ -6,18 +6,18 @@ import { IdentityOptions } from "./shared.contract";
 
 export abstract class AbstractPublicKeyService implements PublicKeyService {
 	public async fromMnemonic(mnemonic: string, options?: IdentityOptions): Promise<PublicKeyDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromMultiSignature");
+		throw new NotImplemented(this.constructor.name, this.fromMultiSignature.name);
 	}
 
 	public async fromMultiSignature(min: number, publicKeys: string[]): Promise<PublicKeyDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromMultiSignature");
+		throw new NotImplemented(this.constructor.name, this.fromMultiSignature.name);
 	}
 
 	public async fromWIF(wif: string): Promise<PublicKeyDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromWIF");
+		throw new NotImplemented(this.constructor.name, this.fromWIF.name);
 	}
 
 	public async fromSecret(secret: string): Promise<PublicKeyDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromSecret");
+		throw new NotImplemented(this.constructor.name, this.fromSecret.name);
 	}
 }

--- a/packages/platform-sdk/src/services/wif.service.ts
+++ b/packages/platform-sdk/src/services/wif.service.ts
@@ -6,14 +6,14 @@ import { WIFDataTransferObject, WIFService } from "./wif.contract";
 
 export abstract class AbstractWIFService implements WIFService {
 	public async fromMnemonic(mnemonic: string, options?: IdentityOptions): Promise<WIFDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromPrivateKey");
+		throw new NotImplemented(this.constructor.name, this.fromPrivateKey.name);
 	}
 
 	public async fromPrivateKey(privateKey: string): Promise<WIFDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromPrivateKey");
+		throw new NotImplemented(this.constructor.name, this.fromPrivateKey.name);
 	}
 
 	public async fromSecret(secret: string): Promise<WIFDataTransferObject> {
-		throw new NotImplemented(this.constructor.name, "fromSecret");
+		throw new NotImplemented(this.constructor.name, this.fromSecret.name);
 	}
 }

--- a/packages/platform-sdk/src/signatories/signatory.ts
+++ b/packages/platform-sdk/src/signatories/signatory.ts
@@ -35,11 +35,11 @@ export class Signatory {
 	public signingKey(): string {
 		// @TODO: deduplicate this
 		if (this.#signatory instanceof MultiMnemonicSignatory) {
-			throw new ForbiddenMethodCallException(this.constructor.name, "signingKey");
+			throw new ForbiddenMethodCallException(this.constructor.name, this.signingKey.name);
 		}
 
 		if (this.#signatory instanceof MultiSignatureSignatory) {
-			throw new ForbiddenMethodCallException(this.constructor.name, "signingKey");
+			throw new ForbiddenMethodCallException(this.constructor.name, this.signingKey.name);
 		}
 
 		return this.#signatory.signingKey();
@@ -55,7 +55,7 @@ export class Signatory {
 			return this.#signatory.signingKeys();
 		}
 
-		throw new ForbiddenMethodCallException(this.constructor.name, "signingKeys");
+		throw new ForbiddenMethodCallException(this.constructor.name, this.signingKeys.name);
 	}
 
 	public signingList(): MultiSignature {
@@ -63,7 +63,7 @@ export class Signatory {
 			return this.#signatory.signingList();
 		}
 
-		throw new ForbiddenMethodCallException(this.constructor.name, "signingList");
+		throw new ForbiddenMethodCallException(this.constructor.name, this.signingList.name);
 	}
 
 	public confirmKey(): string {
@@ -76,7 +76,7 @@ export class Signatory {
 			return this.#signatory.confirmKey();
 		}
 
-		throw new ForbiddenMethodCallException(this.constructor.name, "confirmKey");
+		throw new ForbiddenMethodCallException(this.constructor.name, this.confirmKey.name);
 	}
 
 	public identifier(): string {
@@ -84,12 +84,12 @@ export class Signatory {
 			return this.#signatory.identifier()!;
 		}
 
-		throw new ForbiddenMethodCallException(this.constructor.name, "identifier");
+		throw new ForbiddenMethodCallException(this.constructor.name, this.identifier.name);
 	}
 
 	public identifiers(): string[] {
 		if (!(this.#signatory instanceof MultiMnemonicSignatory)) {
-			throw new ForbiddenMethodCallException(this.constructor.name, "identifiers");
+			throw new ForbiddenMethodCallException(this.constructor.name, this.identifiers.name);
 		}
 
 		return this.#signatory.identifiers();
@@ -113,7 +113,7 @@ export class Signatory {
 			return this.#signatory.address();
 		}
 
-		throw new ForbiddenMethodCallException(this.constructor.name, "address");
+		throw new ForbiddenMethodCallException(this.constructor.name, this.address.name);
 	}
 
 	public publicKey(): string {
@@ -130,7 +130,7 @@ export class Signatory {
 			return this.#signatory.publicKey();
 		}
 
-		throw new ForbiddenMethodCallException(this.constructor.name, "publicKey");
+		throw new ForbiddenMethodCallException(this.constructor.name, this.publicKey.name);
 	}
 
 	public privateKey(): string {
@@ -147,7 +147,7 @@ export class Signatory {
 			return this.#signatory.privateKey();
 		}
 
-		throw new ForbiddenMethodCallException(this.constructor.name, "privateKey");
+		throw new ForbiddenMethodCallException(this.constructor.name, this.privateKey.name);
 	}
 
 	public actsWithMnemonic(): boolean {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Morph:

```typescript
import { Project, Node } from "ts-morph";

const project = new Project();
project.addSourceFilesAtPaths("packages/*/src/**/*.ts");

for (const file of project.getSourceFiles()) {
  file.forEachDescendant(node => {
    if (Node.isThrowStatement(node) && node.getText().match(/NotImplemented|NotSupported|InvalidArguments|MissingArgument|ForbiddenMethodCallException|BadMethodDependencyException|BadVariableDependencyException|\(/)) {
      const child = node.getExpression();
      if (Node.isNewExpression(child)) {
        const [_, method] = child.getArguments();
        if (Node.isStringLiteral(method)) {
          const value = method.getLiteralValue();
          if (!value.includes("#") && value !== "method") {
            method.replaceWithText(`this.${value}.name`);
          }
        }
      }
    }
  });
}

project.saveSync();

```

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
