### PR TITLE
fix(json-rpc): remove `coin` and `network` parameters after consuming them

### DIFF
--- a/packages/platform-sdk-json-rpc/src/helpers.ts
+++ b/packages/platform-sdk-json-rpc/src/helpers.ts
@@ -5,19 +5,22 @@ import Joi from "joi";
 
 const coins: Record<string, Coins.Coin> = {};
 
-export const makeCoin = async (coin: string, network: string): Promise<Coins.Coin> => {
-	const cacheKey = `${coin}.${network}`;
+export const makeCoin = async (input: Record<string, string>): Promise<Coins.Coin> => {
+	const cacheKey = `${input.coin}.${input.network}`;
 
 	if (coins[cacheKey]) {
 		return coins[cacheKey];
 	}
 
-	coins[cacheKey] = Coins.CoinFactory.make({ ARK }[coin]!, {
-		network,
+	coins[cacheKey] = Coins.CoinFactory.make({ ARK }[input.coin]!, {
+		network: input.network,
 		httpClient: new Request(),
 	});
 
 	await coins[cacheKey].__construct();
+
+	delete input.coin;
+	delete input.network;
 
 	return coins[cacheKey];
 };

--- a/packages/platform-sdk-json-rpc/src/index.ts
+++ b/packages/platform-sdk-json-rpc/src/index.ts
@@ -40,12 +40,6 @@ export const subscribe = async (flags: {
 		},
 	});
 
-	// $transactions = $this->request('client.transactions', [
-	// 	'coin'      => $wallet->coin->name, // @FIXME
-	// 	'network'   => $wallet->coin->type, // @FIXME
-	// 	'recipient' => $wallet->address, // @FIXME
-	// ]);
-
 	await server.register({
 		plugin: require("@konceiver/hapi-json-rpc"),
 		options: {

--- a/packages/platform-sdk-json-rpc/src/index.ts
+++ b/packages/platform-sdk-json-rpc/src/index.ts
@@ -40,6 +40,12 @@ export const subscribe = async (flags: {
 		},
 	});
 
+	// $transactions = $this->request('client.transactions', [
+	// 	'coin'      => $wallet->coin->name, // @FIXME
+	// 	'network'   => $wallet->coin->type, // @FIXME
+	// 	'recipient' => $wallet->address, // @FIXME
+	// ]);
+
 	await server.register({
 		plugin: require("@konceiver/hapi-json-rpc"),
 		options: {

--- a/packages/platform-sdk-json-rpc/src/methods/client.ts
+++ b/packages/platform-sdk-json-rpc/src/methods/client.ts
@@ -6,7 +6,7 @@ export const registerClient = () => [
 	{
 		name: "client.transaction",
 		async method({ coin, network, id }) {
-			return (await (await makeCoin(coin, network)).client().transaction(id)).toObject();
+			return (await (await makeCoin({ coin, network })).client().transaction(id)).toObject();
 		},
 		schema: Joi.object({
 			...baseSchema,
@@ -16,7 +16,7 @@ export const registerClient = () => [
 	{
 		name: "client.transactions",
 		async method(input) {
-			const coin = await makeCoin(input.coin, input.network);
+			const coin = await makeCoin(input);
 			const transactions = await coin.client().transactions(input);
 
 			return {
@@ -51,7 +51,7 @@ export const registerClient = () => [
 	{
 		name: "client.wallet",
 		async method({ coin, network, id }) {
-			return (await (await makeCoin(coin, network)).client().wallet(id)).toObject();
+			return (await (await makeCoin({ coin, network })).client().wallet(id)).toObject();
 		},
 		schema: Joi.object({
 			...baseSchema,
@@ -61,7 +61,7 @@ export const registerClient = () => [
 	{
 		name: "client.delegate",
 		async method({ coin, network, id }) {
-			return (await (await makeCoin(coin, network)).client().delegate(id)).toObject();
+			return (await (await makeCoin({ coin, network })).client().delegate(id)).toObject();
 		},
 		schema: Joi.object({
 			...baseSchema,
@@ -71,7 +71,7 @@ export const registerClient = () => [
 	{
 		name: "client.broadcast",
 		async method({ coin, network, id, data }) {
-			return (await makeCoin(coin, network)).client().broadcast([
+			return (await makeCoin({ coin, network })).client().broadcast([
 				// @ts-ignore
 				{
 					id: () => id,

--- a/packages/platform-sdk-json-rpc/src/methods/identity/address.ts
+++ b/packages/platform-sdk-json-rpc/src/methods/identity/address.ts
@@ -6,14 +6,14 @@ export const registerAddress = () => [
 	{
 		name: "identity.address.fromMnemonic",
 		async method({ coin, network, mnemonic }) {
-			return (await makeCoin(coin, network)).identity().address().fromMnemonic(mnemonic);
+			return (await makeCoin({ coin, network })).identity().address().fromMnemonic(mnemonic);
 		},
 		schema: Joi.object({ ...baseSchema, mnemonic: Joi.string().required() }).required(),
 	},
 	{
 		name: "identity.address.fromMultiSignature",
 		async method({ coin, network, min, publicKeys }) {
-			return (await makeCoin(coin, network)).identity().address().fromMultiSignature(min, publicKeys);
+			return (await makeCoin({ coin, network })).identity().address().fromMultiSignature(min, publicKeys);
 		},
 		schema: Joi.object({
 			...baseSchema,
@@ -24,28 +24,28 @@ export const registerAddress = () => [
 	{
 		name: "identity.address.fromPublicKey",
 		async method({ coin, network, publicKey }) {
-			return (await makeCoin(coin, network)).identity().address().fromPublicKey(publicKey);
+			return (await makeCoin({ coin, network })).identity().address().fromPublicKey(publicKey);
 		},
 		schema: Joi.object({ ...baseSchema, publicKey: Joi.string().required() }).required(),
 	},
 	{
 		name: "identity.address.fromPrivateKey",
 		async method({ coin, network, privateKey }) {
-			return (await makeCoin(coin, network)).identity().address().fromPrivateKey(privateKey);
+			return (await makeCoin({ coin, network })).identity().address().fromPrivateKey(privateKey);
 		},
 		schema: Joi.object({ ...baseSchema, privateKey: Joi.string().required() }).required(),
 	},
 	{
 		name: "identity.address.fromWIF",
 		async method({ coin, network, wif }) {
-			return (await makeCoin(coin, network)).identity().address().fromWIF(wif);
+			return (await makeCoin({ coin, network })).identity().address().fromWIF(wif);
 		},
 		schema: Joi.object({ ...baseSchema, wif: Joi.string().required() }).required(),
 	},
 	{
 		name: "identity.address.validate",
 		async method({ coin, network, address }) {
-			return (await makeCoin(coin, network)).identity().address().validate(address);
+			return (await makeCoin({ coin, network })).identity().address().validate(address);
 		},
 		schema: Joi.object({ ...baseSchema, address: Joi.string().required() }).required(),
 	},

--- a/packages/platform-sdk-json-rpc/src/methods/identity/keys.ts
+++ b/packages/platform-sdk-json-rpc/src/methods/identity/keys.ts
@@ -6,21 +6,21 @@ export const registerKeys = () => [
 	{
 		name: "identity.keyPair.fromMnemonic",
 		async method({ coin, network, mnemonic }) {
-			return (await makeCoin(coin, network)).identity().keyPair().fromMnemonic(mnemonic);
+			return (await makeCoin({ coin, network })).identity().keyPair().fromMnemonic(mnemonic);
 		},
 		schema: Joi.object({ ...baseSchema, mnemonic: Joi.string().required() }).required(),
 	},
 	{
 		name: "identity.keyPair.fromPrivateKey",
 		async method({ coin, network, privateKey }) {
-			return (await makeCoin(coin, network)).identity().keyPair().fromPrivateKey(privateKey);
+			return (await makeCoin({ coin, network })).identity().keyPair().fromPrivateKey(privateKey);
 		},
 		schema: Joi.object({ ...baseSchema, privateKey: Joi.string().required() }).required(),
 	},
 	{
 		name: "identity.keyPair.fromWIF",
 		async method({ coin, network, wif }) {
-			return (await makeCoin(coin, network)).identity().keyPair().fromWIF(wif);
+			return (await makeCoin({ coin, network })).identity().keyPair().fromWIF(wif);
 		},
 		schema: Joi.object({ ...baseSchema, wif: Joi.string().required() }).required(),
 	},

--- a/packages/platform-sdk-json-rpc/src/methods/identity/private-key.ts
+++ b/packages/platform-sdk-json-rpc/src/methods/identity/private-key.ts
@@ -6,14 +6,14 @@ export const registerPrivateKey = () => [
 	{
 		name: "identity.privateKey.fromMnemonic",
 		async method({ coin, network, mnemonic }) {
-			return (await makeCoin(coin, network)).identity().privateKey().fromMnemonic(mnemonic);
+			return (await makeCoin({ coin, network })).identity().privateKey().fromMnemonic(mnemonic);
 		},
 		schema: Joi.object({ ...baseSchema, mnemonic: Joi.string().required() }).required(),
 	},
 	{
 		name: "identity.privateKey.fromWIF",
 		async method({ coin, network, wif }) {
-			return (await makeCoin(coin, network)).identity().privateKey().fromWIF(wif);
+			return (await makeCoin({ coin, network })).identity().privateKey().fromWIF(wif);
 		},
 		schema: Joi.object({ ...baseSchema, wif: Joi.string().required() }).required(),
 	},

--- a/packages/platform-sdk-json-rpc/src/methods/identity/public-key.ts
+++ b/packages/platform-sdk-json-rpc/src/methods/identity/public-key.ts
@@ -6,14 +6,14 @@ export const registerPublicKey = () => [
 	{
 		name: "identity.publicKey.fromMnemonic",
 		async method({ coin, network, mnemonic }) {
-			return (await makeCoin(coin, network)).identity().publicKey().fromMnemonic(mnemonic);
+			return (await makeCoin({ coin, network })).identity().publicKey().fromMnemonic(mnemonic);
 		},
 		schema: Joi.object({ ...baseSchema, mnemonic: Joi.string().required() }).required(),
 	},
 	{
 		name: "identity.publicKey.fromMultiSignature",
 		async method({ coin, network, min, publicKeys }) {
-			return (await makeCoin(coin, network)).identity().publicKey().fromMultiSignature(min, publicKeys);
+			return (await makeCoin({ coin, network })).identity().publicKey().fromMultiSignature(min, publicKeys);
 		},
 		schema: Joi.object({
 			...baseSchema,
@@ -24,7 +24,7 @@ export const registerPublicKey = () => [
 	{
 		name: "identity.publicKey.fromWIF",
 		async method({ coin, network, wif }) {
-			return (await makeCoin(coin, network)).identity().publicKey().fromWIF(wif);
+			return (await makeCoin({ coin, network })).identity().publicKey().fromWIF(wif);
 		},
 		schema: Joi.object({ ...baseSchema, wif: Joi.string().required() }).required(),
 	},

--- a/packages/platform-sdk-json-rpc/src/methods/identity/wif.ts
+++ b/packages/platform-sdk-json-rpc/src/methods/identity/wif.ts
@@ -6,14 +6,14 @@ export const registerWIF = () => [
 	{
 		name: "identity.wif.fromMnemonic",
 		async method({ coin, network, mnemonic }) {
-			return (await makeCoin(coin, network)).identity().wif().fromMnemonic(mnemonic);
+			return (await makeCoin({ coin, network })).identity().wif().fromMnemonic(mnemonic);
 		},
 		schema: Joi.object({ ...baseSchema, mnemonic: Joi.string().required() }).required(),
 	},
 	{
 		name: "identity.wif.fromPrivateKey",
 		async method({ coin, network, privateKey }) {
-			return (await makeCoin(coin, network)).identity().wif().fromPrivateKey(privateKey);
+			return (await makeCoin({ coin, network })).identity().wif().fromPrivateKey(privateKey);
 		},
 		schema: Joi.object({ ...baseSchema, privateKey: Joi.string().required() }).required(),
 	},

--- a/packages/platform-sdk-json-rpc/src/methods/message.ts
+++ b/packages/platform-sdk-json-rpc/src/methods/message.ts
@@ -6,7 +6,7 @@ export const registerMessage = () => [
 	{
 		name: "message.sign",
 		async method(input) {
-			const coin = await makeCoin(input.coin, input.network);
+			const coin = await makeCoin(input);
 
 			return coin.message().sign({
 				...input,
@@ -22,7 +22,7 @@ export const registerMessage = () => [
 	{
 		name: "message.verify",
 		async method(input) {
-			return (await makeCoin(input.coin, input.network)).message().verify(input);
+			return (await makeCoin(input)).message().verify(input);
 		},
 		schema: Joi.object({
 			...baseSchema,

--- a/packages/platform-sdk-json-rpc/src/methods/transaction.ts
+++ b/packages/platform-sdk-json-rpc/src/methods/transaction.ts
@@ -6,7 +6,7 @@ export const registerTransaction = () => [
 	{
 		name: "transaction.transfer",
 		async method(input) {
-			const coin = await makeCoin(input.coin, input.network);
+			const coin = await makeCoin(input);
 			const signedTransaction = await coin.transaction().transfer({
 				...input,
 				signatory: await coin.signatory().mnemonic(input.sign.mnemonic),

--- a/packages/platform-sdk-json-rpc/src/methods/wallet.ts
+++ b/packages/platform-sdk-json-rpc/src/methods/wallet.ts
@@ -7,7 +7,7 @@ export const registerWallet = () => [
 	{
 		name: "wallet.generate",
 		async method({ coin, network }) {
-			const instance = await makeCoin(coin, network);
+			const instance = await makeCoin({ coin, network });
 			const mnemonic = BIP39.generate();
 
 			return {


### PR DESCRIPTION
If not removed they will be sent to APIs and can result in errors if strict validation is used remotely.