### PR TITLE
refactor(btc-indexer): store pending blocks in database

### DIFF
--- a/packages/platform-sdk-btc-indexer/bin/meow.js
+++ b/packages/platform-sdk-btc-indexer/bin/meow.js
@@ -22,7 +22,7 @@ module.exports = meow(
 			},
 			batchSize: {
 				type: "number",
-				default: 50,
+				default: 100,
 			},
 		},
 	},

--- a/packages/platform-sdk-btc-indexer/prisma/migrations/20210608105900_pending_blocks/migration.sql
+++ b/packages/platform-sdk-btc-indexer/prisma/migrations/20210608105900_pending_blocks/migration.sql
@@ -1,11 +1,7 @@
 -- CreateTable
 CREATE TABLE "PendingBlock" (
     "height" INTEGER NOT NULL,
-    "hash" TEXT NOT NULL,
     "payload" JSONB NOT NULL,
 
     PRIMARY KEY ("height")
 );
-
--- CreateIndex
-CREATE UNIQUE INDEX "PendingBlock.hash_unique" ON "PendingBlock"("hash");

--- a/packages/platform-sdk-btc-indexer/prisma/migrations/20210608105900_pending_blocks/migration.sql
+++ b/packages/platform-sdk-btc-indexer/prisma/migrations/20210608105900_pending_blocks/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "PendingBlock" (
+    "height" INTEGER NOT NULL,
+    "hash" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+
+    PRIMARY KEY ("height")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PendingBlock.hash_unique" ON "PendingBlock"("hash");

--- a/packages/platform-sdk-btc-indexer/prisma/schema.prisma
+++ b/packages/platform-sdk-btc-indexer/prisma/schema.prisma
@@ -1,38 +1,45 @@
 generator client {
-  provider = "prisma-client-js"
-  output   = "./generated"
-  binaryTargets = ["debian-openssl-1.1.x", "darwin", "native"]
+    provider      = "prisma-client-js"
+    output        = "./generated"
+    binaryTargets = ["debian-openssl-1.1.x", "darwin", "native"]
 }
 
 datasource db {
-  provider = "postgres"
-  url      = env("DATABASE_URL")
+    provider = "postgres"
+    url      = env("DATABASE_URL")
+}
+
+model PendingBlock {
+    height  Int    @id
+    hash    String @unique
+    payload Json
 }
 
 model Block {
-  height		Int    			@id
-  hash			String			@unique
-  transactions	Transaction[]
+    height       Int           @id
+    hash         String        @unique
+    transactions Transaction[]
 }
 
 model Transaction {
-  hash				String				@id
-  block				Block				@relation(fields: block_id, references: height)
-  block_id			Int
-  time				Int
-  amount			BigInt
-  fee				BigInt
-  transaction_parts	TransactionPart[]
+    hash              String            @id
+    block             Block             @relation(fields: block_id, references: height)
+    block_id          Int
+    time              Int
+    amount            BigInt
+    fee               BigInt
+    transaction_parts TransactionPart[]
 }
 
 model TransactionPart {
-  output_hash  String
-  output_idx   Int
-  input_hash   String?
-  input_idx    Int?
-  amount       BigInt
-  address      Json?
-  transaction Transaction @relation(fields: [output_hash], references: [hash])
-  @@id([output_hash, output_idx])
-  @@unique([input_hash, input_idx], name: "transaction_input_hash_index")
+    output_hash String
+    output_idx  Int
+    input_hash  String?
+    input_idx   Int?
+    amount      BigInt
+    address     Json?
+    transaction Transaction @relation(fields: [output_hash], references: [hash])
+
+    @@id([output_hash, output_idx])
+    @@unique([input_hash, input_idx], name: "transaction_input_hash_index")
 }

--- a/packages/platform-sdk-btc-indexer/prisma/schema.prisma
+++ b/packages/platform-sdk-btc-indexer/prisma/schema.prisma
@@ -11,7 +11,6 @@ datasource db {
 
 model PendingBlock {
     height  Int    @id
-    hash    String @unique
     payload Json
 }
 

--- a/packages/platform-sdk-btc-indexer/src/client.ts
+++ b/packages/platform-sdk-btc-indexer/src/client.ts
@@ -62,13 +62,13 @@ export class Client {
 	 * @memberof Client
 	 */
 	async #post<T = Record<string, any>>(method: string, params: any): Promise<T> {
-		return (
-			await this.#client.post("/", {
-				jsonrpc: "1.0",
-				id: uuidv4(),
-				method,
-				params,
-			})
-		).json().result;
+		const response = await this.#client.retry(5).post("/", {
+			jsonrpc: "1.0",
+			id: uuidv4(),
+			method,
+			params,
+		});
+
+		return response.json().result;
 	}
 }

--- a/packages/platform-sdk-btc-indexer/src/database.ts
+++ b/packages/platform-sdk-btc-indexer/src/database.ts
@@ -44,7 +44,7 @@ export class Database {
 	 * @memberof Database
 	 */
 	public async lastBlockNumber(): Promise<number> {
-		const lastBlockHeight = await this.#prisma.pendingBlock.aggregate({
+		const lastBlockHeight = await this.#prisma.block.aggregate({
 			_max: {
 				height: true,
 			},

--- a/packages/platform-sdk-btc-indexer/src/database.ts
+++ b/packages/platform-sdk-btc-indexer/src/database.ts
@@ -96,7 +96,7 @@ export class Database {
 					lte: max,
 				},
 			},
-			select: { height: true},
+			select: { height: true },
 		});
 	}
 

--- a/packages/platform-sdk-btc-indexer/src/database.ts
+++ b/packages/platform-sdk-btc-indexer/src/database.ts
@@ -56,7 +56,7 @@ export class Database {
 	public async allPendingBlocks(): Promise<any[]> {
 		return this.#prisma.pendingBlock.findMany({
 			skip: 0,
-			take: 10000,
+			take: 1000,
 			orderBy: {
 				height: "asc",
 			},

--- a/packages/platform-sdk-btc-indexer/src/database.ts
+++ b/packages/platform-sdk-btc-indexer/src/database.ts
@@ -89,6 +89,18 @@ export class Database {
 		}
 	}
 
+	public async alreadyDownloadedBlocks(min: number, max: number): Promise<{ height: number }[]> {
+		return this.#prisma.pendingBlock.findMany({
+			where: {
+				height: {
+					gte: min,
+					lte: max,
+				},
+			},
+			select: { height: true},
+		});
+	}
+
 	/**
 	 * Stores a block and all of its transactions.
 	 *

--- a/packages/platform-sdk-btc-indexer/src/database.ts
+++ b/packages/platform-sdk-btc-indexer/src/database.ts
@@ -56,7 +56,7 @@ export class Database {
 	public async allPendingBlocks(): Promise<any[]> {
 		return this.#prisma.pendingBlock.findMany({
 			skip: 0,
-			take: 1000,
+			take: 10000,
 			orderBy: {
 				height: "asc",
 			},

--- a/packages/platform-sdk-btc-indexer/src/database.ts
+++ b/packages/platform-sdk-btc-indexer/src/database.ts
@@ -69,7 +69,6 @@ export class Database {
 				height: block.height,
 			},
 			create: {
-				hash: block.hash,
 				height: block.height,
 				payload: block,
 			},

--- a/packages/platform-sdk-btc-indexer/src/helpers.ts
+++ b/packages/platform-sdk-btc-indexer/src/helpers.ts
@@ -28,3 +28,23 @@ export const useLogger = (): Logger => new Logger();
  * @returns {Client}
  */
 export const useClient = (flags: Flags): Client => new Client(flags);
+
+export const processPendingBlocks = async (logger: Logger, database: Database): Promise<void> => {
+	logger.info("Checking for pending blocks...");
+
+	const blocks = await database.allPendingBlocks();
+
+	for (const block of blocks) {
+		try {
+			await database.storeBlockWithTransactions(block.payload);
+
+			await database.deletePendingBlock(block.height);
+		} catch (error) {
+			logger.info(`[FAILURE] Block #${block.height} failed to be upserted: ${error.message}`);
+		}
+	}
+
+	if (blocks.length) {
+		logger.info(`Processed ${blocks.length} blocks 🎉`);
+	}
+};

--- a/packages/platform-sdk-btc-indexer/src/index.ts
+++ b/packages/platform-sdk-btc-indexer/src/index.ts
@@ -25,15 +25,17 @@ export const subscribe = async (flags: Flags): Promise<void> => {
 
 	logger.info(`Starting at block ${localHeight}...`);
 
-	const alreadyDownloaded = await database.alreadyDownloadedBlocks(localHeight, remoteHeight);
+	const alreadyDownloaded: Set<number> = new Set();
+	(await database.alreadyDownloadedBlocks(localHeight, remoteHeight)).forEach((downloaded) =>
+		alreadyDownloaded.add(downloaded.height),
+	);
 
 	const range = [...Array(remoteHeight + 1).keys()]
-		.filter(value => remoteHeight >= value && localHeight <= value );
+		.filter((value) => remoteHeight >= value && localHeight <= value)
+		.filter((value) => !alreadyDownloaded.has(value));
 
 	for (const blockHeight of range) {
-		if (alreadyDownloaded.find(ah => ah.height === blockHeight) === undefined) {
-			downloadQueue.add(async () => database.storePendingBlock(await client.blockWithTransactions(blockHeight)));
-		}
+		downloadQueue.add(async () => database.storePendingBlock(await client.blockWithTransactions(blockHeight)));
 	}
 
 	setInterval(async () => processPendingBlocks(logger, database), 60000); // Every 60 seconds

--- a/packages/platform-sdk-btc-indexer/src/index.ts
+++ b/packages/platform-sdk-btc-indexer/src/index.ts
@@ -23,7 +23,7 @@ export const subscribe = async (flags: Flags): Promise<void> => {
 
 	const [localHeight, remoteHeight] = [await database.lastBlockNumber(), await client.height()];
 
-	logger.info(`Starting at block ${localHeight}...`);
+	logger.info(`Starting at block height ${localHeight}.`);
 
 	const alreadyDownloaded: Set<number> = new Set();
 	(await database.alreadyDownloadedBlocks(localHeight, remoteHeight)).forEach((downloaded) =>

--- a/packages/platform-sdk-btc-indexer/src/index.ts
+++ b/packages/platform-sdk-btc-indexer/src/index.ts
@@ -23,7 +23,12 @@ export const subscribe = async (flags: Flags): Promise<void> => {
 
 	const [localHeight, remoteHeight] = [await database.lastBlockNumber(), await client.height()];
 
-	for (const blockHeight of [...Array(Math.abs(localHeight - (remoteHeight + 1))).keys()]) {
+	logger.info(`Starting at block ${localHeight}...`);
+
+	const range = [...Array(remoteHeight + 1).keys()]
+		.filter(value => remoteHeight >= value && localHeight <= value );
+
+	for (const blockHeight of range) {
 		downloadQueue.add(async () => database.storePendingBlock(await client.blockWithTransactions(blockHeight)));
 	}
 

--- a/packages/platform-sdk-btc-indexer/src/index.ts
+++ b/packages/platform-sdk-btc-indexer/src/index.ts
@@ -1,9 +1,8 @@
 import execa from "execa";
 import PQueue from "p-queue";
-import PWaitFor from "p-wait-for";
 import path from "path";
 
-import { useClient, useDatabase, useLogger } from "./helpers";
+import { processPendingBlocks, useClient, useDatabase, useLogger } from "./helpers";
 import { Logger } from "./logger";
 import { Flags } from "./types";
 
@@ -19,36 +18,22 @@ export const subscribe = async (flags: Flags): Promise<void> => {
 	const logger: Logger = useLogger();
 	const database = useDatabase(flags, logger);
 	const client = useClient(flags);
-	const step: number = flags.batchSize;
 
-	const fetchingQueue = new PQueue({ concurrency: step });
-	const toBeProcessed: object = {};
+	const downloadQueue = new PQueue({ concurrency: flags.batchSize });
+	// downloadQueue.on("add", () =>
+	// 	logger.debug(`Task is added. Size: ${downloadQueue.size} | Pending: ${downloadQueue.pending}`),
+	// );
+	// downloadQueue.on("next", () =>
+	// 	logger.debug(`Task is completed. Size: ${downloadQueue.size} | Pending: ${downloadQueue.pending}`),
+	// );
 
-	// Get the last block we stored in the database and grab the latest block
-	// on the network so that we can sync the missing blocks to complete our
-	// copy of the blockchain to avoid holes in the historical data of users.
 	const [localHeight, remoteHeight] = [await database.lastBlockNumber(), await client.height()];
 
-	const addBlock = (blockHeight) =>
-		fetchingQueue.add(async () => (toBeProcessed[blockHeight] = await client.blockWithTransactions(blockHeight)));
-	// Load initial batch of size = {step}
-	for (let i = localHeight; i < Math.min(localHeight + step, remoteHeight); i++) {
-		logger.info(`adding block ${i} to queue`);
-		void addBlock(i);
+	for (const blockHeight of [...Array(Math.abs(localHeight - (remoteHeight + 1))).keys()]) {
+		downloadQueue.add(async () => database.storePendingBlock(await client.blockWithTransactions(blockHeight)));
 	}
 
-	// Process sequential, in order and with no gaps
-	for (let j = localHeight; j <= remoteHeight; j++) {
-		logger.info(`processing block ${j}`);
-		await PWaitFor(() => toBeProcessed[j] !== undefined);
-		await database.storeBlockWithTransactions(toBeProcessed[j]);
-
-		// Schedule fetching of next block (if still not done)
-		const nextBlock: number = j + step;
-		if (nextBlock < remoteHeight) {
-			void addBlock(nextBlock);
-		}
-	}
+	setInterval(async () => processPendingBlocks(logger, database), 60000); // Every 60 seconds
 };
 
 const runMigrations = async (): Promise<void> => {

--- a/packages/platform-sdk-btc-indexer/src/index.ts
+++ b/packages/platform-sdk-btc-indexer/src/index.ts
@@ -20,12 +20,6 @@ export const subscribe = async (flags: Flags): Promise<void> => {
 	const client = useClient(flags);
 
 	const downloadQueue = new PQueue({ concurrency: flags.batchSize });
-	// downloadQueue.on("add", () =>
-	// 	logger.debug(`Task is added. Size: ${downloadQueue.size} | Pending: ${downloadQueue.pending}`),
-	// );
-	// downloadQueue.on("next", () =>
-	// 	logger.debug(`Task is completed. Size: ${downloadQueue.size} | Pending: ${downloadQueue.pending}`),
-	// );
 
 	const [localHeight, remoteHeight] = [await database.lastBlockNumber(), await client.height()];
 

--- a/packages/platform-sdk-btc-indexer/src/index.ts
+++ b/packages/platform-sdk-btc-indexer/src/index.ts
@@ -38,7 +38,14 @@ export const subscribe = async (flags: Flags): Promise<void> => {
 		downloadQueue.add(async () => database.storePendingBlock(await client.blockWithTransactions(blockHeight)));
 	}
 
-	setInterval(async () => processPendingBlocks(logger, database), 60000); // Every 60 seconds
+	let busy = false;
+	setInterval(async () => {
+		if (!busy) {
+			busy = true;
+			await processPendingBlocks(logger, database);
+			busy = false;
+		}
+	}, 10000); // Every 10 seconds
 };
 
 const runMigrations = async (): Promise<void> => {

--- a/packages/platform-sdk-btc-indexer/src/index.ts
+++ b/packages/platform-sdk-btc-indexer/src/index.ts
@@ -35,7 +35,7 @@ export const subscribe = async (flags: Flags): Promise<void> => {
 		.filter((value) => !alreadyDownloaded.has(value));
 
 	for (const blockHeight of range) {
-		downloadQueue.add(async () => database.storePendingBlock(await client.blockWithTransactions(blockHeight)));
+		void downloadQueue.add(async () => database.storePendingBlock(await client.blockWithTransactions(blockHeight)));
 	}
 
 	let busy = false;

--- a/packages/platform-sdk/src/coins/coin-factory.test.ts
+++ b/packages/platform-sdk/src/coins/coin-factory.test.ts
@@ -3,7 +3,6 @@ import "reflect-metadata";
 
 import { ARK } from "../../../platform-sdk-ark/src";
 import { Request } from "../../../platform-sdk-http-got/src";
-
 import { Coin } from "./coin";
 import { CoinFactory } from "./coin-factory";
 


### PR DESCRIPTION
1. Downloaded blocks are stored in the database as pending blocks
2. All blocks between the `localHeight` and `remoteHeight` are downloaded and stored independently from the persistence into the `blocks` and `transactions` table
3. Every 30 seconds we process all pending blocks

The flow now is `download new blocks > store as pending > process pending every 30 seconds > delete processed blocks` which should make things more resilient against crashes because we don't need to re-download a bunch of blocks and we can also have better error handling because we have the data sitting in our database until we successfully process and persist it.

The potential overlap in processing caused by `setInterval` shouldn't be an issue because we `upsert` blocks which means we would be just updating an existing record instead of creating another or causing a collision. I've tested this locally up to 150k blocks and there didn't seem to be any issues so far but there might be some issues revealed when the sync goes up to 550k+ blocks where the processing can take longer but I suspect that `upsert` should take care of avoiding any collisions that would cause a crash.

Also something to keep in mind for possible sequential processing or overlapping issues is that we are now storing blocks in the database and get them sorted by their height in ascending order so we already have a guarantee that blocks are sorted in the right order before we start any processing. I haven't yet decided what to do when a block fails to be persisted, most likely we'll need to guess what the issue is and try to fix it.