### PR TITLE
refactor(btc-indexer): only ignore error if unique constraint violation

### DIFF
--- a/packages/platform-sdk-btc-indexer/src/database.ts
+++ b/packages/platform-sdk-btc-indexer/src/database.ts
@@ -2,7 +2,7 @@ import { BigNumber } from "@arkecosystem/utils";
 import envPaths from "env-paths";
 import { ensureFileSync } from "fs-extra";
 
-import { PrismaClient } from "../prisma/generated";
+import { Prisma, PrismaClient } from "../prisma/generated";
 import { Logger } from "./logger";
 import { getAmount, getFees, getInputs, getOutputs } from "./tx-parsing-helpers";
 import { Flags, Input, Output } from "./types";
@@ -177,9 +177,16 @@ export class Database {
 					},
 				},
 			});
-		} catch {
-			// Ignore, there's nothing to update if already exists
-			// We could query for existence before creation, but it doesn't really make sense
+		} catch (e) {
+			if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
+				// Unique contraint validation. Ignore, there's nothing to update if already exists
+				// We could query for existence before creation, but it doesn't really make sense
+				this.#logger.info(`Ignoring transaction ${transaction.txid} from block ${blockId} as it already exists`);
+			} else {
+				// If there's an error, we don't want to proceed, as this will affect future utxos
+				// It means there's a programming error and we need to fix it
+				throw e;
+			}
 		}
 
 		await this.#prisma.$transaction(utxoUpdates);

--- a/packages/platform-sdk-btc-indexer/src/database.ts
+++ b/packages/platform-sdk-btc-indexer/src/database.ts
@@ -181,7 +181,9 @@ export class Database {
 			if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
 				// Unique contraint validation. Ignore, there's nothing to update if already exists
 				// We could query for existence before creation, but it doesn't really make sense
-				this.#logger.info(`Ignoring transaction ${transaction.txid} from block ${blockId} as it already exists`);
+				this.#logger.info(
+					`Ignoring transaction ${transaction.txid} from block ${blockId} as it already exists`,
+				);
 			} else {
 				// If there's an error, we don't want to proceed, as this will affect future utxos
 				// It means there's a programming error and we need to fix it

--- a/packages/platform-sdk/src/coins/coin.ts
+++ b/packages/platform-sdk/src/coins/coin.ts
@@ -46,7 +46,7 @@ export class Coin {
 
 	public async __destruct(): Promise<void> {
 		/* istanbul ignore next */
-		if (! this.hasBeenSynchronized()) {
+		if (!this.hasBeenSynchronized()) {
 			/* istanbul ignore next */
 			return;
 		}


### PR DESCRIPTION
Implementation that considers error and stops if not a unique constraint violation

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
