### PR TITLE
fix: create `WalletData` through `DataTransferObjectService`

### DIFF
--- a/packages/platform-sdk-ada/source/client.service.ts
+++ b/packages/platform-sdk-ada/source/client.service.ts
@@ -55,7 +55,7 @@ export class ClientService extends Services.AbstractClientService {
 			Array.from(usedSpendAddresses.values()).concat(Array.from(usedChangeAddresses.values())),
 		);
 
-		return new WalletData({
+		return this.dataTransferObjectService.wallet({
 			id,
 			balance,
 		});

--- a/packages/platform-sdk-ark/source/__snapshots__/ledger.service.test.ts.snap
+++ b/packages/platform-sdk-ark/source/__snapshots__/ledger.service.test.ts.snap
@@ -3,6 +3,9 @@
 exports[`scan should return scanned wallet 1`] = `
 Object {
   "44'/1'/0'/0/0": WalletData {
+    "bigNumberService": BigNumberService {
+      "configRepository": ConfigRepository {},
+    },
     "data": Object {
       "address": "D9xJncW4ECUSJQWeLP7wncxhDTvNeg2HNK",
       "attributes": Object {},
@@ -11,6 +14,9 @@ Object {
     },
   },
   "44'/1'/1'/0/0": WalletData {
+    "bigNumberService": BigNumberService {
+      "configRepository": ConfigRepository {},
+    },
     "data": Object {
       "address": "DFgggtreMXQNQKnxHddvkaPHcQbRdK3jyJ",
       "balance": 0,

--- a/packages/platform-sdk-ark/source/client.service.ts
+++ b/packages/platform-sdk-ark/source/client.service.ts
@@ -50,14 +50,14 @@ export class ClientService extends Services.AbstractClientService {
 	public override async delegate(id: string): Promise<Contracts.WalletData> {
 		const body = await this.#get(`delegates/${id}`);
 
-		return new WalletData(body.data);
+		return this.dataTransferObjectService.wallet(body.data);
 	}
 
 	public override async delegates(query?: Contracts.KeyValuePair): Promise<Collections.WalletDataCollection> {
 		const body = await this.#get("delegates", this.#createSearchParams(query || {}));
 
 		return new Collections.WalletDataCollection(
-			body.data.map((wallet) => new WalletData(wallet)),
+			body.data.map((wallet) => this.dataTransferObjectService.wallet(wallet)),
 			this.#createMetaPagination(body),
 		);
 	}
@@ -81,7 +81,7 @@ export class ClientService extends Services.AbstractClientService {
 		const body = await this.#get(`delegates/${id}/voters`, this.#createSearchParams(query || {}));
 
 		return new Collections.WalletDataCollection(
-			body.data.map((wallet) => new WalletData(wallet)),
+			body.data.map((wallet) => this.dataTransferObjectService.wallet(wallet)),
 			this.#createMetaPagination(body),
 		);
 	}

--- a/packages/platform-sdk-ark/source/client.service.ts
+++ b/packages/platform-sdk-ark/source/client.service.ts
@@ -33,7 +33,7 @@ export class ClientService extends Services.AbstractClientService {
 	public override async wallet(id: string): Promise<Contracts.WalletData> {
 		const body = await this.#get(`wallets/${id}`);
 
-		return new WalletData(body.data);
+		return this.dataTransferObjectService.wallet(body.data);
 	}
 
 	public override async wallets(query: Services.ClientWalletsInput): Promise<Collections.WalletDataCollection> {
@@ -42,7 +42,7 @@ export class ClientService extends Services.AbstractClientService {
 			: await this.#post("wallets/search", this.#createSearchParams(query));
 
 		return new Collections.WalletDataCollection(
-			response.data.map((wallet) => new WalletData(wallet)),
+			response.data.map((wallet) => this.dataTransferObjectService.wallet(wallet)),
 			this.#createMetaPagination(response),
 		);
 	}

--- a/packages/platform-sdk-ark/source/wallet.dto.test.ts
+++ b/packages/platform-sdk-ark/source/wallet.dto.test.ts
@@ -3,6 +3,7 @@ import "jest-extended";
 import { BigNumber } from "@arkecosystem/platform-sdk-support";
 
 import { WalletData } from "./wallet.dto";
+import { createService } from "../test/mocking";
 
 let subject: WalletData;
 
@@ -78,7 +79,9 @@ describe("WalletData", () => {
 	};
 
 	describe.each(["mainnet", "devnet"])("%s", (network) => {
-		beforeEach(() => (subject = new WalletData(WalletDataFixture[network])));
+		beforeEach(() => {
+			subject = createService(WalletData).fill(WalletDataFixture[network]);
+		});
 
 		test("#primaryKey", () => {
 			expect(subject.primaryKey()).toBe("DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9");

--- a/packages/platform-sdk-ark/source/wallet.dto.ts
+++ b/packages/platform-sdk-ark/source/wallet.dto.ts
@@ -18,8 +18,8 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: BigNumber.make(this.data.balance),
-			fees: BigNumber.make(this.data.balance),
+			available: this.bigNumberService.make(this.data.balance),
+			fees: this.bigNumberService.make(this.data.balance),
 		};
 	}
 

--- a/packages/platform-sdk-atom/source/client.service.ts
+++ b/packages/platform-sdk-atom/source/client.service.ts
@@ -67,7 +67,7 @@ export class ClientService extends Services.AbstractClientService {
 		const { result: details } = await this.#get(`auth/accounts/${id}`);
 		const { result: balance } = await this.#get(`bank/balances/${id}`);
 
-		return new WalletData({
+		return this.dataTransferObjectService.wallet({
 			address: details.value.address,
 			publicKey: details.value.public_key.value,
 			balance: Object.values(balance).find(({ denom }: any) => denom === "uatom"),

--- a/packages/platform-sdk-avax/source/client.service.ts
+++ b/packages/platform-sdk-avax/source/client.service.ts
@@ -62,7 +62,9 @@ export class ClientService extends Services.AbstractClientService {
 		const validators: string[] = await this.#pchain.sampleValidators(10000);
 
 		return new Collections.WalletDataCollection(
-			uniq(validators).map((validator: string) => this.dataTransferObjectService.wallet({ address: validator, balance: 0 })),
+			uniq(validators).map((validator: string) =>
+				this.dataTransferObjectService.wallet({ address: validator, balance: 0 }),
+			),
 			{
 				prev: undefined,
 				self: undefined,

--- a/packages/platform-sdk-avax/source/client.service.ts
+++ b/packages/platform-sdk-avax/source/client.service.ts
@@ -52,7 +52,7 @@ export class ClientService extends Services.AbstractClientService {
 	public override async wallet(id: string): Promise<Contracts.WalletData> {
 		const { balance }: any = await this.#xchain.getBalance(id, this.configRepository.get("network.meta.assetId"));
 
-		return new WalletData({
+		return this.dataTransferObjectService.wallet({
 			address: id,
 			balance: balance,
 		});
@@ -62,7 +62,7 @@ export class ClientService extends Services.AbstractClientService {
 		const validators: string[] = await this.#pchain.sampleValidators(10000);
 
 		return new Collections.WalletDataCollection(
-			uniq(validators).map((validator: string) => new WalletData({ address: validator, balance: 0 })),
+			uniq(validators).map((validator: string) => this.dataTransferObjectService.wallet({ address: validator, balance: 0 })),
 			{
 				prev: undefined,
 				self: undefined,

--- a/packages/platform-sdk-btc/source/client.service.ts
+++ b/packages/platform-sdk-btc/source/client.service.ts
@@ -20,7 +20,7 @@ export class ClientService extends Services.AbstractClientService {
 	}
 
 	public override async wallet(id: string): Promise<Contracts.WalletData> {
-		return new WalletData(await this.#get(`wallets/${id}`));
+		return this.dataTransferObjectService.wallet(await this.#get(`wallets/${id}`));
 	}
 
 	public override async broadcast(

--- a/packages/platform-sdk-dot/source/client.service.ts
+++ b/packages/platform-sdk-dot/source/client.service.ts
@@ -16,7 +16,7 @@ export class ClientService extends Services.AbstractClientService {
 	public override async wallet(id: string): Promise<Contracts.WalletData> {
 		const { data: balances, nonce } = await this.client.query.system.account(id);
 
-		return new WalletData({
+		return this.dataTransferObjectService.wallet({
 			address: id,
 			balance: balances.free.toString(),
 			nonce: nonce.toString(),

--- a/packages/platform-sdk-egld/source/client.service.ts
+++ b/packages/platform-sdk-egld/source/client.service.ts
@@ -29,7 +29,7 @@ export class ClientService extends Services.AbstractClientService {
 	public override async wallet(id: string): Promise<Contracts.WalletData> {
 		const { data } = await this.#get(`address/${id}`);
 
-		return new WalletData(data.account);
+		return this.dataTransferObjectService.wallet(data.account);
 	}
 
 	public override async broadcast(

--- a/packages/platform-sdk-eos/source/client.service.ts
+++ b/packages/platform-sdk-eos/source/client.service.ts
@@ -30,7 +30,7 @@ export class ClientService extends Services.AbstractClientService {
 	// https://developers.eos.io/manuals/eosjs/latest/how-to-guides/how-to-get-table-information
 
 	public override async wallet(id: string): Promise<Contracts.WalletData> {
-		return new WalletData(await this.#rpc.get_account(id));
+		return this.dataTransferObjectService.wallet(await this.#rpc.get_account(id));
 	}
 
 	// https://developers.eos.io/manuals/eosjs/latest/how-to-guides/how-to-transfer-an-eosio-token

--- a/packages/platform-sdk-eth/source/client.service.ts
+++ b/packages/platform-sdk-eth/source/client.service.ts
@@ -49,7 +49,7 @@ export class ClientService extends Services.AbstractClientService {
 	}
 
 	public override async wallet(id: string): Promise<Contracts.WalletData> {
-		return new WalletData(await this.#get(`wallets/${id}`));
+		return this.dataTransferObjectService.wallet(await this.#get(`wallets/${id}`));
 	}
 
 	public override async broadcast(

--- a/packages/platform-sdk-json-rpc/bin/meow.js
+++ b/packages/platform-sdk-json-rpc/bin/meow.js
@@ -15,7 +15,7 @@ module.exports = meow(
 			},
 			port: {
 				type: "number",
-				default: 3100,
+				default: 3000,
 			},
 			points: {
 				type: "number",

--- a/packages/platform-sdk-json-rpc/bin/meow.js
+++ b/packages/platform-sdk-json-rpc/bin/meow.js
@@ -15,7 +15,7 @@ module.exports = meow(
 			},
 			port: {
 				type: "number",
-				default: 3000,
+				default: 3100,
 			},
 			points: {
 				type: "number",

--- a/packages/platform-sdk-json-rpc/source/index.ts
+++ b/packages/platform-sdk-json-rpc/source/index.ts
@@ -2,6 +2,7 @@ import Hapi from "@hapi/hapi";
 import Joi from "joi";
 
 import { useLogger } from "./helpers";
+import { registerBusiness } from "./methods/business";
 import { registerClient } from "./methods/client";
 import { registerAddress } from "./methods/identity/address";
 import { registerKeys } from "./methods/identity/keys";
@@ -44,6 +45,8 @@ export const subscribe = async (flags: {
 		plugin: require("@konceiver/hapi-json-rpc"),
 		options: {
 			methods: [
+				// Business Use-Case
+				...registerBusiness(),
 				// Client Service
 				...registerClient(),
 				// Identity Service

--- a/packages/platform-sdk-json-rpc/source/methods/business.ts
+++ b/packages/platform-sdk-json-rpc/source/methods/business.ts
@@ -5,18 +5,35 @@ import { baseSchema, makeCoin } from "../helpers";
 export const registerBusiness = () => [
 	{
 		name: "business.withdraw",
-		async method({ coin, network, amount, to, mnemonic }) {
+		async method({ coin, network, from, to, mnemonic }) {
 			const business = await makeCoin({ coin, network });
+
+			const transferFee = (await business.fee().all()).transfer.avg.toHuman();
+
+			const sender = await business.client().wallet(from);
+			const amount = sender.balance().available.toHuman() - transferFee;
+
+			console.log("before:balance", sender.balance().available.toHuman())
+			console.log("before:amount", amount)
+			console.log("before:fee", transferFee)
 
             const transfer = await business.transaction().transfer({
                 data: {
-                    amount: Number.parseFloat(amount) - (await business.fee().all()).transfer.avg.toHuman(),
+                    amount,
                     to,
                 },
+				fee: transferFee,
                 signatory: await business.signatory().mnemonic(mnemonic),
             });
 
-			await business.client().broadcast([transfer]);
+			console.log("after:amount", transfer.amount().toString())
+			console.log("after:fee", transfer.fee().toString())
+
+			const broadcast = await business.client().broadcast([transfer]);
+
+			if (broadcast.rejected.length > 0) {
+				return broadcast;
+			}
 
             return {
 				id: transfer.id(),
@@ -29,7 +46,7 @@ export const registerBusiness = () => [
 		},
 		schema: Joi.object({
 			...baseSchema,
-			amount: Joi.number().required(),
+			from: Joi.string().required(),
 			to: Joi.string().required(),
 			mnemonic: Joi.string().required(),
 		}).required(),

--- a/packages/platform-sdk-json-rpc/source/methods/business.ts
+++ b/packages/platform-sdk-json-rpc/source/methods/business.ts
@@ -8,15 +8,24 @@ export const registerBusiness = () => [
 		async method({ coin, network, amount, to, mnemonic }) {
 			const business = await makeCoin({ coin, network });
 
-			return business.client().broadcast([
-				await business.transaction().transfer({
-					data: {
-						amount: Number.parseFloat(amount) - (await business.fee().all()).transfer.avg.toHuman(),
-						to,
-					},
-					signatory: await business.signatory().mnemonic(mnemonic),
-				})
-			]);
+            const transfer = await business.transaction().transfer({
+                data: {
+                    amount: Number.parseFloat(amount) - (await business.fee().all()).transfer.avg.toHuman(),
+                    to,
+                },
+                signatory: await business.signatory().mnemonic(mnemonic),
+            });
+
+			await business.client().broadcast([transfer]);
+
+            return {
+				id: transfer.id(),
+				sender: transfer.sender(),
+				recipient: transfer.recipient(),
+				amount: transfer.amount().toHuman(),
+				fee: transfer.fee().toHuman(),
+				timestamp: transfer.timestamp().toISOString(),
+			};
 		},
 		schema: Joi.object({
 			...baseSchema,

--- a/packages/platform-sdk-json-rpc/source/methods/business.ts
+++ b/packages/platform-sdk-json-rpc/source/methods/business.ts
@@ -11,7 +11,7 @@ export const registerBusiness = () => [
 			return business.client().broadcast([
 				await business.transaction().transfer({
 					data: {
-						amount: amount - (await business.fee().all()).transfer.avg.toHuman(),
+						amount: Number.parseFloat(amount) - (await business.fee().all()).transfer.avg.toHuman(),
 						to,
 					},
 					signatory: await business.signatory().mnemonic(mnemonic),

--- a/packages/platform-sdk-json-rpc/source/methods/business.ts
+++ b/packages/platform-sdk-json-rpc/source/methods/business.ts
@@ -10,24 +10,16 @@ export const registerBusiness = () => [
 
 			const transferFee = (await business.fee().all()).transfer.avg.toHuman();
 
-			const sender = await business.client().wallet(from);
-			const amount = sender.balance().available.toHuman() - transferFee;
-
-			console.log("before:balance", sender.balance().available.toHuman())
-			console.log("before:amount", amount)
-			console.log("before:fee", transferFee)
-
             const transfer = await business.transaction().transfer({
                 data: {
-                    amount,
+                    amount: (
+						await business.client().wallet(from)
+					).balance().available.toHuman() - transferFee,
                     to,
                 },
 				fee: transferFee,
                 signatory: await business.signatory().mnemonic(mnemonic),
             });
-
-			console.log("after:amount", transfer.amount().toString())
-			console.log("after:fee", transfer.fee().toString())
 
 			const broadcast = await business.client().broadcast([transfer]);
 

--- a/packages/platform-sdk-json-rpc/source/methods/business.ts
+++ b/packages/platform-sdk-json-rpc/source/methods/business.ts
@@ -10,16 +10,14 @@ export const registerBusiness = () => [
 
 			const transferFee = (await business.fee().all()).transfer.avg.toHuman();
 
-            const transfer = await business.transaction().transfer({
-                data: {
-                    amount: (
-						await business.client().wallet(from)
-					).balance().available.toHuman() - transferFee,
-                    to,
-                },
+			const transfer = await business.transaction().transfer({
+				data: {
+					amount: (await business.client().wallet(from)).balance().available.toHuman() - transferFee,
+					to,
+				},
 				fee: transferFee,
-                signatory: await business.signatory().mnemonic(mnemonic),
-            });
+				signatory: await business.signatory().mnemonic(mnemonic),
+			});
 
 			const broadcast = await business.client().broadcast([transfer]);
 
@@ -27,7 +25,7 @@ export const registerBusiness = () => [
 				return broadcast;
 			}
 
-            return {
+			return {
 				id: transfer.id(),
 				sender: transfer.sender(),
 				recipient: transfer.recipient(),

--- a/packages/platform-sdk-json-rpc/source/methods/business.ts
+++ b/packages/platform-sdk-json-rpc/source/methods/business.ts
@@ -1,0 +1,28 @@
+import Joi from "joi";
+
+import { baseSchema, makeCoin } from "../helpers";
+
+export const registerBusiness = () => [
+	{
+		name: "business.withdraw",
+		async method({ coin, network, amount, to, mnemonic }) {
+			const business = await makeCoin({ coin, network });
+
+			return business.client().broadcast([
+				await business.transaction().transfer({
+					data: {
+						amount: amount - (await business.fee().all()).transfer.avg.toHuman(),
+						to,
+					},
+					signatory: await business.signatory().mnemonic(mnemonic),
+				})
+			]);
+		},
+		schema: Joi.object({
+			...baseSchema,
+			amount: Joi.number().required(),
+			to: Joi.string().required(),
+			mnemonic: Joi.string().required(),
+		}).required(),
+	},
+];

--- a/packages/platform-sdk-lsk/source/__snapshots__/ledger.service.test.ts.snap
+++ b/packages/platform-sdk-lsk/source/__snapshots__/ledger.service.test.ts.snap
@@ -3,6 +3,9 @@
 exports[`scan should return scanned wallet 1`] = `
 Object {
   "m/44'/134'/0'/0/0": WalletData {
+    "bigNumberService": BigNumberService {
+      "configRepository": ConfigRepository {},
+    },
     "data": Object {
       "address": "7399986239080551550L",
       "asset": Object {},
@@ -12,6 +15,9 @@ Object {
     },
   },
   "m/44'/134'/1'/0/0": WalletData {
+    "bigNumberService": BigNumberService {
+      "configRepository": ConfigRepository {},
+    },
     "data": Object {
       "address": "11603034586667438647L",
       "asset": Object {},
@@ -21,6 +27,9 @@ Object {
     },
   },
   "m/44'/134'/2'/0/0": WalletData {
+    "bigNumberService": BigNumberService {
+      "configRepository": ConfigRepository {},
+    },
     "data": Object {
       "address": "8261766349562104742L",
       "asset": Object {},
@@ -30,6 +39,9 @@ Object {
     },
   },
   "m/44'/134'/3'/0/0": WalletData {
+    "bigNumberService": BigNumberService {
+      "configRepository": ConfigRepository {},
+    },
     "data": Object {
       "address": "10806468874187168404L",
       "balance": 0,

--- a/packages/platform-sdk-lsk/source/client.service.ts
+++ b/packages/platform-sdk-lsk/source/client.service.ts
@@ -43,14 +43,14 @@ export class ClientService extends Services.AbstractClientService {
 	public override async wallet(id: string): Promise<Contracts.WalletData> {
 		const result = await this.#get("accounts", { address: id });
 
-		return new WalletData(result.data[0]);
+		return this.dataTransferObjectService.wallet(result.data[0]);
 	}
 
 	public override async wallets(query: Services.ClientWalletsInput): Promise<Collections.WalletDataCollection> {
 		const result = await this.#get("accounts", query);
 
 		return new Collections.WalletDataCollection(
-			result.data.map((wallet) => new WalletData(wallet)),
+			result.data.map((wallet) => this.dataTransferObjectService.wallet(wallet)),
 			this.#createPagination(result.data, result.meta),
 		);
 	}
@@ -58,14 +58,14 @@ export class ClientService extends Services.AbstractClientService {
 	public override async delegate(id: string): Promise<Contracts.WalletData> {
 		const result = await this.#get("delegates", { username: id });
 
-		return new WalletData(result.data[0]);
+		return this.dataTransferObjectService.wallet(result.data[0]);
 	}
 
 	public override async delegates(query?: any): Promise<Collections.WalletDataCollection> {
 		const result = await this.#get("delegates", this.#createSearchParams({ limit: 101, ...query }));
 
 		return new Collections.WalletDataCollection(
-			result.data.map((wallet) => new WalletData(wallet)),
+			result.data.map((wallet) => this.dataTransferObjectService.wallet(wallet)),
 			this.#createPagination(result.data, result.meta),
 		);
 	}

--- a/packages/platform-sdk-lsk/source/wallet.dto.test.ts
+++ b/packages/platform-sdk-lsk/source/wallet.dto.test.ts
@@ -2,10 +2,11 @@ import { BigNumber } from "@arkecosystem/platform-sdk-support";
 
 import Fixture from "../test/fixtures/client/wallet.json";
 import { WalletData } from "./wallet.dto";
+import { createService } from "../test/mocking";
 
 let subject: WalletData;
 
-beforeEach(() => (subject = new WalletData(Fixture.data[0])));
+beforeEach(() => (subject = createService(WalletData).fill(Fixture.data[0])));
 
 describe("WalletData", () => {
 	test("#address", () => {

--- a/packages/platform-sdk-nano/source/client.service.ts
+++ b/packages/platform-sdk-nano/source/client.service.ts
@@ -38,7 +38,7 @@ export class ClientService extends Services.AbstractClientService {
 	public override async wallet(id: string): Promise<Contracts.WalletData> {
 		const { balance, pending } = await this.#client.accountInfo(id, { pending: true });
 
-		return new WalletData({ id, balance, pending });
+		return this.dataTransferObjectService.wallet({ id, balance, pending });
 	}
 
 	public override async broadcast(

--- a/packages/platform-sdk-neo/source/client.service.ts
+++ b/packages/platform-sdk-neo/source/client.service.ts
@@ -51,7 +51,7 @@ export class ClientService extends Services.AbstractClientService {
 	public override async wallet(id: string): Promise<Contracts.WalletData> {
 		const response = await this.#get(`get_balance/${id}`);
 
-		return new WalletData({
+		return this.dataTransferObjectService.wallet({
 			address: id,
 			balance: response.balance.find((balance) => balance.asset === "NEO").amount,
 		});

--- a/packages/platform-sdk-sol/source/client.service.ts
+++ b/packages/platform-sdk-sol/source/client.service.ts
@@ -19,7 +19,7 @@ export class ClientService extends Services.AbstractClientService {
 			throw new Exceptions.Exception("Received an invalid response.");
 		}
 
-		return new WalletData({
+		return this.dataTransferObjectService.wallet({
 			address: id,
 			balance: response.lamports,
 		});

--- a/packages/platform-sdk-trx/source/client.service.ts
+++ b/packages/platform-sdk-trx/source/client.service.ts
@@ -71,7 +71,7 @@ export class ClientService extends Services.AbstractClientService {
 	public override async wallet(id: string): Promise<Contracts.WalletData> {
 		const { data } = (await this.httpClient.get(`${this.#getHost()}/v1/accounts/${id}`)).json();
 
-		return new WalletData(data[0]);
+		return this.dataTransferObjectService.wallet(data[0]);
 	}
 
 	public override async broadcast(

--- a/packages/platform-sdk-xlm/source/client.service.ts
+++ b/packages/platform-sdk-xlm/source/client.service.ts
@@ -55,7 +55,7 @@ export class ClientService extends Services.AbstractClientService {
 	}
 
 	public override async wallet(id: string): Promise<Contracts.WalletData> {
-		return new WalletData(await this.#client.loadAccount(id));
+		return this.dataTransferObjectService.wallet(await this.#client.loadAccount(id));
 	}
 
 	public override async broadcast(

--- a/packages/platform-sdk-xrp/source/client.service.ts
+++ b/packages/platform-sdk-xrp/source/client.service.ts
@@ -42,7 +42,7 @@ export class ClientService extends Services.AbstractClientService {
 	}
 
 	public override async wallet(id: string): Promise<Contracts.WalletData> {
-		return new WalletData(
+		return this.dataTransferObjectService.wallet(
 			(
 				await this.#post("account_info", [
 					{

--- a/packages/platform-sdk-zil/source/client.service.ts
+++ b/packages/platform-sdk-zil/source/client.service.ts
@@ -42,7 +42,7 @@ export class ClientService extends Services.AbstractClientService {
 			throw new Exceptions.Exception(`Received an invalid response: ${JSON.stringify(response)}`);
 		}
 
-		return new WalletData({
+		return this.dataTransferObjectService.wallet({
 			address: id,
 			balance: response.result.balance,
 			nonce: response.result.nonce,

--- a/packages/platform-sdk/source/dto/wallet.ts
+++ b/packages/platform-sdk/source/dto/wallet.ts
@@ -4,10 +4,15 @@ import { BigNumber } from "@arkecosystem/platform-sdk-support";
 
 import { KeyValuePair, WalletBalance } from "../contracts";
 import { NotImplemented } from "../exceptions";
-import { injectable } from "../ioc";
+import { inject, injectable } from "../ioc";
+import { BindingType } from "../ioc/service-provider.contract";
+import { BigNumberService } from "../services/big-number.service";
 
 @injectable()
 export class AbstractWalletData {
+	@inject(BindingType.BigNumberService)
+	protected readonly bigNumberService!: BigNumberService;
+
 	protected data!: KeyValuePair;
 
 	public constructor(data: KeyValuePair) {

--- a/packages/platform-sdk/source/services/data-transfer-object.service.ts
+++ b/packages/platform-sdk/source/services/data-transfer-object.service.ts
@@ -26,17 +26,14 @@ export class AbstractDataTransferObjectService implements DataTransferObjectServ
 	protected readonly dataTransferObjects!: Record<string, any>;
 
 	public signedTransaction(identifier: string, signedData: string, broadcastData: any): SignedTransactionData {
-		const signedTransaction = this.container.resolve<SignedTransactionData>(
+		return this.container.resolve<SignedTransactionData>(
 			this.dataTransferObjects.SignedTransactionData,
-		);
-		signedTransaction.configure(
+		).configure(
 			identifier,
 			signedData,
 			broadcastData,
 			this.configRepository.get<number>(ConfigKey.CurrencyDecimals),
 		);
-
-		return signedTransaction;
 	}
 
 	public transaction(transaction: unknown): TransactionDataType & TransactionData {

--- a/packages/platform-sdk/source/services/data-transfer-object.service.ts
+++ b/packages/platform-sdk/source/services/data-transfer-object.service.ts
@@ -26,14 +26,14 @@ export class AbstractDataTransferObjectService implements DataTransferObjectServ
 	protected readonly dataTransferObjects!: Record<string, any>;
 
 	public signedTransaction(identifier: string, signedData: string, broadcastData: any): SignedTransactionData {
-		return this.container.resolve<SignedTransactionData>(
-			this.dataTransferObjects.SignedTransactionData,
-		).configure(
-			identifier,
-			signedData,
-			broadcastData,
-			this.configRepository.get<number>(ConfigKey.CurrencyDecimals),
-		);
+		return this.container
+			.resolve<SignedTransactionData>(this.dataTransferObjects.SignedTransactionData)
+			.configure(
+				identifier,
+				signedData,
+				broadcastData,
+				this.configRepository.get<number>(ConfigKey.CurrencyDecimals),
+			);
 	}
 
 	public transaction(transaction: unknown): TransactionDataType & TransactionData {


### PR DESCRIPTION
Ensures consistency and that the `BigNumberService` is accessible when needed, for things like balances. Noticed this while working on the JSON-RPC which caused a bug with `toHuman()` on balances.