### PR TITLE
feat(sdk): implement `BigNumberService`

### DIFF
--- a/packages/platform-sdk/src/coins/coin.test.ts
+++ b/packages/platform-sdk/src/coins/coin.test.ts
@@ -7,6 +7,7 @@ import { Network, NetworkRepository } from "../networks";
 import { Coin } from "./coin";
 import { Config } from "./config";
 import { Manifest } from "./manifest";
+import { BigNumberService } from "../../dist/services";
 
 let subject: Coin;
 
@@ -53,6 +54,15 @@ class ServiceProvider {
 		services.walletDiscovery.__construct();
 
 		return {
+			bigNumber: new BigNumberService(
+				// @ts-ignore
+				new Config(
+					{ network: "ark.mainnet" },
+					ValidatorSchema.object({
+						network: ValidatorSchema.string().valid("ark.mainnet", "ark.devnet"),
+					}),
+				),
+			),
 			client: services.client,
 			dataTransferObject: services.dataTransferObject,
 			fee: services.fee,
@@ -139,6 +149,16 @@ test("#manifest", () => {
 
 test("#config", () => {
 	expect(subject.config()).toBeInstanceOf(Config);
+});
+
+test("#bigNumber", async () => {
+	await subject.__construct();
+
+	expect(subject.bigNumber()).toBeObject();
+});
+
+test("#bigNumber with throw", async () => {
+	expect(() => subject.bigNumber()).toThrow();
 });
 
 test("#client", async () => {

--- a/packages/platform-sdk/src/coins/coin.ts
+++ b/packages/platform-sdk/src/coins/coin.ts
@@ -1,6 +1,7 @@
 import { BadMethodDependencyException } from "../exceptions";
 import { Network, NetworkManifest, NetworkRepository } from "../networks";
 import {
+	BigNumberService,
 	ClientService,
 	DataTransferObjectService,
 	FeeService,
@@ -84,6 +85,14 @@ export class Coin {
 
 	public config(): Config {
 		return this.#config;
+	}
+
+	public bigNumber(): BigNumberService {
+		if (!this.hasBeenSynchronized()) {
+			throw new BadMethodDependencyException(this.constructor.name, this.bigNumber.name, "__construct");
+		}
+
+		return this.#services!.bigNumber;
 	}
 
 	public client(): ClientService {

--- a/packages/platform-sdk/src/coins/contracts.ts
+++ b/packages/platform-sdk/src/coins/contracts.ts
@@ -15,6 +15,7 @@ import {
 	TransactionService,
 	WalletDiscoveryService,
 } from "../services";
+import { BigNumberService } from "../services/big-number.service";
 
 export interface CoinSpec {
 	manifest: CoinManifest;
@@ -28,6 +29,7 @@ export interface CoinOptions {
 }
 
 export interface CoinServices {
+	bigNumber: BigNumberService;
 	client: ClientService;
 	dataTransferObject: DataTransferObjectService;
 	fee: FeeService;

--- a/packages/platform-sdk/src/ioc/service-provider.ts
+++ b/packages/platform-sdk/src/ioc/service-provider.ts
@@ -1,11 +1,13 @@
 /* istanbul ignore file */
 
 import { CoinServices, CoinSpec, Config } from "../coins";
+import { BigNumberService } from "../services/big-number.service";
 import { Container } from "./container";
 
 export type ServiceList = Record<string, { __construct: Function }>;
 
 export const ServiceKeys = {
+	BigNumberService: Symbol("BigNumberService"),
 	ClientService: Symbol("ClientService"),
 	DataTransferObjectService: Symbol("DataTransferObjectService"),
 	FeeService: Symbol("FeeService"),
@@ -77,6 +79,7 @@ export abstract class AbstractServiceProvider {
 		]);
 
 		return {
+			bigNumber: new BigNumberService(this.#config),
 			client,
 			dataTransferObject,
 			fee,
@@ -93,6 +96,7 @@ export abstract class AbstractServiceProvider {
 	}
 
 	protected bindServices(services: CoinServices, container: Container): void {
+		container.constant(ServiceKeys.BigNumberService, services.bigNumber);
 		container.constant(ServiceKeys.ClientService, services.client);
 		container.constant(ServiceKeys.DataTransferObjectService, services.dataTransferObject);
 		container.constant(ServiceKeys.FeeService, services.fee);

--- a/packages/platform-sdk/src/services/big-number.service.ts
+++ b/packages/platform-sdk/src/services/big-number.service.ts
@@ -1,0 +1,15 @@
+import { BigNumber, NumberLike } from "@arkecosystem/platform-sdk-support";
+
+import { Config, ConfigKey } from "../coins";
+
+export class BigNumberService {
+	readonly #config: Config;
+
+	public constructor(config: Config) {
+		this.#config = config;
+	}
+
+	public make(value: NumberLike): BigNumber {
+		return BigNumber.make(value, this.#config.get<number>(ConfigKey.CurrencyDecimals));
+	}
+}

--- a/packages/platform-sdk/src/services/big-number.test.ts
+++ b/packages/platform-sdk/src/services/big-number.test.ts
@@ -1,0 +1,25 @@
+import "jest-extended";
+import Joi from "joi";
+
+import { BigNumberService } from "./big-number.service";
+import { Config } from "../coins";
+
+test.each([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])("#make(%s)", async (power) => {
+	const subject = new BigNumberService(
+		new Config({
+			network: {
+				currency: {
+					decimals: power,
+				}
+			}
+		}, Joi.object({
+			network: Joi.object({
+				currency: Joi.object({
+					decimals: Joi.number(),
+				})
+			})
+		}))
+	);
+
+	expect(subject.make(`1${"0".repeat(power)}`).toHuman()).toBe("1");
+});

--- a/packages/platform-sdk/src/services/index.ts
+++ b/packages/platform-sdk/src/services/index.ts
@@ -1,5 +1,6 @@
 export * from "./address.contract";
 export * from "./address.service";
+export * from "./big-number.service";
 export * from "./client.contract";
 export * from "./client.service";
 export * from "./data-transfer-object.contract";
@@ -26,6 +27,7 @@ export * from "./private-key.contract";
 export * from "./private-key.service";
 export * from "./public-key.contract";
 export * from "./public-key.service";
+export * from "./shared.contract";
 export * from "./signatory.contract";
 export * from "./signatory.service";
 export * from "./transaction.contract";
@@ -34,5 +36,3 @@ export * from "./wallet-discovery.contract";
 export * from "./wallet-discovery.service";
 export * from "./wif.contract";
 export * from "./wif.service";
-// @TODO: remove
-export * from "./shared.contract";


### PR DESCRIPTION
This service can be accessed through every coin instance like `coin.bigNumber().make(value)` and will remove the need for passing around the decimals as much as it is currently done.