### PR TITLE
refactor(sdk): remove `TransactionOptions` in favour of `Signatory`

### DIFF
--- a/packages/platform-sdk-ada/src/services/transaction.ts
+++ b/packages/platform-sdk-ada/src/services/transaction.ts
@@ -12,7 +12,6 @@ import { UnspentTransaction } from "./transaction.models";
 export class TransactionService extends Services.AbstractTransactionService {
 	public async transfer(
 		input: Services.TransferInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		const {
 			minFeeA,

--- a/packages/platform-sdk-ada/src/services/transaction.ts
+++ b/packages/platform-sdk-ada/src/services/transaction.ts
@@ -10,9 +10,7 @@ import { UnspentTransaction } from "./transaction.models";
 
 @IoC.injectable()
 export class TransactionService extends Services.AbstractTransactionService {
-	public async transfer(
-		input: Services.TransferInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		const {
 			minFeeA,
 			minFeeB,

--- a/packages/platform-sdk-ark/src/services/transaction.ts
+++ b/packages/platform-sdk-ark/src/services/transaction.ts
@@ -36,7 +36,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async transfer(
 		input: Services.TransferInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("transfer", input, options, ({ transaction, data }) => {
 			transaction.recipientId(data.to);
@@ -49,7 +48,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async secondSignature(
 		input: Services.SecondSignatureInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("secondSignature", input, options, ({ transaction, data }) =>
 			transaction.signatureAsset(BIP39.normalize(data.mnemonic)),
@@ -58,7 +56,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async delegateRegistration(
 		input: Services.DelegateRegistrationInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("delegateRegistration", input, options, ({ transaction, data }) =>
 			transaction.usernameAsset(data.username),
@@ -67,7 +64,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async vote(
 		input: Services.VoteInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("vote", input, options, ({ transaction, data }) => {
 			const votes: string[] = [];
@@ -90,7 +86,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async multiSignature(
 		input: Services.MultiSignatureInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("multiSignature", input, options, ({ transaction, data }) => {
 			transaction.multiSignatureAsset({
@@ -104,7 +99,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async ipfs(
 		input: Services.IpfsInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("ipfs", input, options, ({ transaction, data }) =>
 			transaction.ipfsAsset(data.hash),
@@ -113,7 +107,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async multiPayment(
 		input: Services.MultiPaymentInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("multiPayment", input, options, ({ transaction, data }) => {
 			for (const payment of data.payments) {
@@ -128,14 +121,12 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async delegateResignation(
 		input: Services.DelegateResignationInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("delegateResignation", input, options);
 	}
 
 	public async htlcLock(
 		input: Services.HtlcLockInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("htlcLock", input, options, ({ transaction, data }) => {
 			transaction.amount(Helpers.toRawUnit(data.amount, this.configRepository).toString());
@@ -151,7 +142,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async htlcClaim(
 		input: Services.HtlcClaimInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("htlcClaim", input, options, ({ transaction, data }) =>
 			transaction.htlcClaimAsset({
@@ -163,7 +153,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async htlcRefund(
 		input: Services.HtlcRefundInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("htlcRefund", input, options, ({ transaction, data }) =>
 			transaction.htlcRefundAsset({
@@ -231,7 +220,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 	async #createFromData(
 		type: string,
 		input: Services.TransactionInputs,
-		options?: Services.TransactionOptions,
 		callback?: Function,
 	): Promise<Contracts.SignedTransactionData> {
 		applyCryptoConfiguration(this.#configCrypto);

--- a/packages/platform-sdk-ark/src/services/transaction.ts
+++ b/packages/platform-sdk-ark/src/services/transaction.ts
@@ -34,9 +34,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 	#multiSignatureSigner!: MultiSignatureSigner;
 	#configCrypto!: { crypto: Interfaces.NetworkConfig; height: number };
 
-	public async transfer(
-		input: Services.TransferInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("transfer", input, ({ transaction, data }) => {
 			transaction.recipientId(data.to);
 
@@ -46,9 +44,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		});
 	}
 
-	public async secondSignature(
-		input: Services.SecondSignatureInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async secondSignature(input: Services.SecondSignatureInput): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("secondSignature", input, ({ transaction, data }) =>
 			transaction.signatureAsset(BIP39.normalize(data.mnemonic)),
 		);
@@ -62,9 +58,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		);
 	}
 
-	public async vote(
-		input: Services.VoteInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async vote(input: Services.VoteInput): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("vote", input, ({ transaction, data }) => {
 			const votes: string[] = [];
 
@@ -84,9 +78,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		});
 	}
 
-	public async multiSignature(
-		input: Services.MultiSignatureInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async multiSignature(input: Services.MultiSignatureInput): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("multiSignature", input, ({ transaction, data }) => {
 			transaction.multiSignatureAsset({
 				publicKeys: data.publicKeys,
@@ -97,17 +89,11 @@ export class TransactionService extends Services.AbstractTransactionService {
 		});
 	}
 
-	public async ipfs(
-		input: Services.IpfsInput,
-	): Promise<Contracts.SignedTransactionData> {
-		return this.#createFromData("ipfs", input, ({ transaction, data }) =>
-			transaction.ipfsAsset(data.hash),
-		);
+	public async ipfs(input: Services.IpfsInput): Promise<Contracts.SignedTransactionData> {
+		return this.#createFromData("ipfs", input, ({ transaction, data }) => transaction.ipfsAsset(data.hash));
 	}
 
-	public async multiPayment(
-		input: Services.MultiPaymentInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async multiPayment(input: Services.MultiPaymentInput): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("multiPayment", input, ({ transaction, data }) => {
 			for (const payment of data.payments) {
 				transaction.addPayment(payment.to, Helpers.toRawUnit(payment.amount, this.configRepository).toString());
@@ -122,12 +108,10 @@ export class TransactionService extends Services.AbstractTransactionService {
 	public async delegateResignation(
 		input: Services.DelegateResignationInput,
 	): Promise<Contracts.SignedTransactionData> {
-		return this.#createFromData("delegateResignation", input, options);
+		return this.#createFromData("delegateResignation", input);
 	}
 
-	public async htlcLock(
-		input: Services.HtlcLockInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async htlcLock(input: Services.HtlcLockInput): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("htlcLock", input, ({ transaction, data }) => {
 			transaction.amount(Helpers.toRawUnit(data.amount, this.configRepository).toString());
 
@@ -140,9 +124,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		});
 	}
 
-	public async htlcClaim(
-		input: Services.HtlcClaimInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async htlcClaim(input: Services.HtlcClaimInput): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("htlcClaim", input, ({ transaction, data }) =>
 			transaction.htlcClaimAsset({
 				lockTransactionId: data.lockTransactionId,
@@ -151,9 +133,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		);
 	}
 
-	public async htlcRefund(
-		input: Services.HtlcRefundInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async htlcRefund(input: Services.HtlcRefundInput): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("htlcRefund", input, ({ transaction, data }) =>
 			transaction.htlcRefundAsset({
 				lockTransactionId: data.lockTransactionId,

--- a/packages/platform-sdk-ark/src/services/transaction.ts
+++ b/packages/platform-sdk-ark/src/services/transaction.ts
@@ -37,7 +37,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 	public async transfer(
 		input: Services.TransferInput,
 	): Promise<Contracts.SignedTransactionData> {
-		return this.#createFromData("transfer", input, options, ({ transaction, data }) => {
+		return this.#createFromData("transfer", input, ({ transaction, data }) => {
 			transaction.recipientId(data.to);
 
 			if (data.memo) {
@@ -49,7 +49,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 	public async secondSignature(
 		input: Services.SecondSignatureInput,
 	): Promise<Contracts.SignedTransactionData> {
-		return this.#createFromData("secondSignature", input, options, ({ transaction, data }) =>
+		return this.#createFromData("secondSignature", input, ({ transaction, data }) =>
 			transaction.signatureAsset(BIP39.normalize(data.mnemonic)),
 		);
 	}
@@ -57,7 +57,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 	public async delegateRegistration(
 		input: Services.DelegateRegistrationInput,
 	): Promise<Contracts.SignedTransactionData> {
-		return this.#createFromData("delegateRegistration", input, options, ({ transaction, data }) =>
+		return this.#createFromData("delegateRegistration", input, ({ transaction, data }) =>
 			transaction.usernameAsset(data.username),
 		);
 	}
@@ -65,7 +65,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 	public async vote(
 		input: Services.VoteInput,
 	): Promise<Contracts.SignedTransactionData> {
-		return this.#createFromData("vote", input, options, ({ transaction, data }) => {
+		return this.#createFromData("vote", input, ({ transaction, data }) => {
 			const votes: string[] = [];
 
 			if (Array.isArray(data.unvotes)) {
@@ -87,7 +87,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 	public async multiSignature(
 		input: Services.MultiSignatureInput,
 	): Promise<Contracts.SignedTransactionData> {
-		return this.#createFromData("multiSignature", input, options, ({ transaction, data }) => {
+		return this.#createFromData("multiSignature", input, ({ transaction, data }) => {
 			transaction.multiSignatureAsset({
 				publicKeys: data.publicKeys,
 				min: data.min,
@@ -100,7 +100,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 	public async ipfs(
 		input: Services.IpfsInput,
 	): Promise<Contracts.SignedTransactionData> {
-		return this.#createFromData("ipfs", input, options, ({ transaction, data }) =>
+		return this.#createFromData("ipfs", input, ({ transaction, data }) =>
 			transaction.ipfsAsset(data.hash),
 		);
 	}
@@ -108,7 +108,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 	public async multiPayment(
 		input: Services.MultiPaymentInput,
 	): Promise<Contracts.SignedTransactionData> {
-		return this.#createFromData("multiPayment", input, options, ({ transaction, data }) => {
+		return this.#createFromData("multiPayment", input, ({ transaction, data }) => {
 			for (const payment of data.payments) {
 				transaction.addPayment(payment.to, Helpers.toRawUnit(payment.amount, this.configRepository).toString());
 			}
@@ -128,7 +128,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 	public async htlcLock(
 		input: Services.HtlcLockInput,
 	): Promise<Contracts.SignedTransactionData> {
-		return this.#createFromData("htlcLock", input, options, ({ transaction, data }) => {
+		return this.#createFromData("htlcLock", input, ({ transaction, data }) => {
 			transaction.amount(Helpers.toRawUnit(data.amount, this.configRepository).toString());
 
 			transaction.recipientId(data.to);
@@ -143,7 +143,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 	public async htlcClaim(
 		input: Services.HtlcClaimInput,
 	): Promise<Contracts.SignedTransactionData> {
-		return this.#createFromData("htlcClaim", input, options, ({ transaction, data }) =>
+		return this.#createFromData("htlcClaim", input, ({ transaction, data }) =>
 			transaction.htlcClaimAsset({
 				lockTransactionId: data.lockTransactionId,
 				unlockSecret: data.unlockSecret,
@@ -154,7 +154,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 	public async htlcRefund(
 		input: Services.HtlcRefundInput,
 	): Promise<Contracts.SignedTransactionData> {
-		return this.#createFromData("htlcRefund", input, options, ({ transaction, data }) =>
+		return this.#createFromData("htlcRefund", input, ({ transaction, data }) =>
 			transaction.htlcRefundAsset({
 				lockTransactionId: data.lockTransactionId,
 			}),

--- a/packages/platform-sdk-atom/src/services/transaction.ts
+++ b/packages/platform-sdk-atom/src/services/transaction.ts
@@ -17,9 +17,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 	#networkId;
 	#decimals;
 
-	public async transfer(
-		input: Services.TransferInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		try {
 			if (input.signatory.signingKey() === undefined) {
 				throw new Error("No mnemonic provided.");

--- a/packages/platform-sdk-atom/src/services/transaction.ts
+++ b/packages/platform-sdk-atom/src/services/transaction.ts
@@ -19,7 +19,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async transfer(
 		input: Services.TransferInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		try {
 			if (input.signatory.signingKey() === undefined) {

--- a/packages/platform-sdk-avax/src/services/transaction.ts
+++ b/packages/platform-sdk-avax/src/services/transaction.ts
@@ -24,7 +24,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async transfer(
 		input: Services.TransferInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		if (input.signatory.signingKey() === undefined) {
 			throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "input.signatory");
@@ -69,7 +68,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async vote(
 		input: Services.VoteInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		if (input.signatory.signingKey() === undefined) {
 			throw new Exceptions.MissingArgument(this.constructor.name, this.vote.name, "input.signatory");

--- a/packages/platform-sdk-avax/src/services/transaction.ts
+++ b/packages/platform-sdk-avax/src/services/transaction.ts
@@ -22,9 +22,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		this.#keychain = useKeychain(this.configRepository);
 	}
 
-	public async transfer(
-		input: Services.TransferInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		if (input.signatory.signingKey() === undefined) {
 			throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "input.signatory");
 		}
@@ -66,9 +64,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		}
 	}
 
-	public async vote(
-		input: Services.VoteInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async vote(input: Services.VoteInput): Promise<Contracts.SignedTransactionData> {
 		if (input.signatory.signingKey() === undefined) {
 			throw new Exceptions.MissingArgument(this.constructor.name, this.vote.name, "input.signatory");
 		}

--- a/packages/platform-sdk-btc/src/services/transaction.ts
+++ b/packages/platform-sdk-btc/src/services/transaction.ts
@@ -12,9 +12,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 	// @TODO: bind via service provider and inject
 	#unspent;
 
-	public async transfer(
-		input: Services.TransferInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		try {
 			if (input.signatory.signingKey() === undefined) {
 				throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "input.signatory");

--- a/packages/platform-sdk-btc/src/services/transaction.ts
+++ b/packages/platform-sdk-btc/src/services/transaction.ts
@@ -14,7 +14,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async transfer(
 		input: Services.TransferInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		try {
 			if (input.signatory.signingKey() === undefined) {

--- a/packages/platform-sdk-dot/src/services/transaction.ts
+++ b/packages/platform-sdk-dot/src/services/transaction.ts
@@ -17,9 +17,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		await this.client.disconnect();
 	}
 
-	public async transfer(
-		input: Services.TransferInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		if (input.signatory.signingKey() === undefined) {
 			throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "input.signatory");
 		}

--- a/packages/platform-sdk-dot/src/services/transaction.ts
+++ b/packages/platform-sdk-dot/src/services/transaction.ts
@@ -19,7 +19,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async transfer(
 		input: Services.TransferInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		if (input.signatory.signingKey() === undefined) {
 			throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "input.signatory");

--- a/packages/platform-sdk-egld/src/services/transaction.ts
+++ b/packages/platform-sdk-egld/src/services/transaction.ts
@@ -15,7 +15,6 @@ import {
 export class TransactionService extends Services.AbstractTransactionService {
 	public async transfer(
 		input: Services.TransferInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		if (input.signatory.signingKey() === undefined) {
 			throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "sign.mnemonic");

--- a/packages/platform-sdk-egld/src/services/transaction.ts
+++ b/packages/platform-sdk-egld/src/services/transaction.ts
@@ -13,9 +13,7 @@ import {
 } from "@elrondnetwork/erdjs";
 
 export class TransactionService extends Services.AbstractTransactionService {
-	public async transfer(
-		input: Services.TransferInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		if (input.signatory.signingKey() === undefined) {
 			throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "sign.mnemonic");
 		}

--- a/packages/platform-sdk-eos/src/services/transaction.ts
+++ b/packages/platform-sdk-eos/src/services/transaction.ts
@@ -21,7 +21,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async transfer(
 		input: Services.TransferInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		try {
 			if (input.signatory.signingKey() === undefined) {

--- a/packages/platform-sdk-eos/src/services/transaction.ts
+++ b/packages/platform-sdk-eos/src/services/transaction.ts
@@ -19,9 +19,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		this.#ticker = this.configRepository.get<string>(Coins.ConfigKey.CurrencyTicker);
 	}
 
-	public async transfer(
-		input: Services.TransferInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		try {
 			if (input.signatory.signingKey() === undefined) {
 				throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "input.signatory");

--- a/packages/platform-sdk-eth/src/services/transaction.ts
+++ b/packages/platform-sdk-eth/src/services/transaction.ts
@@ -23,9 +23,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		this.#web3 = new Web3(); // @TODO: provide a host
 	}
 
-	public async transfer(
-		input: Services.TransferInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		try {
 			const senderData = await this.addressService.fromMnemonic(input.signatory.signingKey());
 

--- a/packages/platform-sdk-eth/src/services/transaction.ts
+++ b/packages/platform-sdk-eth/src/services/transaction.ts
@@ -25,7 +25,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async transfer(
 		input: Services.TransferInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		try {
 			const senderData = await this.addressService.fromMnemonic(input.signatory.signingKey());

--- a/packages/platform-sdk-lsk/src/services/transaction.ts
+++ b/packages/platform-sdk-lsk/src/services/transaction.ts
@@ -27,7 +27,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async transfer(
 		input: Services.TransferInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData(
 			"transfer",
@@ -45,7 +44,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async secondSignature(
 		input: Services.SecondSignatureInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData(
 			"registerSecondPassphrase",
@@ -61,21 +59,18 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async delegateRegistration(
 		input: Services.DelegateRegistrationInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("registerDelegate", input, options);
 	}
 
 	public async vote(
 		input: Services.VoteInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("castVotes", input, options);
 	}
 
 	public async multiSignature(
 		input: Services.MultiSignatureInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData(
 			"registerMultisignature",
@@ -94,7 +89,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 	async #createFromData(
 		type: string,
 		input: Contracts.KeyValuePair,
-		options?: Services.TransactionOptions,
 		callback?: Function,
 	): Promise<Contracts.SignedTransactionData> {
 		try {

--- a/packages/platform-sdk-lsk/src/services/transaction.ts
+++ b/packages/platform-sdk-lsk/src/services/transaction.ts
@@ -25,9 +25,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		this.#network = this.configRepository.get<string>("network.meta.networkId");
 	}
 
-	public async transfer(
-		input: Services.TransferInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData(
 			"transfer",
 			{
@@ -42,9 +40,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		);
 	}
 
-	public async secondSignature(
-		input: Services.SecondSignatureInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async secondSignature(input: Services.SecondSignatureInput): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData(
 			"registerSecondPassphrase",
 			{
@@ -63,15 +59,11 @@ export class TransactionService extends Services.AbstractTransactionService {
 		return this.#createFromData("registerDelegate", input, options);
 	}
 
-	public async vote(
-		input: Services.VoteInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async vote(input: Services.VoteInput): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData("castVotes", input, options);
 	}
 
-	public async multiSignature(
-		input: Services.MultiSignatureInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async multiSignature(input: Services.MultiSignatureInput): Promise<Contracts.SignedTransactionData> {
 		return this.#createFromData(
 			"registerMultisignature",
 			{

--- a/packages/platform-sdk-luna/src/services/transaction.ts
+++ b/packages/platform-sdk-luna/src/services/transaction.ts
@@ -7,7 +7,6 @@ import { useClient } from "./helpers";
 export class TransactionService extends Services.AbstractTransactionService {
 	public async transfer(
 		input: Services.TransferInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		const amount = Helpers.toRawUnit(input.data.amount, this.configRepository).toString();
 

--- a/packages/platform-sdk-luna/src/services/transaction.ts
+++ b/packages/platform-sdk-luna/src/services/transaction.ts
@@ -5,9 +5,7 @@ import { LCDClient, MnemonicKey, MsgSend } from "@terra-money/terra.js";
 import { useClient } from "./helpers";
 
 export class TransactionService extends Services.AbstractTransactionService {
-	public async transfer(
-		input: Services.TransferInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		const amount = Helpers.toRawUnit(input.data.amount, this.configRepository).toString();
 
 		const transaction = await this.#useClient()

--- a/packages/platform-sdk-nano/src/services/transaction.ts
+++ b/packages/platform-sdk-nano/src/services/transaction.ts
@@ -17,9 +17,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		this.#decimals = this.configRepository.get(Coins.ConfigKey.CurrencyDecimals);
 	}
 
-	public async transfer(
-		input: Services.TransferInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		const { address, privateKey } = deriveAccount(input.signatory.signingKey());
 		const { balance, representative, frontier } = await this.#client.accountInfo(address, { representative: true });
 

--- a/packages/platform-sdk-nano/src/services/transaction.ts
+++ b/packages/platform-sdk-nano/src/services/transaction.ts
@@ -19,7 +19,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async transfer(
 		input: Services.TransferInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		const { address, privateKey } = deriveAccount(input.signatory.signingKey());
 		const { balance, representative, frontier } = await this.#client.accountInfo(address, { representative: true });

--- a/packages/platform-sdk-neo/src/services/transaction.ts
+++ b/packages/platform-sdk-neo/src/services/transaction.ts
@@ -7,7 +7,6 @@ import { v4 as uuidv4 } from "uuid";
 export class TransactionService extends Services.AbstractTransactionService {
 	public async transfer(
 		input: Services.TransferInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		try {
 			const signedTransaction = {

--- a/packages/platform-sdk-neo/src/services/transaction.ts
+++ b/packages/platform-sdk-neo/src/services/transaction.ts
@@ -5,9 +5,7 @@ import { v4 as uuidv4 } from "uuid";
 
 @IoC.injectable()
 export class TransactionService extends Services.AbstractTransactionService {
-	public async transfer(
-		input: Services.TransferInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		try {
 			const signedTransaction = {
 				account: new wallet.Account(input.signatory.signingKey()),

--- a/packages/platform-sdk-profiles/src/contracts/wallets/wallet-transaction-service.ts
+++ b/packages/platform-sdk-profiles/src/contracts/wallets/wallet-transaction-service.ts
@@ -67,9 +67,7 @@ export interface ITransactionService {
 	 * @return {Promise<string>}
 	 * @memberof ITransactionService
 	 */
-	signDelegateRegistration(
-		input: Services.DelegateRegistrationInput,
-	): Promise<string>;
+	signDelegateRegistration(input: Services.DelegateRegistrationInput): Promise<string>;
 
 	/**
 	 * Sign a Vote transaction.
@@ -114,9 +112,7 @@ export interface ITransactionService {
 	 * @return {Promise<string>}
 	 * @memberof ITransactionService
 	 */
-	signDelegateResignation(
-		input: Services.DelegateResignationInput,
-	): Promise<string>;
+	signDelegateResignation(input: Services.DelegateResignationInput): Promise<string>;
 
 	/**
 	 * Sign a HTLC Lock transaction.

--- a/packages/platform-sdk-profiles/src/contracts/wallets/wallet-transaction-service.ts
+++ b/packages/platform-sdk-profiles/src/contracts/wallets/wallet-transaction-service.ts
@@ -46,117 +46,104 @@ export interface ITransactionService {
 	 * Sign a Transfer transaction.
 	 *
 	 * @param {Services.TransferInput} input
-	 * @param {Services.TransactionOptions} options
 	 * @return {Promise<string>}
 	 * @memberof ITransactionService
 	 */
-	signTransfer(input: Services.TransferInput, options?: Services.TransactionOptions): Promise<string>;
+	signTransfer(input: Services.TransferInput): Promise<string>;
 
 	/**
 	 * Sign a Second-Signature Registration transaction.
 	 *
 	 * @param {Services.SecondSignatureInput} input
-	 * @param {Services.TransactionOptions} options
 	 * @return {Promise<string>}
 	 * @memberof ITransactionService
 	 */
-	signSecondSignature(input: Services.SecondSignatureInput, options?: Services.TransactionOptions): Promise<string>;
+	signSecondSignature(input: Services.SecondSignatureInput): Promise<string>;
 
 	/**
 	 * Sign a Delegate Registration transaction.
 	 *
 	 * @param {Services.DelegateRegistrationInput} input
-	 * @param {Services.TransactionOptions} options
 	 * @return {Promise<string>}
 	 * @memberof ITransactionService
 	 */
 	signDelegateRegistration(
 		input: Services.DelegateRegistrationInput,
-		options?: Services.TransactionOptions,
 	): Promise<string>;
 
 	/**
 	 * Sign a Vote transaction.
 	 *
 	 * @param {Services.VoteInput} input
-	 * @param {Services.TransactionOptions} options
 	 * @return {Promise<string>}
 	 * @memberof ITransactionService
 	 */
-	signVote(input: Services.VoteInput, options?: Services.TransactionOptions): Promise<string>;
+	signVote(input: Services.VoteInput): Promise<string>;
 
 	/**
 	 * Sign a Multi-Signature Registration transaction.
 	 *
 	 * @param {Services.MultiSignatureInput} input
-	 * @param {Services.TransactionOptions} options
 	 * @return {Promise<string>}
 	 * @memberof ITransactionService
 	 */
-	signMultiSignature(input: Services.MultiSignatureInput, options?: Services.TransactionOptions): Promise<string>;
+	signMultiSignature(input: Services.MultiSignatureInput): Promise<string>;
 
 	/**
 	 * Sign an IPFS transaction.
 	 *
 	 * @param {Services.IpfsInput} input
-	 * @param {Services.TransactionOptions} options
 	 * @return {Promise<string>}
 	 * @memberof ITransactionService
 	 */
-	signIpfs(input: Services.IpfsInput, options?: Services.TransactionOptions): Promise<string>;
+	signIpfs(input: Services.IpfsInput): Promise<string>;
 
 	/**
 	 * Sign a Multi-Payment transaction.
 	 *
 	 * @param {Services.MultiPaymentInput} input
-	 * @param {Services.TransactionOptions} options
 	 * @return {Promise<string>}
 	 * @memberof ITransactionService
 	 */
-	signMultiPayment(input: Services.MultiPaymentInput, options?: Services.TransactionOptions): Promise<string>;
+	signMultiPayment(input: Services.MultiPaymentInput): Promise<string>;
 
 	/**
 	 * Sign a Delegate Resignation transaction.
 	 *
 	 * @param {Services.DelegateResignationInput} input
-	 * @param {Services.TransactionOptions} options
 	 * @return {Promise<string>}
 	 * @memberof ITransactionService
 	 */
 	signDelegateResignation(
 		input: Services.DelegateResignationInput,
-		options?: Services.TransactionOptions,
 	): Promise<string>;
 
 	/**
 	 * Sign a HTLC Lock transaction.
 	 *
 	 * @param {Services.HtlcLockInput} input
-	 * @param {Services.TransactionOptions} options
 	 * @return {Promise<string>}
 	 * @memberof ITransactionService
 	 */
-	signHtlcLock(input: Services.HtlcLockInput, options?: Services.TransactionOptions): Promise<string>;
+	signHtlcLock(input: Services.HtlcLockInput): Promise<string>;
 
 	/**
 	 * Sign a HTLC Claim transaction.
 	 *
 	 * @param {Services.HtlcClaimInput} input
-	 * @param {Services.TransactionOptions} options
 	 * @return {Promise<string>}
 	 * @memberof ITransactionService
 	 */
-	signHtlcClaim(input: Services.HtlcClaimInput, options?: Services.TransactionOptions): Promise<string>;
+	signHtlcClaim(input: Services.HtlcClaimInput): Promise<string>;
 
 	/**
 	 * Sign a HTLC Refund transaction.
 	 *
 	 * @param {Services.HtlcRefundInput} input
-	 * @param {Services.TransactionOptions} options
 	 * @return {Promise<string>}
 	 * @memberof ITransactionService
 	 */
-	signHtlcRefund(input: Services.HtlcRefundInput, options?: Services.TransactionOptions): Promise<string>;
+	signHtlcRefund(input: Services.HtlcRefundInput): Promise<string>;
 
 	/**
 	 * Get the transaction for the given ID if it is exists with any valid state.

--- a/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet-transaction-service.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet-transaction-service.ts
@@ -78,16 +78,12 @@ export class TransactionService implements ITransactionService {
 	}
 
 	/** {@inheritDoc ITransactionService.signSecondSignature} */
-	public async signSecondSignature(
-		input: Services.SecondSignatureInput,
-	): Promise<string> {
+	public async signSecondSignature(input: Services.SecondSignatureInput): Promise<string> {
 		return this.#signTransaction("secondSignature", input, options);
 	}
 
 	/** {@inheritDoc ITransactionService.signDelegateRegistration} */
-	public async signDelegateRegistration(
-		input: Services.DelegateRegistrationInput,
-	): Promise<string> {
+	public async signDelegateRegistration(input: Services.DelegateRegistrationInput): Promise<string> {
 		return this.#signTransaction("delegateRegistration", input, options);
 	}
 
@@ -97,9 +93,7 @@ export class TransactionService implements ITransactionService {
 	}
 
 	/** {@inheritDoc ITransactionService.signMultiSignature} */
-	public async signMultiSignature(
-		input: Services.MultiSignatureInput,
-	): Promise<string> {
+	public async signMultiSignature(input: Services.MultiSignatureInput): Promise<string> {
 		return this.#signTransaction("multiSignature", input, options);
 	}
 
@@ -109,16 +103,12 @@ export class TransactionService implements ITransactionService {
 	}
 
 	/** {@inheritDoc ITransactionService.signMultiPayment} */
-	public async signMultiPayment(
-		input: Services.MultiPaymentInput,
-	): Promise<string> {
+	public async signMultiPayment(input: Services.MultiPaymentInput): Promise<string> {
 		return this.#signTransaction("multiPayment", input, options);
 	}
 
 	/** {@inheritDoc ITransactionService.signDelegateResignation} */
-	public async signDelegateResignation(
-		input: Services.DelegateResignationInput,
-	): Promise<string> {
+	public async signDelegateResignation(input: Services.DelegateResignationInput): Promise<string> {
 		return this.#signTransaction("delegateResignation", input, options);
 	}
 
@@ -133,9 +123,7 @@ export class TransactionService implements ITransactionService {
 	}
 
 	/** {@inheritDoc ITransactionService.signHtlcRefund} */
-	public async signHtlcRefund(
-		input: Services.HtlcRefundInput,
-	): Promise<string> {
+	public async signHtlcRefund(input: Services.HtlcRefundInput): Promise<string> {
 		return this.#signTransaction("htlcRefund", input, options);
 	}
 

--- a/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet-transaction-service.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet-transaction-service.ts
@@ -73,14 +73,13 @@ export class TransactionService implements ITransactionService {
 	}
 
 	/** {@inheritDoc ITransactionService.signTransfer} */
-	public async signTransfer(input: Services.TransferInput, options?: Services.TransactionOptions): Promise<string> {
+	public async signTransfer(input: Services.TransferInput): Promise<string> {
 		return this.#signTransaction("transfer", input, options);
 	}
 
 	/** {@inheritDoc ITransactionService.signSecondSignature} */
 	public async signSecondSignature(
 		input: Services.SecondSignatureInput,
-		options?: Services.TransactionOptions,
 	): Promise<string> {
 		return this.#signTransaction("secondSignature", input, options);
 	}
@@ -88,33 +87,30 @@ export class TransactionService implements ITransactionService {
 	/** {@inheritDoc ITransactionService.signDelegateRegistration} */
 	public async signDelegateRegistration(
 		input: Services.DelegateRegistrationInput,
-		options?: Services.TransactionOptions,
 	): Promise<string> {
 		return this.#signTransaction("delegateRegistration", input, options);
 	}
 
 	/** {@inheritDoc ITransactionService.signVote} */
-	public async signVote(input: Services.VoteInput, options?: Services.TransactionOptions): Promise<string> {
+	public async signVote(input: Services.VoteInput): Promise<string> {
 		return this.#signTransaction("vote", input, options);
 	}
 
 	/** {@inheritDoc ITransactionService.signMultiSignature} */
 	public async signMultiSignature(
 		input: Services.MultiSignatureInput,
-		options?: Services.TransactionOptions,
 	): Promise<string> {
 		return this.#signTransaction("multiSignature", input, options);
 	}
 
 	/** {@inheritDoc ITransactionService.signIpfs} */
-	public async signIpfs(input: Services.IpfsInput, options?: Services.TransactionOptions): Promise<string> {
+	public async signIpfs(input: Services.IpfsInput): Promise<string> {
 		return this.#signTransaction("ipfs", input, options);
 	}
 
 	/** {@inheritDoc ITransactionService.signMultiPayment} */
 	public async signMultiPayment(
 		input: Services.MultiPaymentInput,
-		options?: Services.TransactionOptions,
 	): Promise<string> {
 		return this.#signTransaction("multiPayment", input, options);
 	}
@@ -122,25 +118,23 @@ export class TransactionService implements ITransactionService {
 	/** {@inheritDoc ITransactionService.signDelegateResignation} */
 	public async signDelegateResignation(
 		input: Services.DelegateResignationInput,
-		options?: Services.TransactionOptions,
 	): Promise<string> {
 		return this.#signTransaction("delegateResignation", input, options);
 	}
 
 	/** {@inheritDoc ITransactionService.signHtlcLock} */
-	public async signHtlcLock(input: Services.HtlcLockInput, options?: Services.TransactionOptions): Promise<string> {
+	public async signHtlcLock(input: Services.HtlcLockInput): Promise<string> {
 		return this.#signTransaction("htlcLock", input, options);
 	}
 
 	/** {@inheritDoc ITransactionService.signHtlcClaim} */
-	public async signHtlcClaim(input: Services.HtlcClaimInput, options?: Services.TransactionOptions): Promise<string> {
+	public async signHtlcClaim(input: Services.HtlcClaimInput): Promise<string> {
 		return this.#signTransaction("htlcClaim", input, options);
 	}
 
 	/** {@inheritDoc ITransactionService.signHtlcRefund} */
 	public async signHtlcRefund(
 		input: Services.HtlcRefundInput,
-		options?: Services.TransactionOptions,
 	): Promise<string> {
 		return this.#signTransaction("htlcRefund", input, options);
 	}
@@ -384,11 +378,10 @@ export class TransactionService implements ITransactionService {
 	 * @private
 	 * @param {string} type
 	 * @param {*} input
-	 * @param {Services.TransactionOptions} [options]
 	 * @returns {Promise<string>}
 	 * @memberof TransactionService
 	 */
-	async #signTransaction(type: string, input: any, options?: Services.TransactionOptions): Promise<string> {
+	async #signTransaction(type: string, input: any): Promise<string> {
 		const transaction: Contracts.SignedTransactionData = await this.#wallet
 			.coin()
 			.transaction()

--- a/packages/platform-sdk-sol/src/services/transaction.ts
+++ b/packages/platform-sdk-sol/src/services/transaction.ts
@@ -18,7 +18,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async transfer(
 		input: Services.TransferInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		if (input.signatory.signingKey() === undefined) {
 			throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "signatory");

--- a/packages/platform-sdk-sol/src/services/transaction.ts
+++ b/packages/platform-sdk-sol/src/services/transaction.ts
@@ -16,9 +16,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		this.#slip44 = this.configRepository.get<number>("network.constants.slip44");
 	}
 
-	public async transfer(
-		input: Services.TransferInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		if (input.signatory.signingKey() === undefined) {
 			throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "signatory");
 		}

--- a/packages/platform-sdk-trx/src/services/transaction.ts
+++ b/packages/platform-sdk-trx/src/services/transaction.ts
@@ -18,7 +18,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async transfer(
 		input: Services.TransferInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		try {
 			if (input.signatory.signingKey() === undefined) {

--- a/packages/platform-sdk-trx/src/services/transaction.ts
+++ b/packages/platform-sdk-trx/src/services/transaction.ts
@@ -16,9 +16,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		this.#connection = new TronWeb({ fullHost: Helpers.randomHostFromConfig(this.configRepository) });
 	}
 
-	public async transfer(
-		input: Services.TransferInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		try {
 			if (input.signatory.signingKey() === undefined) {
 				throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "input.signatory");

--- a/packages/platform-sdk-xlm/src/services/transaction.ts
+++ b/packages/platform-sdk-xlm/src/services/transaction.ts
@@ -32,7 +32,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async transfer(
 		input: Services.TransferInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		try {
 			if (input.signatory.signingKey() === undefined) {

--- a/packages/platform-sdk-xlm/src/services/transaction.ts
+++ b/packages/platform-sdk-xlm/src/services/transaction.ts
@@ -30,9 +30,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		this.#networkPassphrase = network.networkPassphrase;
 	}
 
-	public async transfer(
-		input: Services.TransferInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		try {
 			if (input.signatory.signingKey() === undefined) {
 				throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "input.signatory");

--- a/packages/platform-sdk-xrp/src/services/transaction.ts
+++ b/packages/platform-sdk-xrp/src/services/transaction.ts
@@ -12,9 +12,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		this.#ripple = new RippleAPI();
 	}
 
-	public async transfer(
-		input: Services.TransferInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		try {
 			if (input.signatory.signingKey() === undefined) {
 				throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "input.signatory");

--- a/packages/platform-sdk-xrp/src/services/transaction.ts
+++ b/packages/platform-sdk-xrp/src/services/transaction.ts
@@ -14,7 +14,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async transfer(
 		input: Services.TransferInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		try {
 			if (input.signatory.signingKey() === undefined) {

--- a/packages/platform-sdk-zil/src/services/transaction.ts
+++ b/packages/platform-sdk-zil/src/services/transaction.ts
@@ -15,9 +15,7 @@ export class TransactionService extends Services.AbstractTransactionService {
 		this.#version = getZilliqaVersion(this.configRepository);
 	}
 
-	public async transfer(
-		input: Services.TransferInput,
-	): Promise<Contracts.SignedTransactionData> {
+	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
 		if (!input.data.to) {
 			throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "data.to");
 		}

--- a/packages/platform-sdk-zil/src/services/transaction.ts
+++ b/packages/platform-sdk-zil/src/services/transaction.ts
@@ -17,7 +17,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 
 	public async transfer(
 		input: Services.TransferInput,
-		options?: Services.TransactionOptions,
 	): Promise<Contracts.SignedTransactionData> {
 		if (!input.data.to) {
 			throw new Exceptions.MissingArgument(this.constructor.name, this.transfer.name, "data.to");

--- a/packages/platform-sdk/src/services/transaction.contract.ts
+++ b/packages/platform-sdk/src/services/transaction.contract.ts
@@ -5,9 +5,7 @@ export interface TransactionService {
 	// Core
 	transfer(input: TransferInput): Promise<SignedTransactionData>;
 	secondSignature(input: SecondSignatureInput): Promise<SignedTransactionData>;
-	delegateRegistration(
-		input: DelegateRegistrationInput,
-	): Promise<SignedTransactionData>;
+	delegateRegistration(input: DelegateRegistrationInput): Promise<SignedTransactionData>;
 	vote(input: VoteInput): Promise<SignedTransactionData>;
 	multiSignature(input: MultiSignatureInput): Promise<SignedTransactionData>;
 	ipfs(input: IpfsInput): Promise<SignedTransactionData>;

--- a/packages/platform-sdk/src/services/transaction.contract.ts
+++ b/packages/platform-sdk/src/services/transaction.contract.ts
@@ -3,20 +3,19 @@ import { Signatory } from "../signatories";
 
 export interface TransactionService {
 	// Core
-	transfer(input: TransferInput, options?: TransactionOptions): Promise<SignedTransactionData>;
-	secondSignature(input: SecondSignatureInput, options?: TransactionOptions): Promise<SignedTransactionData>;
+	transfer(input: TransferInput): Promise<SignedTransactionData>;
+	secondSignature(input: SecondSignatureInput): Promise<SignedTransactionData>;
 	delegateRegistration(
 		input: DelegateRegistrationInput,
-		options?: TransactionOptions,
 	): Promise<SignedTransactionData>;
-	vote(input: VoteInput, options?: TransactionOptions): Promise<SignedTransactionData>;
-	multiSignature(input: MultiSignatureInput, options?: TransactionOptions): Promise<SignedTransactionData>;
-	ipfs(input: IpfsInput, options?: TransactionOptions): Promise<SignedTransactionData>;
-	multiPayment(input: MultiPaymentInput, options?: TransactionOptions): Promise<SignedTransactionData>;
-	delegateResignation(input: DelegateResignationInput, options?: TransactionOptions): Promise<SignedTransactionData>;
-	htlcLock(input: HtlcLockInput, options?: TransactionOptions): Promise<SignedTransactionData>;
-	htlcClaim(input: HtlcClaimInput, options?: TransactionOptions): Promise<SignedTransactionData>;
-	htlcRefund(input: HtlcRefundInput, options?: TransactionOptions): Promise<SignedTransactionData>;
+	vote(input: VoteInput): Promise<SignedTransactionData>;
+	multiSignature(input: MultiSignatureInput): Promise<SignedTransactionData>;
+	ipfs(input: IpfsInput): Promise<SignedTransactionData>;
+	multiPayment(input: MultiPaymentInput): Promise<SignedTransactionData>;
+	delegateResignation(input: DelegateResignationInput): Promise<SignedTransactionData>;
+	htlcLock(input: HtlcLockInput): Promise<SignedTransactionData>;
+	htlcClaim(input: HtlcClaimInput): Promise<SignedTransactionData>;
+	htlcRefund(input: HtlcRefundInput): Promise<SignedTransactionData>;
 
 	// Multi-Signature
 	multiSign(transaction: RawTransactionData, input: TransactionInputs): Promise<SignedTransactionData>;
@@ -34,11 +33,6 @@ export interface TransactionInput {
 	contract?: {
 		address: string;
 	};
-}
-
-export interface TransactionOptions {
-	unsignedBytes: boolean;
-	unsignedJson: boolean;
 }
 
 export interface TransferInput extends TransactionInput {

--- a/packages/platform-sdk/src/services/transaction.service.ts
+++ b/packages/platform-sdk/src/services/transaction.service.ts
@@ -18,7 +18,6 @@ import {
 	MultiSignatureInput,
 	SecondSignatureInput,
 	TransactionInputs,
-	TransactionOptions,
 	TransactionService as Contract,
 	TransferInput,
 	VoteInput,
@@ -35,59 +34,55 @@ export class AbstractTransactionService implements Contract {
 	@inject(BindingType.HttpClient)
 	protected readonly httpClient!: HttpClient;
 
-	public async transfer(input: TransferInput, options?: TransactionOptions): Promise<SignedTransactionData> {
+	public async transfer(input: TransferInput): Promise<SignedTransactionData> {
 		throw new NotImplemented(this.constructor.name, this.transfer.name);
 	}
 
 	public async secondSignature(
 		input: SecondSignatureInput,
-		options?: TransactionOptions,
 	): Promise<SignedTransactionData> {
 		throw new NotImplemented(this.constructor.name, this.secondSignature.name);
 	}
 
 	public async delegateRegistration(
 		input: DelegateRegistrationInput,
-		options?: TransactionOptions,
 	): Promise<SignedTransactionData> {
 		throw new NotImplemented(this.constructor.name, this.delegateRegistration.name);
 	}
 
-	public async vote(input: VoteInput, options?: TransactionOptions): Promise<SignedTransactionData> {
+	public async vote(input: VoteInput): Promise<SignedTransactionData> {
 		throw new NotImplemented(this.constructor.name, this.vote.name);
 	}
 
 	public async multiSignature(
 		input: MultiSignatureInput,
-		options?: TransactionOptions,
 	): Promise<SignedTransactionData> {
 		throw new NotImplemented(this.constructor.name, this.multiSignature.name);
 	}
 
-	public async ipfs(input: IpfsInput, options?: TransactionOptions): Promise<SignedTransactionData> {
+	public async ipfs(input: IpfsInput): Promise<SignedTransactionData> {
 		throw new NotImplemented(this.constructor.name, this.ipfs.name);
 	}
 
-	public async multiPayment(input: MultiPaymentInput, options?: TransactionOptions): Promise<SignedTransactionData> {
+	public async multiPayment(input: MultiPaymentInput): Promise<SignedTransactionData> {
 		throw new NotImplemented(this.constructor.name, this.multiPayment.name);
 	}
 
 	public async delegateResignation(
 		input: DelegateResignationInput,
-		options?: TransactionOptions,
 	): Promise<SignedTransactionData> {
 		throw new NotImplemented(this.constructor.name, this.delegateResignation.name);
 	}
 
-	public async htlcLock(input: HtlcLockInput, options?: TransactionOptions): Promise<SignedTransactionData> {
+	public async htlcLock(input: HtlcLockInput): Promise<SignedTransactionData> {
 		throw new NotImplemented(this.constructor.name, this.htlcLock.name);
 	}
 
-	public async htlcClaim(input: HtlcClaimInput, options?: TransactionOptions): Promise<SignedTransactionData> {
+	public async htlcClaim(input: HtlcClaimInput): Promise<SignedTransactionData> {
 		throw new NotImplemented(this.constructor.name, this.htlcClaim.name);
 	}
 
-	public async htlcRefund(input: HtlcRefundInput, options?: TransactionOptions): Promise<SignedTransactionData> {
+	public async htlcRefund(input: HtlcRefundInput): Promise<SignedTransactionData> {
 		throw new NotImplemented(this.constructor.name, this.htlcRefund.name);
 	}
 

--- a/packages/platform-sdk/src/services/transaction.service.ts
+++ b/packages/platform-sdk/src/services/transaction.service.ts
@@ -38,15 +38,11 @@ export class AbstractTransactionService implements Contract {
 		throw new NotImplemented(this.constructor.name, this.transfer.name);
 	}
 
-	public async secondSignature(
-		input: SecondSignatureInput,
-	): Promise<SignedTransactionData> {
+	public async secondSignature(input: SecondSignatureInput): Promise<SignedTransactionData> {
 		throw new NotImplemented(this.constructor.name, this.secondSignature.name);
 	}
 
-	public async delegateRegistration(
-		input: DelegateRegistrationInput,
-	): Promise<SignedTransactionData> {
+	public async delegateRegistration(input: DelegateRegistrationInput): Promise<SignedTransactionData> {
 		throw new NotImplemented(this.constructor.name, this.delegateRegistration.name);
 	}
 
@@ -54,9 +50,7 @@ export class AbstractTransactionService implements Contract {
 		throw new NotImplemented(this.constructor.name, this.vote.name);
 	}
 
-	public async multiSignature(
-		input: MultiSignatureInput,
-	): Promise<SignedTransactionData> {
+	public async multiSignature(input: MultiSignatureInput): Promise<SignedTransactionData> {
 		throw new NotImplemented(this.constructor.name, this.multiSignature.name);
 	}
 
@@ -68,9 +62,7 @@ export class AbstractTransactionService implements Contract {
 		throw new NotImplemented(this.constructor.name, this.multiPayment.name);
 	}
 
-	public async delegateResignation(
-		input: DelegateResignationInput,
-	): Promise<SignedTransactionData> {
+	public async delegateResignation(input: DelegateResignationInput): Promise<SignedTransactionData> {
 		throw new NotImplemented(this.constructor.name, this.delegateResignation.name);
 	}
 


### PR DESCRIPTION
No longer needed because we now have the signatory setup which handles this much cleaner.