### PR TITLE
refactor(sdk): remove `SignatureSignatory` in favour of `LedgerSignatory`

### DIFF
--- a/packages/platform-sdk-ark/src/services/transaction.test.ts
+++ b/packages/platform-sdk-ark/src/services/transaction.test.ts
@@ -9,8 +9,8 @@ import { AddressService } from "./address";
 import { ClientService } from "./client";
 import { DataTransferObjectService } from "./data-transfer-object";
 import { KeyPairService } from "./key-pair";
-import { PublicKeyService } from "./public-key";
 import { LedgerService } from "./ledger";
+import { PublicKeyService } from "./public-key";
 import { TransactionService } from "./transaction";
 
 let subject: TransactionService;

--- a/packages/platform-sdk-ark/src/services/transaction.test.ts
+++ b/packages/platform-sdk-ark/src/services/transaction.test.ts
@@ -56,26 +56,6 @@ describe("TransactionService", () => {
 			expect(result.amount().toNumber()).toBe(100_000_000);
 		});
 
-		it("should compute the id with a custom signature", async () => {
-			const result = await subject.transfer({
-				nonce: "1",
-				signatory: new Signatories.Signatory(
-					new Signatories.SignatureSignatory({
-						signingKey:
-							"678f44d24bf1bd08198467102c835bc6973fcfee064fef9ab578b350e8656acabf91d20c83d8745c2d76e3c898ebbabed84aba8786386e13d35e507f991239d6",
-						address: "address",
-						publicKey: "039180ea4a8a803ee11ecb462bb8f9613fcdb5fe917e292dbcc73409f0e98f8f22",
-					}),
-				),
-				data: {
-					amount: 1,
-					to: "DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9",
-				},
-			});
-
-			expect(result.id()).toBe("2309501a11e4353f894c39268e65e24b2e12a6106769dc10ed898ed3c793a9f6");
-		});
-
 		it("should sign with a custom expiration", async () => {
 			const result = await subject.transfer({
 				nonce: "1",

--- a/packages/platform-sdk-ark/src/services/transaction.ts
+++ b/packages/platform-sdk-ark/src/services/transaction.ts
@@ -4,7 +4,6 @@ import { Contracts, Exceptions, Helpers, IoC, Services } from "@arkecosystem/pla
 import { BIP39 } from "@arkecosystem/platform-sdk-crypto";
 import { BigNumber } from "@arkecosystem/platform-sdk-support";
 import LedgerTransportNodeHID from "@ledgerhq/hw-transport-node-hid-singleton";
-import { v4 as uuidv4 } from "uuid";
 
 import { Bindings } from "../contracts";
 import { applyCryptoConfiguration } from "./helpers";

--- a/packages/platform-sdk-ark/src/services/transaction.ts
+++ b/packages/platform-sdk-ark/src/services/transaction.ts
@@ -223,12 +223,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 				transaction.senderPublicKey(input.signatory.signingKey());
 			}
 
-			if (input.signatory.actsWithSignature()) {
-				address = (await this.addressService.fromPublicKey(input.signatory.publicKey())).address;
-
-				transaction.senderPublicKey(input.signatory.publicKey());
-			}
-
 			if (input.nonce) {
 				transaction.nonce(input.nonce);
 			} else {
@@ -310,8 +304,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 				for (let i = 0; i < signingKeys.length; i++) {
 					transaction.multiSign(signingKeys[i], i);
 				}
-			} else if (input.signatory.actsWithSignature()) {
-				transaction.data.signature = input.signatory.signingKey();
 			} else {
 				if (input.signatory.actsWithMnemonic()) {
 					transaction.sign(input.signatory.signingKey());

--- a/packages/platform-sdk-lsk/src/services/transaction.ts
+++ b/packages/platform-sdk-lsk/src/services/transaction.ts
@@ -26,29 +26,23 @@ export class TransactionService extends Services.AbstractTransactionService {
 	}
 
 	public async transfer(input: Services.TransferInput): Promise<Contracts.SignedTransactionData> {
-		return this.#createFromData(
-			"transfer",
-			{
-				...input,
-				data: {
-					amount: Helpers.toRawUnit(input.data.amount, this.configRepository).toString(),
-					recipientId: input.data.to,
-					data: input.data.memo,
-				},
+		return this.#createFromData("transfer", {
+			...input,
+			data: {
+				amount: Helpers.toRawUnit(input.data.amount, this.configRepository).toString(),
+				recipientId: input.data.to,
+				data: input.data.memo,
 			},
-		);
+		});
 	}
 
 	public async secondSignature(input: Services.SecondSignatureInput): Promise<Contracts.SignedTransactionData> {
-		return this.#createFromData(
-			"registerSecondPassphrase",
-			{
-				...input,
-				data: {
-					secondMnemonic: BIP39.normalize(input.data.mnemonic),
-				},
+		return this.#createFromData("registerSecondPassphrase", {
+			...input,
+			data: {
+				secondMnemonic: BIP39.normalize(input.data.mnemonic),
 			},
-		);
+		});
 	}
 
 	public async delegateRegistration(
@@ -62,17 +56,14 @@ export class TransactionService extends Services.AbstractTransactionService {
 	}
 
 	public async multiSignature(input: Services.MultiSignatureInput): Promise<Contracts.SignedTransactionData> {
-		return this.#createFromData(
-			"registerMultisignature",
-			{
-				...input,
-				data: {
-					keysgroup: input.data.publicKeys,
-					lifetime: input.data.lifetime,
-					minimum: input.data.min,
-				},
+		return this.#createFromData("registerMultisignature", {
+			...input,
+			data: {
+				keysgroup: input.data.publicKeys,
+				lifetime: input.data.lifetime,
+				minimum: input.data.min,
 			},
-		);
+		});
 	}
 
 	async #createFromData(

--- a/packages/platform-sdk-lsk/src/services/transaction.ts
+++ b/packages/platform-sdk-lsk/src/services/transaction.ts
@@ -36,7 +36,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 					data: input.data.memo,
 				},
 			},
-			options,
 		);
 	}
 
@@ -49,7 +48,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 					secondMnemonic: BIP39.normalize(input.data.mnemonic),
 				},
 			},
-			options,
 		);
 	}
 
@@ -74,7 +72,6 @@ export class TransactionService extends Services.AbstractTransactionService {
 					minimum: input.data.min,
 				},
 			},
-			options,
 		);
 	}
 

--- a/packages/platform-sdk-lsk/src/services/transaction.ts
+++ b/packages/platform-sdk-lsk/src/services/transaction.ts
@@ -54,11 +54,11 @@ export class TransactionService extends Services.AbstractTransactionService {
 	public async delegateRegistration(
 		input: Services.DelegateRegistrationInput,
 	): Promise<Contracts.SignedTransactionData> {
-		return this.#createFromData("registerDelegate", input, options);
+		return this.#createFromData("registerDelegate", input);
 	}
 
 	public async vote(input: Services.VoteInput): Promise<Contracts.SignedTransactionData> {
-		return this.#createFromData("castVotes", input, options);
+		return this.#createFromData("castVotes", input);
 	}
 
 	public async multiSignature(input: Services.MultiSignatureInput): Promise<Contracts.SignedTransactionData> {

--- a/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet-transaction-service.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet-transaction-service.ts
@@ -74,57 +74,57 @@ export class TransactionService implements ITransactionService {
 
 	/** {@inheritDoc ITransactionService.signTransfer} */
 	public async signTransfer(input: Services.TransferInput): Promise<string> {
-		return this.#signTransaction("transfer", input, options);
+		return this.#signTransaction("transfer", input);
 	}
 
 	/** {@inheritDoc ITransactionService.signSecondSignature} */
 	public async signSecondSignature(input: Services.SecondSignatureInput): Promise<string> {
-		return this.#signTransaction("secondSignature", input, options);
+		return this.#signTransaction("secondSignature", input);
 	}
 
 	/** {@inheritDoc ITransactionService.signDelegateRegistration} */
 	public async signDelegateRegistration(input: Services.DelegateRegistrationInput): Promise<string> {
-		return this.#signTransaction("delegateRegistration", input, options);
+		return this.#signTransaction("delegateRegistration", input);
 	}
 
 	/** {@inheritDoc ITransactionService.signVote} */
 	public async signVote(input: Services.VoteInput): Promise<string> {
-		return this.#signTransaction("vote", input, options);
+		return this.#signTransaction("vote", input);
 	}
 
 	/** {@inheritDoc ITransactionService.signMultiSignature} */
 	public async signMultiSignature(input: Services.MultiSignatureInput): Promise<string> {
-		return this.#signTransaction("multiSignature", input, options);
+		return this.#signTransaction("multiSignature", input);
 	}
 
 	/** {@inheritDoc ITransactionService.signIpfs} */
 	public async signIpfs(input: Services.IpfsInput): Promise<string> {
-		return this.#signTransaction("ipfs", input, options);
+		return this.#signTransaction("ipfs", input);
 	}
 
 	/** {@inheritDoc ITransactionService.signMultiPayment} */
 	public async signMultiPayment(input: Services.MultiPaymentInput): Promise<string> {
-		return this.#signTransaction("multiPayment", input, options);
+		return this.#signTransaction("multiPayment", input);
 	}
 
 	/** {@inheritDoc ITransactionService.signDelegateResignation} */
 	public async signDelegateResignation(input: Services.DelegateResignationInput): Promise<string> {
-		return this.#signTransaction("delegateResignation", input, options);
+		return this.#signTransaction("delegateResignation", input);
 	}
 
 	/** {@inheritDoc ITransactionService.signHtlcLock} */
 	public async signHtlcLock(input: Services.HtlcLockInput): Promise<string> {
-		return this.#signTransaction("htlcLock", input, options);
+		return this.#signTransaction("htlcLock", input);
 	}
 
 	/** {@inheritDoc ITransactionService.signHtlcClaim} */
 	public async signHtlcClaim(input: Services.HtlcClaimInput): Promise<string> {
-		return this.#signTransaction("htlcClaim", input, options);
+		return this.#signTransaction("htlcClaim", input);
 	}
 
 	/** {@inheritDoc ITransactionService.signHtlcRefund} */
 	public async signHtlcRefund(input: Services.HtlcRefundInput): Promise<string> {
-		return this.#signTransaction("htlcRefund", input, options);
+		return this.#signTransaction("htlcRefund", input);
 	}
 
 	/** {@inheritDoc ITransactionService.transaction} */
@@ -373,7 +373,7 @@ export class TransactionService implements ITransactionService {
 		const transaction: Contracts.SignedTransactionData = await this.#wallet
 			.coin()
 			.transaction()
-			[type](input, options);
+			[type](input);
 
 		const uuid: string = uuidv4();
 

--- a/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet-transaction-service.ts
+++ b/packages/platform-sdk-profiles/src/drivers/memory/wallets/wallet-transaction-service.ts
@@ -370,10 +370,7 @@ export class TransactionService implements ITransactionService {
 	 * @memberof TransactionService
 	 */
 	async #signTransaction(type: string, input: any): Promise<string> {
-		const transaction: Contracts.SignedTransactionData = await this.#wallet
-			.coin()
-			.transaction()
-			[type](input);
+		const transaction: Contracts.SignedTransactionData = await this.#wallet.coin().transaction()[type](input);
 
 		const uuid: string = uuidv4();
 

--- a/packages/platform-sdk/src/coins/coin.ts
+++ b/packages/platform-sdk/src/coins/coin.ts
@@ -27,7 +27,7 @@ import { Manifest } from "./manifest";
 @injectable()
 export class Coin {
 	readonly #container: Container;
-	#isSyncing: boolean = false;
+	#isSyncing = false;
 
 	public constructor(container: Container) {
 		this.#container = container;

--- a/packages/platform-sdk/src/services/signatory.contract.ts
+++ b/packages/platform-sdk/src/services/signatory.contract.ts
@@ -14,8 +14,6 @@ export interface SignatoryService {
 
 	privateKey(privateKey: string, options?: IdentityOptions): Promise<Signatory>;
 
-	signature(signature: string, senderPublicKey: string): Promise<Signatory>;
-
 	senderPublicKey(publicKey: string, options?: IdentityOptions): Promise<Signatory>;
 
 	multiSignature(min: number, publicKeys: string[]): Promise<Signatory>;

--- a/packages/platform-sdk/src/services/signatory.service.ts
+++ b/packages/platform-sdk/src/services/signatory.service.ts
@@ -12,7 +12,6 @@ import {
 	SecondaryWIFSignatory,
 	SenderPublicKeySignatory,
 	Signatory,
-	SignatureSignatory,
 	WIFSignatory,
 } from "../signatories";
 import { AddressService } from "./address.contract";
@@ -110,16 +109,6 @@ export class AbstractSignatoryService implements SignatoryService {
 			new PrivateKeySignatory({
 				signingKey: privateKey,
 				address: (await this.addressService.fromPrivateKey(privateKey, options)).address,
-			}),
-		);
-	}
-
-	public async signature(signature: string, senderPublicKey: string): Promise<Signatory> {
-		return new Signatory(
-			new SignatureSignatory({
-				signingKey: signature,
-				address: (await this.addressService.fromPublicKey(senderPublicKey)).address,
-				publicKey: senderPublicKey,
 			}),
 		);
 	}

--- a/packages/platform-sdk/src/signatories/index.ts
+++ b/packages/platform-sdk/src/signatories/index.ts
@@ -8,7 +8,6 @@ import { SecondaryMnemonicSignatory } from "./secondary-mnemonic";
 import { SecondaryWIFSignatory } from "./secondary-wif";
 import { SenderPublicKeySignatory } from "./sender-public-key";
 import { Signatory } from "./signatory";
-import { SignatureSignatory } from "./signature";
 import { WIFSignatory } from "./wif";
 
 export {
@@ -22,6 +21,5 @@ export {
 	SecondaryWIFSignatory,
 	SenderPublicKeySignatory,
 	Signatory,
-	SignatureSignatory,
 	WIFSignatory,
 };

--- a/packages/platform-sdk/src/signatories/signatory.test.ts
+++ b/packages/platform-sdk/src/signatories/signatory.test.ts
@@ -1,6 +1,6 @@
 import "jest-extended";
-import { LedgerSignatory } from "./ledger";
 
+import { LedgerSignatory } from "./ledger";
 import { MnemonicSignatory } from "./mnemonic";
 import { MultiMnemonicSignatory } from "./multi-mnemonic";
 import { MultiSignatureSignatory } from "./multi-signature";
@@ -10,7 +10,6 @@ import { SecondaryMnemonicSignatory } from "./secondary-mnemonic";
 import { SecondaryWIFSignatory } from "./secondary-wif";
 import { SenderPublicKeySignatory } from "./sender-public-key";
 import { Signatory } from "./signatory";
-import { SignatureSignatory } from "./signature";
 import { WIFSignatory } from "./wif";
 
 describe("MnemonicSignatory", () => {

--- a/packages/platform-sdk/src/signatories/signatory.test.ts
+++ b/packages/platform-sdk/src/signatories/signatory.test.ts
@@ -672,116 +672,6 @@ describe("PrivateKeySignatory", () => {
 	});
 });
 
-describe("SignatureSignatory", () => {
-	test("#signingKey", () => {
-		const subject = new Signatory(
-			new SignatureSignatory({
-				signingKey: "signingKey",
-				address: "address",
-				publicKey: "publicKey",
-			}),
-		);
-
-		expect(subject.signingKey()).toMatchInlineSnapshot(`"signingKey"`);
-	});
-
-	test("#signingKeys", () => {
-		const subject = new Signatory(
-			new SignatureSignatory({
-				signingKey: "signingKey",
-				address: "address",
-				publicKey: "publicKey",
-			}),
-		);
-
-		expect(() => subject.signingKeys()).toThrow(/cannot be called/);
-	});
-
-	test("#signingList", () => {
-		const subject = new Signatory(
-			new SignatureSignatory({
-				signingKey: "signingKey",
-				address: "address",
-				publicKey: "publicKey",
-			}),
-		);
-
-		expect(() => subject.signingList()).toThrow(/cannot be called/);
-	});
-
-	test("#confirmKey", () => {
-		const subject = new Signatory(
-			new SignatureSignatory({
-				signingKey: "signingKey",
-				address: "address",
-				publicKey: "publicKey",
-			}),
-		);
-
-		expect(() => subject.confirmKey()).toThrow(/cannot be called/);
-	});
-
-	test("#identifier", () => {
-		const subject = new Signatory(
-			new SignatureSignatory({
-				signingKey: "signingKey",
-				address: "address",
-				publicKey: "publicKey",
-			}),
-		);
-
-		expect(() => subject.identifier()).toThrow(/cannot be called/);
-	});
-
-	test("#identifiers", () => {
-		const subject = new Signatory(
-			new SignatureSignatory({
-				signingKey: "signingKey",
-				address: "address",
-				publicKey: "publicKey",
-			}),
-		);
-
-		expect(() => subject.identifiers()).toThrow(/cannot be called/);
-	});
-
-	test("#address", () => {
-		const subject = new Signatory(
-			new SignatureSignatory({
-				signingKey: "signingKey",
-				address: "address",
-				publicKey: "publicKey",
-			}),
-		);
-
-		expect(subject.address()).toMatchInlineSnapshot(`"address"`);
-	});
-
-	test("#publicKey", () => {
-		const subject = new Signatory(
-			new SignatureSignatory({
-				signingKey: "signingKey",
-				address: "address",
-				publicKey: "publicKey",
-			}),
-		);
-
-		expect(subject.publicKey()).toMatchInlineSnapshot(`"publicKey"`);
-	});
-
-	test("#privateKey", () => {
-		const subject = new Signatory(
-			new SignatureSignatory({
-				signingKey: "signingKey",
-				address: "address",
-				publicKey: "publicKey",
-			}),
-		);
-
-		expect(() => subject.privateKey()).toThrow(/cannot be called/);
-	});
-});
-
 describe("SenderPublicKeySignatory", () => {
 	test("#signingKey", () => {
 		const subject = new Signatory(
@@ -1143,17 +1033,6 @@ test("#actsWithPrivateKey", () => {
 	);
 
 	expect(subject.actsWithPrivateKey()).toBeBoolean();
-});
-
-test("#actsWithSignature", () => {
-	const subject = new Signatory(
-		new PrivateMultiSignatureSignatory("this is a top secret passphrase 1", [
-			"this is a top secret passphrase 1",
-			"this is a top secret passphrase 2",
-		]),
-	);
-
-	expect(subject.actsWithSignature()).toBeBoolean();
 });
 
 test("#actsWithSenderPublicKey", () => {

--- a/packages/platform-sdk/src/signatories/signatory.ts
+++ b/packages/platform-sdk/src/signatories/signatory.ts
@@ -13,7 +13,6 @@ import { PrivateMultiSignatureSignatory } from "./private-multi-signature";
 import { SecondaryMnemonicSignatory } from "./secondary-mnemonic";
 import { SecondaryWIFSignatory } from "./secondary-wif";
 import { SenderPublicKeySignatory } from "./sender-public-key";
-import { SignatureSignatory } from "./signature";
 import { WIFSignatory } from "./wif";
 
 type SignatoryType =
@@ -26,7 +25,6 @@ type SignatoryType =
 	| SecondaryMnemonicSignatory
 	| SecondaryWIFSignatory
 	| SenderPublicKeySignatory
-	| SignatureSignatory
 	| WIFSignatory;
 
 export class Signatory {
@@ -184,10 +182,6 @@ export class Signatory {
 
 	public actsWithPrivateKey(): boolean {
 		return this.#signatory instanceof PrivateKeySignatory;
-	}
-
-	public actsWithSignature(): boolean {
-		return this.#signatory instanceof SignatureSignatory;
 	}
 
 	public actsWithSenderPublicKey(): boolean {

--- a/packages/platform-sdk/src/signatories/signature.ts
+++ b/packages/platform-sdk/src/signatories/signature.ts
@@ -1,5 +1,0 @@
-import { AbstractValueSignatory } from "./abstract-value-signatory";
-
-export class SignatureSignatory extends AbstractValueSignatory {
-	//
-}


### PR DESCRIPTION
`SignatureSignatory` was introduced to handle ledger signing but we now reworked that have the `LedgerSignatory` instead.