### PR TITLE
refactor(profiles): treat balances, amounts and fees as numbers

### DIFF
--- a/packages/platform-sdk-ada/source/signed-transaction.dto.test.ts
+++ b/packages/platform-sdk-ada/source/signed-transaction.dto.test.ts
@@ -34,7 +34,7 @@ describe("SignedTransactionData", () => {
 	});
 
 	test("#amount", () => {
-		expect(subject.amount().toHuman()).toEqual("12500000000");
+		expect(subject.amount().toHuman()).toEqual(12500000000);
 	});
 
 	test("#fee", () => {

--- a/packages/platform-sdk-ark/source/multi-payment.dto.ts
+++ b/packages/platform-sdk-ark/source/multi-payment.dto.ts
@@ -1,4 +1,5 @@
 import { Contracts, IoC } from "@arkecosystem/platform-sdk";
+import { BigNumber } from "@arkecosystem/platform-sdk-support";
 
 import { TransactionData } from "./transaction.dto";
 
@@ -8,7 +9,10 @@ export class MultiPaymentData extends TransactionData implements Contracts.Multi
 		return this.data.vendorField;
 	}
 
-	public payments(): { recipientId: string; amount: string }[] {
-		return this.data.asset.payments;
+	public payments(): { recipientId: string; amount: BigNumber }[] {
+		return this.data.asset.payments.map((payment: { recipientId: string; amount: BigNumber }) => ({
+			address: payment.recipientId,
+			amount: this.bigNumberService.make(payment.amount),
+		}));
 	}
 }

--- a/packages/platform-sdk-ark/source/transaction.dto.ts
+++ b/packages/platform-sdk-ark/source/transaction.dto.ts
@@ -34,7 +34,7 @@ export class TransactionData extends DTO.AbstractTransactionData implements Cont
 			return [];
 		}
 
-		return this.data.asset.payments.map((payment: { recipientId: string; amount: string }) => ({
+		return this.data.asset.payments.map((payment: { recipientId: string; amount: BigNumber }) => ({
 			address: payment.recipientId,
 			amount: this.bigNumberService.make(payment.amount),
 		}));

--- a/packages/platform-sdk-avax/source/signed-transaction.dto.test.ts
+++ b/packages/platform-sdk-avax/source/signed-transaction.dto.test.ts
@@ -35,7 +35,7 @@ describe("SignedTransactionData", () => {
 	});
 
 	test("#amount", () => {
-		expect(subject.amount().toHuman()).toEqual("125");
+		expect(subject.amount().toHuman()).toEqual(125);
 	});
 
 	test("#fee", () => {

--- a/packages/platform-sdk-avax/source/transaction.service.ts
+++ b/packages/platform-sdk-avax/source/transaction.service.ts
@@ -1,7 +1,7 @@
 import { Contracts, Exceptions, Helpers, IoC, Services } from "@arkecosystem/platform-sdk";
 import { Hash } from "@arkecosystem/platform-sdk-crypto";
 import { DateTime } from "@arkecosystem/platform-sdk-intl";
-import { BigNumber } from "@arkecosystem/utils";
+import { BigNumber } from "@arkecosystem/platform-sdk-support";
 import { BN, Buffer } from "avalanche";
 import { AVMAPI } from "avalanche/dist/apis/avm";
 import { PlatformVMAPI } from "avalanche/dist/apis/platformvm";

--- a/packages/platform-sdk-cli/source/commands/access-wallet.ts
+++ b/packages/platform-sdk-cli/source/commands/access-wallet.ts
@@ -63,7 +63,7 @@ export const accessWallet = async (profile: Contracts.IProfile): Promise<void> =
 	}
 
 	if (command === "balance") {
-		useLogger().info(wallet.balance().toHuman());
+		useLogger().info(wallet.balance());
 	}
 
 	if (command === "list-transactions") {

--- a/packages/platform-sdk-cli/source/commands/examples/commands/ada/transfer-funds.ts
+++ b/packages/platform-sdk-cli/source/commands/examples/commands/ada/transfer-funds.ts
@@ -33,8 +33,8 @@ export const transferFundsWithADA = async (env: Environment): Promise<void> => {
 	profile.wallets().push(wallet2);
 
 	// Display profile and wallet balances
-	logger.log("Wallet 1", wallet1.address(), "balance", wallet1.balance().toHuman(2));
-	logger.log("Wallet 2", wallet2.address(), "balance", wallet2.balance().toHuman(2));
+	logger.log("Wallet 1", wallet1.address(), "balance", wallet1.balance());
+	logger.log("Wallet 2", wallet2.address(), "balance", wallet2.balance());
 
 	// Transfer from wallet1 to wallet2
 	const signatory = await wallet1.coin().signatory().mnemonic(mnemonic1);

--- a/packages/platform-sdk-cli/source/commands/examples/commands/ark/transfer-funds.ts
+++ b/packages/platform-sdk-cli/source/commands/examples/commands/ark/transfer-funds.ts
@@ -30,8 +30,8 @@ export const transferFundsWithARK = async (env: Environment): Promise<void> => {
 	profile.wallets().push(wallet2);
 
 	// Display profile and wallet balances
-	logger.log("Wallet 1", wallet1.address(), "balance", wallet1.balance().toHuman(2));
-	logger.log("Wallet 2", wallet2.address(), "balance", wallet2.balance().toHuman(2));
+	logger.log("Wallet 1", wallet1.address(), "balance", wallet1.balance());
+	logger.log("Wallet 2", wallet2.address(), "balance", wallet2.balance());
 
 	// Transfer from wallet1 to wallet2
 	const signatory = await wallet1.coin().signatory().mnemonic(mnemonic1);

--- a/packages/platform-sdk-cli/source/commands/examples/commands/create-profile-with-wallets.ts
+++ b/packages/platform-sdk-cli/source/commands/examples/commands/create-profile-with-wallets.ts
@@ -28,7 +28,7 @@ export const createProfileWithWallets = async (env: Environment): Promise<void> 
 	profile.wallets().push(wallet2);
 
 	// Display profile balance
-	logger.log("Profile balance", profile.balance().toHuman(2));
+	logger.log("Profile balance", profile.balance());
 
 	// Create contact
 	const contact: Contracts.IContact = profile.contacts().create("friend1");

--- a/packages/platform-sdk-cli/source/commands/examples/commands/lsk/transfer-funds.ts
+++ b/packages/platform-sdk-cli/source/commands/examples/commands/lsk/transfer-funds.ts
@@ -30,8 +30,8 @@ export const transferFundsWithLSK = async (env: Environment): Promise<void> => {
 	profile.wallets().push(wallet2);
 
 	// Display profile and wallet balances
-	logger.log("Wallet 1", wallet1.address(), "balance", wallet1.balance().toHuman(2));
-	logger.log("Wallet 2", wallet2.address(), "balance", wallet2.balance().toHuman(2));
+	logger.log("Wallet 1", wallet1.address(), "balance", wallet1.balance());
+	logger.log("Wallet 2", wallet2.address(), "balance", wallet2.balance());
 
 	// Transfer from wallet1 to wallet2
 	const signatory = await wallet1.coin().signatory().mnemonic(mnemonic1);

--- a/packages/platform-sdk-cli/source/commands/examples/commands/open-existing-profile.ts
+++ b/packages/platform-sdk-cli/source/commands/examples/commands/open-existing-profile.ts
@@ -16,9 +16,9 @@ export const openExistingProfile = async (env: Environment): Promise<void> => {
 	await profile.sync();
 
 	// Display profile and wallet balances
-	logger.log("Profile balance", profile.balance().toHuman(2));
+	logger.log("Profile balance", profile.balance());
 	for (const wallet of Object.values(await profile.wallets().all())) {
-		logger.log("Wallet", wallet.address(), "balance", wallet.balance().toHuman(2));
+		logger.log("Wallet", wallet.address(), "balance", wallet.balance());
 	}
 
 	for (const contact of Object.values(await profile.contacts().all())) {

--- a/packages/platform-sdk-cli/source/commands/examples/commands/trx/transfer-funds.ts
+++ b/packages/platform-sdk-cli/source/commands/examples/commands/trx/transfer-funds.ts
@@ -31,8 +31,8 @@ export const transferFundsWithTRX = async (env: Environment): Promise<void> => {
 	profile.wallets().push(wallet2);
 
 	// Display profile and wallet balances
-	logger.log("Wallet 1", wallet1.address(), "balance", wallet1.balance().toHuman(2));
-	logger.log("Wallet 2", wallet2.address(), "balance", wallet2.balance().toHuman(2));
+	logger.log("Wallet 1", wallet1.address(), "balance", wallet1.balance());
+	logger.log("Wallet 2", wallet2.address(), "balance", wallet2.balance());
 
 	// Transfer from wallet1 to wallet2
 	const signatory = await wallet1.coin().signatory().mnemonic(mnemonic1);

--- a/packages/platform-sdk-cli/source/commands/examples/commands/xlm/list-transactions.ts
+++ b/packages/platform-sdk-cli/source/commands/examples/commands/xlm/list-transactions.ts
@@ -22,7 +22,7 @@ export const listTransactionsWithXLM = async (env: Environment): Promise<void> =
 	profile.wallets().push(wallet1);
 
 	// Display profile and wallet balances
-	logger.log("Wallet 1", wallet1.address(), "balance", wallet1.balance().toHuman(2));
+	logger.log("Wallet 1", wallet1.address(), "balance", wallet1.balance());
 
 	// Show transactions
 	const transactions: Collections.TransactionDataCollection = await wallet1

--- a/packages/platform-sdk-cli/source/commands/examples/commands/xlm/transfer-funds.ts
+++ b/packages/platform-sdk-cli/source/commands/examples/commands/xlm/transfer-funds.ts
@@ -30,8 +30,8 @@ export const transferFundsWithXLM = async (env: Environment): Promise<void> => {
 	profile.wallets().push(wallet2);
 
 	// Display profile and wallet balances
-	logger.log("Wallet 1", wallet1.address(), "balance", wallet1.balance().toHuman(2));
-	logger.log("Wallet 2", wallet2.address(), "balance", wallet2.balance().toHuman(2));
+	logger.log("Wallet 1", wallet1.address(), "balance", wallet1.balance());
+	logger.log("Wallet 2", wallet2.address(), "balance", wallet2.balance());
 
 	// Transfer from wallet1 to wallet2
 	const signatory = await wallet1.coin().signatory().mnemonic(mnemonic1);

--- a/packages/platform-sdk-dot/source/signed-transaction.dto.test.ts
+++ b/packages/platform-sdk-dot/source/signed-transaction.dto.test.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
 			method: {
 				args: {
 					dest: "0xfoobar",
-					value: "4206900000000",
+					value: "1200000000000",
 				},
 			},
 			timestamp: "1970-01-01T00:00:00.000Z",
@@ -38,7 +38,7 @@ describe("SignedTransactionData", () => {
 	});
 
 	test("#amount", () => {
-		expect(subject.amount().toHuman()).toEqual("420.69");
+		expect(subject.amount().toHuman()).toEqual(120);
 	});
 
 	test("#fee", () => {

--- a/packages/platform-sdk-egld/source/signed-transaction.dto.test.ts
+++ b/packages/platform-sdk-egld/source/signed-transaction.dto.test.ts
@@ -15,7 +15,7 @@ beforeEach(() => {
 		{
 			sender: "0xdeadbeef",
 			receiver: "0xfoobar",
-			value: "420690000000000000000",
+			value: "120000000000000000000",
 			timestamp: "1970-01-01T00:00:00.000Z",
 			gasUsed: 2,
 			gasPrice: 3,
@@ -34,7 +34,7 @@ describe("SignedTransactionData", () => {
 	});
 
 	test("#amount", () => {
-		expect(subject.amount().toHuman()).toEqual("420.69");
+		expect(subject.amount().toHuman()).toEqual(120);
 	});
 
 	test("#fee", () => {

--- a/packages/platform-sdk-nano/source/signed-transaction.dto.test.ts
+++ b/packages/platform-sdk-nano/source/signed-transaction.dto.test.ts
@@ -16,7 +16,7 @@ beforeEach(() => {
 		{
 			fromAddress: "123456",
 			toAddress: "456789",
-			amountRaw: "420690000000000000000000000000000",
+			amountRaw: "120000000000000000000000000000000",
 			timestamp: "1970-01-01T00:00:00.000Z",
 		},
 		"",
@@ -33,7 +33,7 @@ describe("SignedTransactionData", () => {
 	});
 
 	test("#amount", () => {
-		expect(subject.amount().toHuman()).toEqual("420.69");
+		expect(subject.amount().toHuman()).toEqual(120);
 	});
 
 	test("#fee", () => {

--- a/packages/platform-sdk-profiles/source/exchange-rate.service.contract.ts
+++ b/packages/platform-sdk-profiles/source/exchange-rate.service.contract.ts
@@ -1,5 +1,5 @@
 import { DateTime } from "@arkecosystem/platform-sdk-intl";
-import { BigNumber } from "@arkecosystem/platform-sdk-support";
+import { BigNumber, NumberLike } from "@arkecosystem/platform-sdk-support";
 
 import { IProfile } from "./contracts";
 
@@ -26,11 +26,11 @@ export interface IExchangeRateService {
 	 * @param {string} currency
 	 * @param {string} exchangeCurrency
 	 * @param {DateTime} date
-	 * @param {BigNumber} value
-	 * @return {BigNumber}
+	 * @param {NumberLike} value
+	 * @return {number}
 	 * @memberof IExchangeRateService
 	 */
-	exchange(currency: string, exchangeCurrency: string, date: DateTime, value: BigNumber): BigNumber;
+	exchange(currency: string, exchangeCurrency: string, date: DateTime, value: NumberLike): number;
 
 	/**
 	 * Take a snapshot of the current data.

--- a/packages/platform-sdk-profiles/source/exchange-rate.service.test.ts
+++ b/packages/platform-sdk-profiles/source/exchange-rate.service.test.ts
@@ -89,7 +89,7 @@ describe("ExchangeRateService", () => {
 
 		await subject.syncAll(profile, "DARK");
 
-		expect(wallet.convertedBalance().toNumber()).toBe(0.00005048);
+		expect(wallet.convertedBalance()).toBe(0.00005048);
 		const allStorage: Record<string, any> = await container.get<StubStorage>(Identifiers.Storage).all();
 		expect(allStorage.EXCHANGE_RATE_SERVICE).toMatchObject({ DARK: { BTC: expect.anything() } });
 	});
@@ -103,7 +103,7 @@ describe("ExchangeRateService", () => {
 
 		await subject.syncAll(profile, "DARK");
 
-		expect(wallet.convertedBalance().toNumber()).toBe(0.00002134);
+		expect(wallet.convertedBalance()).toBe(0.00002134);
 	});
 
 	it("should fail to sync a coin for a specific profile if there are no wallets", async () => {
@@ -126,7 +126,7 @@ describe("ExchangeRateService", () => {
 		profile.settings().set(ProfileSetting.MarketProvider, "cryptocompare");
 
 		await subject.syncAll(profile, "DARK");
-		expect(wallet.convertedBalance().toNumber()).toBe(0.00005048);
+		expect(wallet.convertedBalance()).toBe(0.00005048);
 	});
 
 	it("should cache historic exchange rates", async () => {
@@ -139,7 +139,7 @@ describe("ExchangeRateService", () => {
 		profile.settings().set(ProfileSetting.MarketProvider, "cryptocompare");
 
 		await subject.syncAll(profile, "DARK");
-		expect(wallet.convertedBalance().toNumber()).toBe(0.00005048);
+		expect(wallet.convertedBalance()).toBe(0.00005048);
 
 		nock(/.+/)
 			.get("/data/dayAvg")
@@ -149,7 +149,7 @@ describe("ExchangeRateService", () => {
 
 		await subject.syncAll(profile, "DARK");
 		// The price should be the cached price from previous sync: 0.00005048
-		expect(wallet.convertedBalance().toNumber()).toBe(0.00005048);
+		expect(wallet.convertedBalance()).toBe(0.00005048);
 	});
 
 	it("handle restore", async () => {

--- a/packages/platform-sdk-profiles/source/exchange-rate.service.ts
+++ b/packages/platform-sdk-profiles/source/exchange-rate.service.ts
@@ -1,6 +1,6 @@
 import { DateTime } from "@arkecosystem/platform-sdk-intl";
 import { MarketService } from "@arkecosystem/platform-sdk-markets";
-import { BigNumber } from "@arkecosystem/platform-sdk-support";
+import { BigNumber, NumberLike } from "@arkecosystem/platform-sdk-support";
 
 import { DataRepository } from "./data.repository";
 import { container } from "./container";
@@ -55,26 +55,15 @@ export class ExchangeRateService implements IExchangeRateService {
 	}
 
 	/** {@inheritDoc IExchangeRateService.exchange} */
-	public exchange(currency: string, exchangeCurrency: string, date: DateTime, value: BigNumber): BigNumber {
-		const exchangeRate: BigNumber = this.#rateByDate(currency, exchangeCurrency, date);
+	public exchange(currency: string, exchangeCurrency: string, date: DateTime, value: NumberLike): number {
+		const exchangeRate: number =
+			this.#dataRepository.get(`${currency}.${exchangeCurrency}.${date.format("YYYY-MM-DD")}`) || 0;
 
-		if (exchangeRate.isZero()) {
-			return exchangeRate;
+		if (exchangeRate === 0) {
+			return 0;
 		}
 
-		return value.times(exchangeRate);
-	}
-
-	#rateByDate(currency: string, exchangeCurrency: string, date: DateTime): BigNumber {
-		const result: number | undefined = this.#dataRepository.get(
-			`${currency}.${exchangeCurrency}.${date.format("YYYY-MM-DD")}`,
-		);
-
-		if (result === undefined) {
-			return BigNumber.ZERO;
-		}
-
-		return BigNumber.make(result);
+		return +value.toString() * exchangeRate;
 	}
 
 	/** {@inheritDoc IExchangeRateService.generate} */

--- a/packages/platform-sdk-profiles/source/fee.service.test.ts
+++ b/packages/platform-sdk-profiles/source/fee.service.test.ts
@@ -65,9 +65,9 @@ describe("FeeService", () => {
 
 		const fees = subject.findByType("ARK", "ark.devnet", "transfer");
 
-		expect(fees.min.toString()).toEqual("357000");
-		expect(fees.avg.toString()).toEqual("10000000");
-		expect(fees.max.toString()).toEqual("10000000");
-		expect(fees.static.toString()).toEqual("10000000");
+		expect(fees.min.toHuman()).toEqual(0.00357);
+		expect(fees.avg.toHuman()).toEqual(0.1);
+		expect(fees.max.toHuman()).toEqual(0.1);
+		expect(fees.static.toHuman()).toEqual(0.1);
 	});
 });

--- a/packages/platform-sdk-profiles/source/portfolio.ts
+++ b/packages/platform-sdk-profiles/source/portfolio.ts
@@ -27,8 +27,8 @@ export class Portfolio implements IPortfolio {
 				};
 			}
 
-			result[ticker].source += parseFloat(wallet.balance().toHuman());
-			result[ticker].target += parseFloat(wallet.convertedBalance().toString());
+			result[ticker].source += wallet.balance();
+			result[ticker].target += wallet.convertedBalance();
 		}
 
 		let totalValue: number = 0;

--- a/packages/platform-sdk-profiles/source/profile.contract.ts
+++ b/packages/platform-sdk-profiles/source/profile.contract.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { BigNumber } from "@arkecosystem/platform-sdk-support";
 import { AttributeBag } from "./helpers/attribute-bag";
 import {
 	IPluginRepository,
@@ -119,18 +118,18 @@ export interface IProfile {
 	/**
 	 * Get the balance.
 	 *
-	 * @return {BigNumber}
+	 * @return {number}
 	 * @memberof IProfile
 	 */
-	balance(): BigNumber;
+	balance(): number;
 
 	/**
 	 * Get the converted balance.
 	 *
-	 * @return {BigNumber}
+	 * @return {number}
 	 * @memberof IProfile
 	 */
-	convertedBalance(): BigNumber;
+	convertedBalance(): number;
 
 	/**
 	 * Get the coin service instance.

--- a/packages/platform-sdk-profiles/source/profile.test.ts
+++ b/packages/platform-sdk-profiles/source/profile.test.ts
@@ -84,13 +84,11 @@ it("should have a custom avatar in data", () => {
 });
 
 it("should have a balance", () => {
-	expect(subject.balance()).toBeInstanceOf(BigNumber);
-	expect(subject.balance().toString()).toBe("0");
+	expect(subject.balance()).toBe(0);
 });
 
 it("should have a converted balance", () => {
-	expect(subject.convertedBalance()).toBeInstanceOf(BigNumber);
-	expect(subject.convertedBalance().toString()).toBe("0");
+	expect(subject.convertedBalance()).toBe(0);
 });
 
 it("should have a contacts repository", () => {

--- a/packages/platform-sdk-profiles/source/profile.ts
+++ b/packages/platform-sdk-profiles/source/profile.ts
@@ -242,12 +242,12 @@ export class Profile implements IProfile {
 	}
 
 	/** {@inheritDoc IProfile.balance} */
-	public balance(): BigNumber {
+	public balance(): number {
 		return this.walletAggregate().balance();
 	}
 
 	/** {@inheritDoc IProfile.convertedBalance} */
-	public convertedBalance(): BigNumber {
+	public convertedBalance(): number {
 		return this.walletAggregate().convertedBalance();
 	}
 

--- a/packages/platform-sdk-profiles/source/transaction.dto.test.ts
+++ b/packages/platform-sdk-profiles/source/transaction.dto.test.ts
@@ -163,7 +163,7 @@ describe("Transaction", () => {
 	});
 
 	it("should have an amount", () => {
-		expect(subject.amount()).toStrictEqual(BigNumber.make(18));
+		expect(subject.amount()).toStrictEqual(18);
 	});
 
 	it("should have a converted amount", async () => {
@@ -178,15 +178,15 @@ describe("Transaction", () => {
 
 		await container.get<IExchangeRateService>(Identifiers.ExchangeRateService).syncAll(profile, "DARK");
 
-		expect(subject.convertedAmount().toNumber()).toBe(0.0005048);
+		expect(subject.convertedAmount()).toBe(0.0005048);
 	});
 
 	it("should have a default converted amount", () => {
-		expect(subject.convertedAmount().toNumber()).toStrictEqual(0);
+		expect(subject.convertedAmount()).toStrictEqual(0);
 	});
 
 	it("should have a fee", () => {
-		expect(subject.fee().toNumber()).toStrictEqual(2e8);
+		expect(subject.fee()).toStrictEqual(2);
 	});
 
 	it("should have a converted fee", async () => {
@@ -201,11 +201,11 @@ describe("Transaction", () => {
 
 		await container.get<IExchangeRateService>(Identifiers.ExchangeRateService).syncAll(profile, "DARK");
 
-		expect(subject.convertedFee().toNumber()).toBe(0.0005048);
+		expect(subject.convertedFee()).toBe(0.0005048);
 	});
 
 	it("should have a default converted fee", () => {
-		expect(subject.convertedFee().toNumber()).toStrictEqual(0);
+		expect(subject.convertedFee()).toStrictEqual(0);
 	});
 
 	test("#toObject", () => {
@@ -333,7 +333,7 @@ describe("Transaction", () => {
 	});
 
 	it("should have a total for sent", () => {
-		expect(subject.total().toNumber()).toStrictEqual(20e8);
+		expect(subject.total()).toStrictEqual(20);
 	});
 
 	it("should have a total for unsent", () => {
@@ -343,7 +343,7 @@ describe("Transaction", () => {
 			fee: () => BigNumber.make(2e8, 8),
 			isSent: () => false,
 		});
-		expect(subject.total().toNumber()).toStrictEqual(18e8);
+		expect(subject.total()).toStrictEqual(18);
 	});
 
 	it("should have a converted total", async () => {
@@ -359,11 +359,11 @@ describe("Transaction", () => {
 
 		await container.get<IExchangeRateService>(Identifiers.ExchangeRateService).syncAll(profile, "DARK");
 
-		expect(subject.convertedTotal().toNumber()).toBe(0.0007572);
+		expect(subject.convertedTotal()).toBe(0.0007572);
 	});
 
 	it("should have a default converted total", () => {
-		expect(subject.convertedTotal().toNumber()).toStrictEqual(0);
+		expect(subject.convertedTotal()).toStrictEqual(0);
 	});
 
 	it("should have meta", () => {
@@ -533,14 +533,14 @@ describe("MultiPaymentData", () => {
 		subject = createSubject(
 			wallet,
 			{
-				payments: () => [{ recipient: "recipient", amount: 1000 }],
+				payments: () => [{ recipientId: "recipientId", amount: BigNumber.make(1000, 8).times(1e8) }],
 			},
 			MultiPaymentData,
 		);
 	});
 
 	test("#payments", () => {
-		expect(subject.payments()).toEqual([{ recipient: "recipient", amount: 1000 }]);
+		expect(subject.payments()).toEqual([{ recipientId: "recipientId", amount: 1000 }]);
 	});
 });
 

--- a/packages/platform-sdk-profiles/source/transaction.dto.ts
+++ b/packages/platform-sdk-profiles/source/transaction.dto.ts
@@ -284,10 +284,12 @@ export class MultiPaymentData extends TransactionData {
 	// TODO: expose read-only wallet instances
 	public payments(): { recipientId: string; amount: number }[] {
 		// @ts-ignore
-		return this.data<Contracts.MultiPaymentData>().payments().map((payment: { recipientId: string; amount: BigNumber }) => ({
-			recipientId: payment.recipientId,
-			amount: payment.amount.toHuman(),
-		}));
+		return this.data<Contracts.MultiPaymentData>()
+			.payments()
+			.map((payment: { recipientId: string; amount: BigNumber }) => ({
+				recipientId: payment.recipientId,
+				amount: payment.amount.toHuman(),
+			}));
 	}
 }
 

--- a/packages/platform-sdk-profiles/source/wallet.aggregate.contract.ts
+++ b/packages/platform-sdk-profiles/source/wallet.aggregate.contract.ts
@@ -1,5 +1,3 @@
-import { BigNumber } from "@arkecosystem/platform-sdk-support";
-
 type NetworkType = "live" | "test";
 
 /**
@@ -13,16 +11,16 @@ export interface IWalletAggregate {
 	 * Aggregate the balance for all wallets of the currently selected profile.
 	 *
 	 * @param {NetworkType} [networkType]
-	 * @return {BigNumber}
+	 * @return {number}
 	 * @memberof IWalletAggregate
 	 */
-	balance(networkType?: NetworkType): BigNumber;
+	balance(networkType?: NetworkType): number;
 
 	/**
 	 * Aggregate the converted balance for all wallets of the currently selected profile.
 	 *
-	 * @return {BigNumber}
+	 * @return {number}
 	 * @memberof IWalletAggregate
 	 */
-	convertedBalance(): BigNumber;
+	convertedBalance(): number;
 }

--- a/packages/platform-sdk-profiles/source/wallet.aggregate.test.ts
+++ b/packages/platform-sdk-profiles/source/wallet.aggregate.test.ts
@@ -38,17 +38,17 @@ beforeEach(async () => {
 
 describe("WalletAggregate", () => {
 	it("#balance", async () => {
-		expect(subject.balance("test").toString()).toEqual("55827093444556");
-		expect(subject.balance("live").toString()).toEqual("0");
-		expect(subject.balance().toString()).toEqual("0");
+		expect(subject.balance("test")).toEqual(558270.93444556);
+		expect(subject.balance("live")).toEqual(0);
+		expect(subject.balance()).toEqual(0);
 
 		const mockWalletLive = jest.spyOn(profile.wallets().first().network(), "isLive").mockReturnValue(true);
-		expect(subject.balance("live").toString()).toEqual("55827093444556");
+		expect(subject.balance("live")).toEqual(558270.93444556);
 		mockWalletLive.mockRestore();
 	});
 
 	it("#convertedBalance", async () => {
-		expect(subject.convertedBalance().toString()).toEqual("0");
+		expect(subject.convertedBalance()).toEqual(0);
 	});
 
 	it("#balancesByNetworkType", async () => {
@@ -65,11 +65,11 @@ describe("WalletAggregate", () => {
 		expect(subject.balancePerCoin("test")).toEqual({
 			DARK: {
 				percentage: "100.00",
-				total: "55827093444556",
+				total: "558270.93444556",
 			},
 		});
 
-		const mockWalletLive = jest.spyOn(profile.wallets().first(), "balance").mockReturnValue(BigNumber.ZERO);
+		const mockWalletLive = jest.spyOn(profile.wallets().first(), "balance").mockReturnValue(0);
 
 		expect(subject.balancePerCoin("test")).toEqual({ DARK: { percentage: "0.00", total: "0" } });
 		mockWalletLive.mockRestore();

--- a/packages/platform-sdk-profiles/source/wallet.aggregate.ts
+++ b/packages/platform-sdk-profiles/source/wallet.aggregate.ts
@@ -11,8 +11,8 @@ export class WalletAggregate implements IWalletAggregate {
 	}
 
 	/** {@inheritDoc IWalletAggregate.balance} */
-	public balance(networkType: NetworkType = "live"): BigNumber {
-		return this.balancesByNetworkType()[networkType];
+	public balance(networkType: NetworkType = "live"): number {
+		return +this.balancesByNetworkType()[networkType].toHuman();
 	}
 
 	/** {@inheritDoc IWalletAggregate.balancesByNetworkType} */
@@ -37,21 +37,22 @@ export class WalletAggregate implements IWalletAggregate {
 	}
 
 	/** {@inheritDoc IWalletAggregate.convertedBalance} */
-	public convertedBalance(): BigNumber {
+	public convertedBalance(): number {
 		return this.#profile
 			.wallets()
 			.values()
 			.reduce(
 				(total: BigNumber, wallet: IReadWriteWallet) => total.plus(wallet.convertedBalance()),
 				BigNumber.ZERO,
-			);
+			)
+			.toNumber();
 	}
 
 	/** {@inheritDoc IWalletAggregate.balancePerCoin} */
 	public balancePerCoin(networkType: NetworkType = "live"): Record<string, { total: number; percentage: number }> {
 		const result = {};
 
-		const totalByProfile: BigNumber = this.balance(networkType);
+		const totalByProfile: number = this.balance(networkType);
 		const walletsByCoin: Record<string, Record<string, IReadWriteWallet>> = this.#profile.wallets().allByCoin();
 
 		for (const [coin, wallets] of Object.entries(walletsByCoin)) {
@@ -67,9 +68,8 @@ export class WalletAggregate implements IWalletAggregate {
 
 				result[coin] = {
 					total: totalByCoin.toFixed(),
-					percentage: totalByProfile.isZero()
-						? "0.00"
-						: totalByCoin.divide(totalByProfile).times(100).toFixed(2),
+					percentage:
+						totalByProfile === 0 ? "0.00" : totalByCoin.divide(totalByProfile).times(100).toFixed(2),
 				};
 			}
 		}

--- a/packages/platform-sdk-profiles/source/wallet.contract.ts
+++ b/packages/platform-sdk-profiles/source/wallet.contract.ts
@@ -159,18 +159,18 @@ export interface IReadWriteWallet {
 	/**
 	 * Get the balance.
 	 *
-	 * @return {BigNumber}
+	 * @return {number}
 	 * @memberof IReadWriteWallet
 	 */
-	balance(): BigNumber;
+	balance(): number;
 
 	/**
 	 * Get the converted balance.
 	 *
-	 * @return {BigNumber}
+	 * @return {number}
 	 * @memberof IReadWriteWallet
 	 */
-	convertedBalance(): BigNumber;
+	convertedBalance(): number;
 
 	/**
 	 * Get the nonce.

--- a/packages/platform-sdk-profiles/source/wallet.repository.ts
+++ b/packages/platform-sdk-profiles/source/wallet.repository.ts
@@ -191,9 +191,11 @@ export class WalletRepository implements IWalletRepository {
 			if (options.excludeLedgerWallets && wallet.isLedger()) {
 				continue;
 			}
-			if (options.excludeEmptyWallets && wallet.balance().isZero()) {
+
+			if (options.excludeEmptyWallets && wallet.balance() === 0) {
 				continue;
 			}
+
 			result[id] = wallet.toObject();
 		}
 

--- a/packages/platform-sdk-profiles/source/wallet.ts
+++ b/packages/platform-sdk-profiles/source/wallet.ts
@@ -139,21 +139,21 @@ export class Wallet implements IReadWriteWallet {
 	}
 
 	/** {@inheritDoc IReadWriteWallet.balance} */
-	public balance(): BigNumber {
+	public balance(): number {
 		const value: Contracts.WalletBalance | undefined = this.data().get(WalletData.Balance);
 
-		return BigNumber.make(value?.available || 0, this.#decimals());
+		return +BigNumber.make(value?.available || 0, this.#decimals()).toHuman();
 	}
 
 	/** {@inheritDoc IReadWriteWallet.convertedBalance} */
-	public convertedBalance(): BigNumber {
+	public convertedBalance(): number {
 		if (this.network().isTest()) {
-			return BigNumber.ZERO;
+			return 0;
 		}
 
-		return container
+		return +container
 			.get<IExchangeRateService>(Identifiers.ExchangeRateService)
-			.exchange(this.currency(), this.exchangeCurrency(), DateTime.make(), this.balance().denominated());
+			.exchange(this.currency(), this.exchangeCurrency(), DateTime.make(), this.balance());
 	}
 
 	/** {@inheritDoc IReadWriteWallet.nonce} */

--- a/packages/platform-sdk-sol/source/signed-transaction.dto.test.ts
+++ b/packages/platform-sdk-sol/source/signed-transaction.dto.test.ts
@@ -15,7 +15,7 @@ beforeEach(() => {
 		{
 			sender: "0xdeadbeef",
 			recipient: "0xfoobar",
-			amount: "420690000000",
+			amount: "120000000000",
 			fee: "6",
 			timestamp: "1970-01-01T00:00:00.000Z",
 		},
@@ -33,7 +33,7 @@ describe("SignedTransactionData", () => {
 	});
 
 	test("#amount", () => {
-		expect(subject.amount().toHuman()).toEqual("420.69");
+		expect(subject.amount().toHuman()).toEqual(120);
 	});
 
 	test("#fee", () => {

--- a/packages/platform-sdk-support/source/bignumber.test.ts
+++ b/packages/platform-sdk-support/source/bignumber.test.ts
@@ -120,14 +120,14 @@ test("#toSatoshi", () => {
 });
 
 test("#toHuman", () => {
-	expect(BigNumber.make(100 * 1e8, 8).toHuman()).toBe("100");
-	expect(BigNumber.make(123.456 * 1e8, 8).toHuman()).toBe("123.456");
-	expect(BigNumber.make(123.456789 * 1e8, 8).toHuman()).toBe("123.456789");
-	expect(BigNumber.make(1e8).times(1e8).toHuman(8)).toBe(`${1e8}`);
-	expect(BigNumber.make(123456).toHuman()).toBe("123456");
-	expect(BigNumber.make(123456).toHuman(0)).toBe("123456");
-	expect(BigNumber.make(123456).toHuman(1)).toBe("12345.6");
-	expect(BigNumber.make(123456).toHuman(6)).toBe("0.123456");
+	expect(BigNumber.make(100 * 1e8, 8).toHuman()).toBe(100);
+	expect(BigNumber.make(123.456 * 1e8, 8).toHuman()).toBe(123.456);
+	expect(BigNumber.make(123.456789 * 1e8, 8).toHuman()).toBe(123.456789);
+	expect(BigNumber.make(1e8).times(1e8).toHuman(8)).toBe(+`${1e8}`);
+	expect(BigNumber.make(123456).toHuman()).toBe(123456);
+	expect(BigNumber.make(123456).toHuman(0)).toBe(123456);
+	expect(BigNumber.make(123456).toHuman(1)).toBe(12345.6);
+	expect(BigNumber.make(123456).toHuman(6)).toBe(0.123456);
 });
 
 test("#toFixed", () => {

--- a/packages/platform-sdk-support/source/bignumber.ts
+++ b/packages/platform-sdk-support/source/bignumber.ts
@@ -304,11 +304,11 @@ export class BigNumber {
 	 * Divides the current value by one satoshi and rounds it to the given amount of decimals.
 	 *
 	 * @param {number} [decimals]
-	 * @returns {string}
+	 * @returns {number}
 	 * @memberof BigNumber
 	 */
-	public toHuman(decimals?: number): string {
-		return this.denominated(decimals).toString();
+	public toHuman(decimals?: number): number {
+		return +this.denominated(decimals).toString();
 	}
 
 	/**

--- a/packages/platform-sdk-xlm/source/signed-transaction.dto.test.ts
+++ b/packages/platform-sdk-xlm/source/signed-transaction.dto.test.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
 			_operations: [
 				{
 					destination: "0xfoobar",
-					amount: "4206900000",
+					amount: "1200000000",
 				},
 			],
 			_fee: "6",
@@ -37,7 +37,7 @@ describe("SignedTransactionData", () => {
 	});
 
 	test("#amount", () => {
-		expect(subject.amount().toHuman()).toEqual("420.69");
+		expect(subject.amount().toHuman()).toEqual(120);
 	});
 
 	test("#fee", () => {

--- a/packages/platform-sdk-zil/source/signed-transaction.dto.test.ts
+++ b/packages/platform-sdk-zil/source/signed-transaction.dto.test.ts
@@ -15,7 +15,7 @@ beforeEach(() => {
 		{
 			sender: "zil1ua64tlepq090nw8dttzxyaa9q5zths8w4m9qun",
 			recipient: "zil1ua64tlepq090nw8dttzxyaa9q5zths8w4m9123",
-			amount: "420690000000000",
+			amount: "120000000000000",
 			fee: "25",
 			timestamp: "1970-01-01T00:00:00.000Z",
 		},
@@ -33,7 +33,7 @@ describe("SignedTransactionData", () => {
 	});
 
 	test("#amount", () => {
-		expect(subject.amount().toHuman()).toEqual("420.69");
+		expect(subject.amount().toHuman()).toEqual(120);
 	});
 
 	test("#fee", () => {

--- a/packages/platform-sdk/source/dto/multi-payment.contract.ts
+++ b/packages/platform-sdk/source/dto/multi-payment.contract.ts
@@ -1,6 +1,8 @@
+import { BigNumber } from "@arkecosystem/platform-sdk-support";
+
 import { TransactionData } from "./transaction.contract";
 
 export interface MultiPaymentData extends TransactionData {
 	memo(): string | undefined;
-	payments(): { recipientId: string; amount: string }[];
+	payments(): { recipientId: string; amount: BigNumber }[];
 }

--- a/packages/platform-sdk/source/dto/multi-payment.ts
+++ b/packages/platform-sdk/source/dto/multi-payment.ts
@@ -1,5 +1,7 @@
 /* istanbul ignore file */
 
+import { BigNumber } from "@arkecosystem/platform-sdk-support";
+
 import { NotImplemented } from "../exceptions";
 import { injectable } from "../ioc";
 import { MultiPaymentData as Contract } from "./multi-payment.contract";
@@ -7,7 +9,7 @@ import { AbstractTransactionData } from "./transaction";
 
 @injectable()
 export class MultiPaymentData extends AbstractTransactionData implements Contract {
-	public payments(): { recipientId: string; amount: string }[] {
+	public payments(): { recipientId: string; amount: BigNumber }[] {
 		throw new NotImplemented(this.constructor.name, this.payments.name);
 	}
 }

--- a/packages/platform-sdk/source/dto/wallet.ts
+++ b/packages/platform-sdk/source/dto/wallet.ts
@@ -96,10 +96,10 @@ export class AbstractWalletData {
 		const { available, fees, locked, tokens } = this.balance();
 
 		const balance: {
-			available: string;
-			fees: string;
-			locked?: string | undefined;
-			tokens?: Record<string, string> | undefined;
+			available: number;
+			fees: number;
+			locked?: number | undefined;
+			tokens?: Record<string, number> | undefined;
 		} = {
 			available: available.toHuman(),
 			fees: fees.toHuman(),

--- a/packages/platform-sdk/source/services/big-number.test.ts
+++ b/packages/platform-sdk/source/services/big-number.test.ts
@@ -36,5 +36,5 @@ test.each([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])("#make(%s)", async (power) => {
 			.resolve(BigNumberService)
 			.make(`1${"0".repeat(power)}`)
 			.toHuman(),
-	).toBe("1");
+	).toBe(1);
 });


### PR DESCRIPTION
For clients it is more flexible to get a primitive value that can be used for reactivity with things like React. If they need a `BigNumber` instance they can instantiate it through the respective service.