### PR TITLE
fix(profiles): use `denominated` amount for conversion

### DIFF
--- a/jest.coverage.js
+++ b/jest.coverage.js
@@ -2,7 +2,7 @@ const baseConfig = require("./jest.config");
 
 module.exports = {
 	...baseConfig,
-	collectCoverage: false,
+	collectCoverage: true,
 	collectCoverageFrom: [
 		"source/**/*.ts",
 		"!source/**/index.ts",

--- a/packages/platform-sdk-profiles/source/dto/transaction.test.ts
+++ b/packages/platform-sdk-profiles/source/dto/transaction.test.ts
@@ -41,8 +41,8 @@ const createSubject = (wallet, properties, klass) => {
 		recipient: () => "recipient",
 		memo: () => "memo",
 		recipients: () => [],
-		amount: () => BigNumber.make(18).times(1e8),
-		fee: () => BigNumber.make(2).times(1e8),
+		amount: () => BigNumber.make(18e8, 8),
+		fee: () => BigNumber.make(2e8, 8),
 		asset: () => ({}),
 		inputs: () => [],
 		outputs: () => [],
@@ -171,7 +171,7 @@ describe("Transaction", () => {
 			wallet,
 			{
 				timestamp: () => DateTime.make(),
-				amount: () => BigNumber.make(10e8),
+				amount: () => BigNumber.make(10e8, 8),
 			},
 			TransferData,
 		);
@@ -194,7 +194,7 @@ describe("Transaction", () => {
 			wallet,
 			{
 				timestamp: () => DateTime.make(),
-				fee: () => BigNumber.make(10e8),
+				fee: () => BigNumber.make(10e8, 8),
 			},
 			TransferData,
 		);
@@ -327,11 +327,11 @@ describe("Transaction", () => {
 	it("should have a total for unsent", () => {
 		// @ts-ignore
 		subject = new DelegateRegistrationData(wallet, {
-			amount: () => BigNumber.make(18),
-			fee: () => BigNumber.make(2),
+			amount: () => BigNumber.make(18e8, 8),
+			fee: () => BigNumber.make(2e8, 8),
 			isSent: () => false,
 		});
-		expect(subject.total().toNumber()).toStrictEqual(18);
+		expect(subject.total().toNumber()).toStrictEqual(18e8);
 	});
 
 	it("should have a converted total", async () => {
@@ -339,8 +339,8 @@ describe("Transaction", () => {
 			wallet,
 			{
 				timestamp: () => DateTime.make(),
-				amount: () => BigNumber.make(10e8),
-				fee: () => BigNumber.make(5e8),
+				amount: () => BigNumber.make(10e8, 8),
+				fee: () => BigNumber.make(5e8, 8),
 			},
 			TransferData,
 		);

--- a/packages/platform-sdk-profiles/source/dto/transaction.ts
+++ b/packages/platform-sdk-profiles/source/dto/transaction.ts
@@ -54,7 +54,7 @@ export class TransactionData {
 	}
 
 	public convertedAmount(): BigNumber {
-		return this.#convertAmount(this.amount().divide(1e8));
+		return this.#convertAmount(this.amount());
 	}
 
 	public fee(): BigNumber {
@@ -62,7 +62,7 @@ export class TransactionData {
 	}
 
 	public convertedFee(): BigNumber {
-		return this.#convertAmount(this.fee().divide(1e8));
+		return this.#convertAmount(this.fee());
 	}
 
 	public memo(): string | undefined {
@@ -195,7 +195,7 @@ export class TransactionData {
 	}
 
 	public convertedTotal(): BigNumber {
-		return this.#convertAmount(this.total().divide(1e8));
+		return this.#convertAmount(this.total());
 	}
 
 	/**
@@ -226,7 +226,7 @@ export class TransactionData {
 
 		return container
 			.get<IExchangeRateService>(Identifiers.ExchangeRateService)
-			.exchange(this.wallet().currency(), this.wallet().exchangeCurrency(), timestamp, value);
+			.exchange(this.wallet().currency(), this.wallet().exchangeCurrency(), timestamp, value.denominated());
 	}
 }
 

--- a/packages/platform-sdk-support/source/bignumber.ts
+++ b/packages/platform-sdk-support/source/bignumber.ts
@@ -97,7 +97,7 @@ export class BigNumber {
 	 * @memberof BigNumber
 	 */
 	public plus(value: NumberLike): BigNumber {
-		return BigNumber.make(this.#value.plus(this.#toBigNumber(value)));
+		return BigNumber.make(this.#value.plus(this.#toBigNumber(value)), this.#decimals);
 	}
 
 	/**
@@ -108,7 +108,7 @@ export class BigNumber {
 	 * @memberof BigNumber
 	 */
 	public minus(value: NumberLike): BigNumber {
-		return BigNumber.make(this.#value.minus(this.#toBigNumber(value)));
+		return BigNumber.make(this.#value.minus(this.#toBigNumber(value)), this.#decimals);
 	}
 
 	/**
@@ -119,7 +119,7 @@ export class BigNumber {
 	 * @memberof BigNumber
 	 */
 	public divide(value: NumberLike): BigNumber {
-		return BigNumber.make(this.#value.dividedBy(this.#toBigNumber(value)));
+		return BigNumber.make(this.#value.dividedBy(this.#toBigNumber(value)), this.#decimals);
 	}
 
 	/**
@@ -130,7 +130,7 @@ export class BigNumber {
 	 * @memberof BigNumber
 	 */
 	public times(value: NumberLike): BigNumber {
-		return BigNumber.make(this.#value.multipliedBy(this.#toBigNumber(value)));
+		return BigNumber.make(this.#value.multipliedBy(this.#toBigNumber(value)), this.#decimals);
 	}
 
 	/**


### PR DESCRIPTION
Ensures that the wrapped DTOs don't create different numbers and also fixes a few bugs with decimals not being persisted when using operations on a `BigNumber` instance.