### PR TITLE
fix: always use `BigNumberService` for `BigNumber` creation in DTOs

### DIFF
--- a/packages/platform-sdk-ada/source/wallet.dto.test.ts
+++ b/packages/platform-sdk-ada/source/wallet.dto.test.ts
@@ -1,10 +1,11 @@
 import "jest-extended";
 
 import Fixture from "../test/fixtures/client/wallet.json";
+import { createService } from "../test/mocking";
 import { WalletData } from "./wallet.dto";
 
 describe("WalletData", () => {
-	const subject = new WalletData(Fixture);
+	const subject = createService(WalletData).fill(Fixture);
 
 	it("#address", () => {
 		expect(subject.address()).toEqual("98c83431e94407bc0889e09953461fe5cecfdf18");

--- a/packages/platform-sdk-ada/source/wallet.dto.ts
+++ b/packages/platform-sdk-ada/source/wallet.dto.ts
@@ -16,8 +16,8 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: BigNumber.make(this.data.balance.available?.quantity),
-			fees: BigNumber.make(this.data.balance.reward?.quantity),
+			available: this.bigNumberService.make(this.data.balance.available?.quantity),
+			fees: this.bigNumberService.make(this.data.balance.reward?.quantity),
 		};
 	}
 

--- a/packages/platform-sdk-ark/source/wallet.dto.test.ts
+++ b/packages/platform-sdk-ark/source/wallet.dto.test.ts
@@ -122,7 +122,7 @@ describe("WalletData", () => {
 		test("#isDelegate", () => {
 			expect(subject.isDelegate()).toBeTrue();
 
-			subject = new WalletData({ ...WalletDataFixture.mainnet, isResigned: true });
+			subject = createService(WalletData).fill({ ...WalletDataFixture.mainnet, isResigned: true });
 			expect(subject.isDelegate()).toBeFalse();
 		});
 
@@ -144,8 +144,8 @@ describe("WalletData", () => {
 	});
 
 	test("#multiSignature", () => {
-		const devnetSubject = new WalletData(WalletDataFixture.devnet);
-		const mainnetSubject = new WalletData(WalletDataFixture.mainnet);
+		const devnetSubject = createService(WalletData).fill(WalletDataFixture.devnet);
+		const mainnetSubject = createService(WalletData).fill(WalletDataFixture.mainnet);
 
 		expect(() => mainnetSubject.multiSignature()).toThrow(/does not have/);
 		expect(devnetSubject.multiSignature()).toEqual(WalletDataFixture.devnet.attributes.multiSignature);

--- a/packages/platform-sdk-atom/source/wallet.dto.test.ts
+++ b/packages/platform-sdk-atom/source/wallet.dto.test.ts
@@ -4,9 +4,10 @@ import { BigNumber } from "@arkecosystem/platform-sdk-support";
 
 import Fixture from "../test/fixtures/client/wallet.json";
 import { WalletData } from "./wallet.dto";
+import { createService } from "../test/mocking";
 
 describe("WalletData", () => {
-	const subject = new WalletData({
+	const subject = createService(WalletData).fill({
 		address: Fixture.result.value.address,
 		publicKey: Fixture.result.value.public_key.value,
 		balance: 22019458509,

--- a/packages/platform-sdk-atom/source/wallet.dto.ts
+++ b/packages/platform-sdk-atom/source/wallet.dto.ts
@@ -16,7 +16,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: this.bigNumberService.make((this.data.balance),
+			available: this.bigNumberService.make(this.data.balance),
 			fees: this.bigNumberService.make(this.data.balance),
 		};
 	}

--- a/packages/platform-sdk-atom/source/wallet.dto.ts
+++ b/packages/platform-sdk-atom/source/wallet.dto.ts
@@ -16,8 +16,8 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: BigNumber.make(this.data.balance),
-			fees: BigNumber.make(this.data.balance),
+			available: this.bigNumberService.make((this.data.balance),
+			fees: this.bigNumberService.make(this.data.balance),
 		};
 	}
 

--- a/packages/platform-sdk-avax/source/wallet.dto.ts
+++ b/packages/platform-sdk-avax/source/wallet.dto.ts
@@ -20,8 +20,8 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 		// consistent for future use by other packages that use it.
 
 		return {
-			available: BigNumber.make(this.data.balance / 1e1),
-			fees: BigNumber.make(this.data.balance / 1e1),
+			available: this.bigNumberService.make((this.data.balance / 1e1),
+			fees: this.bigNumberService.make(this.data.balance / 1e1),
 		};
 	}
 

--- a/packages/platform-sdk-avax/source/wallet.dto.ts
+++ b/packages/platform-sdk-avax/source/wallet.dto.ts
@@ -20,7 +20,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 		// consistent for future use by other packages that use it.
 
 		return {
-			available: this.bigNumberService.make((this.data.balance / 1e1),
+			available: this.bigNumberService.make(this.data.balance / 1e1),
 			fees: this.bigNumberService.make(this.data.balance / 1e1),
 		};
 	}

--- a/packages/platform-sdk-btc/source/wallet.dto.test.ts
+++ b/packages/platform-sdk-btc/source/wallet.dto.test.ts
@@ -4,9 +4,10 @@ import { BigNumber } from "@arkecosystem/platform-sdk-support";
 
 import Fixture from "../test/fixtures/client/wallet.json";
 import { WalletData } from "./wallet.dto";
+import { createService } from "../test/mocking";
 
 describe("WalletData", () => {
-	const subject = new WalletData(Fixture);
+	const subject = createService(WalletData).fill(Fixture);
 
 	it("#address", () => {
 		expect(subject.address()).toEqual("my48EN4kDnGEpRZMBfiDS65wdfwfgCGZRz");

--- a/packages/platform-sdk-btc/source/wallet.dto.ts
+++ b/packages/platform-sdk-btc/source/wallet.dto.ts
@@ -16,7 +16,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: this.bigNumberService.make((this.data.balance),
+			available: this.bigNumberService.make(this.data.balance),
 			fees: this.bigNumberService.make(this.data.balance),
 		};
 	}

--- a/packages/platform-sdk-btc/source/wallet.dto.ts
+++ b/packages/platform-sdk-btc/source/wallet.dto.ts
@@ -16,8 +16,8 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: BigNumber.make(this.data.balance),
-			fees: BigNumber.make(this.data.balance),
+			available: this.bigNumberService.make((this.data.balance),
+			fees: this.bigNumberService.make(this.data.balance),
 		};
 	}
 

--- a/packages/platform-sdk-dot/source/wallet.dto.ts
+++ b/packages/platform-sdk-dot/source/wallet.dto.ts
@@ -16,7 +16,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: this.bigNumberService.make((this.data.balance),
+			available: this.bigNumberService.make(this.data.balance),
 			fees: this.bigNumberService.make(this.data.balance),
 		};
 	}

--- a/packages/platform-sdk-dot/source/wallet.dto.ts
+++ b/packages/platform-sdk-dot/source/wallet.dto.ts
@@ -16,8 +16,8 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: BigNumber.make(this.data.balance),
-			fees: BigNumber.make(this.data.balance),
+			available: this.bigNumberService.make((this.data.balance),
+			fees: this.bigNumberService.make(this.data.balance),
 		};
 	}
 

--- a/packages/platform-sdk-egld/source/wallet.dto.ts
+++ b/packages/platform-sdk-egld/source/wallet.dto.ts
@@ -16,7 +16,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: this.bigNumberService.make((this.data.balance).divide(1e18).times(1e8),
+			available: this.bigNumberService.make(this.data.balance).divide(1e18).times(1e8),
 			fees: this.bigNumberService.make(this.data.balance).divide(1e18).times(1e8),
 		};
 	}

--- a/packages/platform-sdk-egld/source/wallet.dto.ts
+++ b/packages/platform-sdk-egld/source/wallet.dto.ts
@@ -16,8 +16,8 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: BigNumber.make(this.data.balance).divide(1e18).times(1e8),
-			fees: BigNumber.make(this.data.balance).divide(1e18).times(1e8),
+			available: this.bigNumberService.make((this.data.balance).divide(1e18).times(1e8),
+			fees: this.bigNumberService.make(this.data.balance).divide(1e18).times(1e8),
 		};
 	}
 

--- a/packages/platform-sdk-eos/source/wallet.dto.test.ts
+++ b/packages/platform-sdk-eos/source/wallet.dto.test.ts
@@ -4,9 +4,10 @@ import { BigNumber } from "@arkecosystem/platform-sdk-support";
 
 import Fixture from "../test/fixtures/client/wallet.json";
 import { WalletData } from "./wallet.dto";
+import { createService } from "../test/mocking";
 
 describe("WalletData", () => {
-	const subject = new WalletData(Fixture);
+	const subject = createService(WalletData).fill(Fixture);
 
 	it("#address", () => {
 		expect(subject.address()).toEqual("bdfkbzietxos");

--- a/packages/platform-sdk-eos/source/wallet.dto.ts
+++ b/packages/platform-sdk-eos/source/wallet.dto.ts
@@ -16,8 +16,8 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: BigNumber.make(this.data.net_weight),
-			fees: BigNumber.make(this.data.net_weight),
+			available: this.bigNumberService.make((this.data.net_weight),
+			fees: this.bigNumberService.make(this.data.net_weight),
 		};
 	}
 

--- a/packages/platform-sdk-eos/source/wallet.dto.ts
+++ b/packages/platform-sdk-eos/source/wallet.dto.ts
@@ -16,7 +16,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: this.bigNumberService.make((this.data.net_weight),
+			available: this.bigNumberService.make(this.data.net_weight),
 			fees: this.bigNumberService.make(this.data.net_weight),
 		};
 	}

--- a/packages/platform-sdk-eth/source/wallet.dto.test.ts
+++ b/packages/platform-sdk-eth/source/wallet.dto.test.ts
@@ -3,12 +3,13 @@ import "jest-extended";
 import { BigNumber } from "@arkecosystem/platform-sdk-support";
 
 import { WalletData } from "./wallet.dto";
+import { createService } from "../test/mocking";
 
 let subject: WalletData;
 
 beforeEach(
 	() =>
-		(subject = new WalletData({
+		(subject = createService(WalletData).fill({
 			address: "0x4581a610f96878266008993475f1476ca9997081",
 			balance: 10,
 			nonce: 0,

--- a/packages/platform-sdk-eth/source/wallet.dto.ts
+++ b/packages/platform-sdk-eth/source/wallet.dto.ts
@@ -17,8 +17,8 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: BigNumber.make(Web3.utils.toBN(this.data.balance).toString()),
-			fees: BigNumber.make(Web3.utils.toBN(this.data.balance).toString()),
+			available: this.bigNumberService.make((Web3.utils.toBN(this.data.balance).toString()),
+			fees: this.bigNumberService.make(Web3.utils.toBN(this.data.balance).toString()),
 		};
 	}
 

--- a/packages/platform-sdk-eth/source/wallet.dto.ts
+++ b/packages/platform-sdk-eth/source/wallet.dto.ts
@@ -17,7 +17,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: this.bigNumberService.make((Web3.utils.toBN(this.data.balance).toString()),
+			available: this.bigNumberService.make(Web3.utils.toBN(this.data.balance).toString()),
 			fees: this.bigNumberService.make(Web3.utils.toBN(this.data.balance).toString()),
 		};
 	}

--- a/packages/platform-sdk-lsk/source/wallet.dto.ts
+++ b/packages/platform-sdk-lsk/source/wallet.dto.ts
@@ -17,8 +17,8 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: BigNumber.make(this.data.balance),
-			fees: BigNumber.make(this.data.balance),
+			available: this.bigNumberService.make(this.data.balance),
+			fees: this.bigNumberService.make(this.data.balance),
 		};
 	}
 

--- a/packages/platform-sdk-neo/source/wallet.dto.test.ts
+++ b/packages/platform-sdk-neo/source/wallet.dto.test.ts
@@ -4,9 +4,10 @@ import { BigNumber } from "@arkecosystem/platform-sdk-support";
 
 import Fixture from "../test/fixtures/client/wallet.json";
 import { WalletData } from "./wallet.dto";
+import { createService } from "../test/mocking";
 
 describe("WalletData", () => {
-	const subject = new WalletData(Fixture);
+	const subject = createService(WalletData).fill(Fixture);
 	it("#address", () => {
 		expect(subject.address()).toEqual("AStJyBXGGBK6bwrRfRUHSjp993PB5C9QgF");
 	});

--- a/packages/platform-sdk-neo/source/wallet.dto.ts
+++ b/packages/platform-sdk-neo/source/wallet.dto.ts
@@ -16,8 +16,8 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: BigNumber.make(this.data.balance).times(1e8),
-			fees: BigNumber.make(this.data.balance).times(1e8),
+			available: this.bigNumberService.make((this.data.balance).times(1e8),
+			fees: this.bigNumberService.make(this.data.balance).times(1e8),
 		};
 	}
 

--- a/packages/platform-sdk-neo/source/wallet.dto.ts
+++ b/packages/platform-sdk-neo/source/wallet.dto.ts
@@ -16,7 +16,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: this.bigNumberService.make((this.data.balance).times(1e8),
+			available: this.bigNumberService.make(this.data.balance).times(1e8),
 			fees: this.bigNumberService.make(this.data.balance).times(1e8),
 		};
 	}

--- a/packages/platform-sdk-profiles/source/serialiser.test.ts
+++ b/packages/platform-sdk-profiles/source/serialiser.test.ts
@@ -102,7 +102,7 @@ describe.each([
 	[
 		456,
 		{
-			available: this.bigNumberService.make((1),
+			available: this.bigNumberService.make(1),
 			fees: this.bigNumberService.make(2),
 			locked: BigNumber.make(3),
 			tokens: {

--- a/packages/platform-sdk-profiles/source/serialiser.test.ts
+++ b/packages/platform-sdk-profiles/source/serialiser.test.ts
@@ -102,8 +102,8 @@ describe.each([
 	[
 		456,
 		{
-			available: BigNumber.make(1),
-			fees: BigNumber.make(2),
+			available: this.bigNumberService.make((1),
+			fees: this.bigNumberService.make(2),
 			locked: BigNumber.make(3),
 			tokens: {
 				ARK: BigNumber.make(4),

--- a/packages/platform-sdk-profiles/source/serialiser.ts
+++ b/packages/platform-sdk-profiles/source/serialiser.ts
@@ -61,8 +61,8 @@ export class WalletSerialiser {
 		const balance = this.#wallet.data().get<Contracts.WalletBalance>(WalletData.Balance);
 
 		const serializedBalance: SerializedBalance = {
-			available: this.bigNumberService.make(balance?.available || 0).toString(),
-			fees: this.bigNumberService.make(balance?.fees || 0).toString(),
+			available: this.#wallet.coin().bigNumber().make(balance?.available || 0).toString(),
+			fees: this.#wallet.coin().bigNumber().make(balance?.fees || 0).toString(),
 		};
 
 		if (balance?.locked) {

--- a/packages/platform-sdk-profiles/source/serialiser.ts
+++ b/packages/platform-sdk-profiles/source/serialiser.ts
@@ -61,8 +61,8 @@ export class WalletSerialiser {
 		const balance = this.#wallet.data().get<Contracts.WalletBalance>(WalletData.Balance);
 
 		const serializedBalance: SerializedBalance = {
-			available: BigNumber.make(balance?.available || 0).toString(),
-			fees: BigNumber.make(balance?.fees || 0).toString(),
+			available: this.bigNumberService.make((balance?.available || 0).toString(),
+			fees: this.bigNumberService.make(balance?.fees || 0).toString(),
 		};
 
 		if (balance?.locked) {

--- a/packages/platform-sdk-profiles/source/serialiser.ts
+++ b/packages/platform-sdk-profiles/source/serialiser.ts
@@ -61,8 +61,16 @@ export class WalletSerialiser {
 		const balance = this.#wallet.data().get<Contracts.WalletBalance>(WalletData.Balance);
 
 		const serializedBalance: SerializedBalance = {
-			available: this.#wallet.coin().bigNumber().make(balance?.available || 0).toString(),
-			fees: this.#wallet.coin().bigNumber().make(balance?.fees || 0).toString(),
+			available: this.#wallet
+				.coin()
+				.bigNumber()
+				.make(balance?.available || 0)
+				.toString(),
+			fees: this.#wallet
+				.coin()
+				.bigNumber()
+				.make(balance?.fees || 0)
+				.toString(),
 		};
 
 		if (balance?.locked) {

--- a/packages/platform-sdk-profiles/source/serialiser.ts
+++ b/packages/platform-sdk-profiles/source/serialiser.ts
@@ -61,7 +61,7 @@ export class WalletSerialiser {
 		const balance = this.#wallet.data().get<Contracts.WalletBalance>(WalletData.Balance);
 
 		const serializedBalance: SerializedBalance = {
-			available: this.bigNumberService.make((balance?.available || 0).toString(),
+			available: this.bigNumberService.make(balance?.available || 0).toString(),
 			fees: this.bigNumberService.make(balance?.fees || 0).toString(),
 		};
 

--- a/packages/platform-sdk-profiles/source/wallet.ts
+++ b/packages/platform-sdk-profiles/source/wallet.ts
@@ -586,8 +586,8 @@ export class Wallet implements IReadWriteWallet {
 
 		/* istanbul ignore next */
 		this.data().set(WalletData.Balance, {
-			available: this.bigNumberService.make(balance?.available || 0, this.#decimals()),
-			fees: this.bigNumberService.make(balance?.fees || 0, this.#decimals()),
+			available: BigNumber.make(balance?.available || 0, this.#decimals()),
+			fees: BigNumber.make(balance?.fees || 0, this.#decimals()),
 		});
 
 		this.data().set(

--- a/packages/platform-sdk-profiles/source/wallet.ts
+++ b/packages/platform-sdk-profiles/source/wallet.ts
@@ -586,8 +586,8 @@ export class Wallet implements IReadWriteWallet {
 
 		/* istanbul ignore next */
 		this.data().set(WalletData.Balance, {
-			available: BigNumber.make(balance?.available || 0, this.#decimals()),
-			fees: BigNumber.make(balance?.fees || 0, this.#decimals()),
+			available: this.bigNumberService.make((balance?.available || 0, this.#decimals()),
+			fees: this.bigNumberService.make(balance?.fees || 0, this.#decimals()),
 		});
 
 		this.data().set(

--- a/packages/platform-sdk-profiles/source/wallet.ts
+++ b/packages/platform-sdk-profiles/source/wallet.ts
@@ -586,7 +586,7 @@ export class Wallet implements IReadWriteWallet {
 
 		/* istanbul ignore next */
 		this.data().set(WalletData.Balance, {
-			available: this.bigNumberService.make((balance?.available || 0, this.#decimals()),
+			available: this.bigNumberService.make(balance?.available || 0, this.#decimals()),
 			fees: this.bigNumberService.make(balance?.fees || 0, this.#decimals()),
 		});
 

--- a/packages/platform-sdk-sol/source/wallet.dto.ts
+++ b/packages/platform-sdk-sol/source/wallet.dto.ts
@@ -16,7 +16,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: this.bigNumberService.make((this.data.balance),
+			available: this.bigNumberService.make(this.data.balance),
 			fees: this.bigNumberService.make(this.data.balance),
 		};
 	}

--- a/packages/platform-sdk-sol/source/wallet.dto.ts
+++ b/packages/platform-sdk-sol/source/wallet.dto.ts
@@ -16,8 +16,8 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: BigNumber.make(this.data.balance),
-			fees: BigNumber.make(this.data.balance),
+			available: this.bigNumberService.make((this.data.balance),
+			fees: this.bigNumberService.make(this.data.balance),
 		};
 	}
 

--- a/packages/platform-sdk-trx/source/wallet.dto.test.ts
+++ b/packages/platform-sdk-trx/source/wallet.dto.test.ts
@@ -4,11 +4,10 @@ import { BigNumber } from "@arkecosystem/platform-sdk-support";
 
 import { data } from "../test/fixtures/client/wallet.json";
 import { WalletData } from "./wallet.dto";
-
-let subject: WalletData;
+import { createService } from "../test/mocking";
 
 describe("WalletData", () => {
-	const subject = new WalletData(data[0]);
+	const subject = createService(WalletData).fill(data[0]);
 
 	it("#address", () => {
 		expect(subject.address()).toEqual(data[0].address);

--- a/packages/platform-sdk-xlm/source/wallet.dto.test.ts
+++ b/packages/platform-sdk-xlm/source/wallet.dto.test.ts
@@ -4,11 +4,10 @@ import { BigNumber } from "@arkecosystem/platform-sdk-support";
 
 import Fixture from "../test/fixtures/client/wallet.json";
 import { WalletData } from "./wallet.dto";
-
-let subject: WalletData;
+import { createService } from "../test/mocking";
 
 describe("WalletData", () => {
-	const subject = new WalletData(Fixture);
+	const subject = createService(WalletData).fill(Fixture);
 	const implementedMethods = {
 		address: "GD42RQNXTRIW6YR3E2HXV5T2AI27LBRHOERV2JIYNFMXOBA234SWLQQB",
 		balance: BigNumber.make("17491629"),

--- a/packages/platform-sdk-xlm/source/wallet.dto.ts
+++ b/packages/platform-sdk-xlm/source/wallet.dto.ts
@@ -16,8 +16,8 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: BigNumber.make(this.data.balances[0].balance).times(1e8),
-			fees: BigNumber.make(this.data.balances[0].balance).times(1e8),
+			available: this.bigNumberService.make((this.data.balances[0].balance).times(1e8),
+			fees: this.bigNumberService.make(this.data.balances[0].balance).times(1e8),
 		};
 	}
 

--- a/packages/platform-sdk-xlm/source/wallet.dto.ts
+++ b/packages/platform-sdk-xlm/source/wallet.dto.ts
@@ -16,7 +16,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: this.bigNumberService.make((this.data.balances[0].balance).times(1e8),
+			available: this.bigNumberService.make(this.data.balances[0].balance).times(1e8),
 			fees: this.bigNumberService.make(this.data.balances[0].balance).times(1e8),
 		};
 	}

--- a/packages/platform-sdk-xrp/source/wallet.dto.test.ts
+++ b/packages/platform-sdk-xrp/source/wallet.dto.test.ts
@@ -4,10 +4,11 @@ import { BigNumber } from "@arkecosystem/platform-sdk-support";
 
 import { result as fixture } from "../test/fixtures/client/wallet.json";
 import { WalletData } from "./wallet.dto";
+import { createService } from "../test/mocking";
 
 describe("WalletData", () => {
 	it("should succeed", async () => {
-		const result = new WalletData(fixture.account_data);
+		const result = createService(WalletData).fill(fixture.account_data);
 
 		expect(result).toBeInstanceOf(WalletData);
 		expect(result.address()).toEqual("r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59");

--- a/packages/platform-sdk-xrp/source/wallet.dto.ts
+++ b/packages/platform-sdk-xrp/source/wallet.dto.ts
@@ -16,7 +16,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: this.bigNumberService.make((this.data.Balance).times(1e8),
+			available: this.bigNumberService.make(this.data.Balance).times(1e8),
 			fees: this.bigNumberService.make(this.data.Balance).times(1e8),
 		};
 	}

--- a/packages/platform-sdk-xrp/source/wallet.dto.ts
+++ b/packages/platform-sdk-xrp/source/wallet.dto.ts
@@ -16,8 +16,8 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: BigNumber.make(this.data.Balance).times(1e8),
-			fees: BigNumber.make(this.data.Balance).times(1e8),
+			available: this.bigNumberService.make((this.data.Balance).times(1e8),
+			fees: this.bigNumberService.make(this.data.Balance).times(1e8),
 		};
 	}
 

--- a/packages/platform-sdk-zil/source/wallet.dto.ts
+++ b/packages/platform-sdk-zil/source/wallet.dto.ts
@@ -16,8 +16,8 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: BigNumber.make(this.data.balance).divide(1e4),
-			fees: BigNumber.make(this.data.balance).divide(1e4),
+			available: this.bigNumberService.make((this.data.balance).divide(1e4),
+			fees: this.bigNumberService.make(this.data.balance).divide(1e4),
 		};
 	}
 

--- a/packages/platform-sdk-zil/source/wallet.dto.ts
+++ b/packages/platform-sdk-zil/source/wallet.dto.ts
@@ -16,7 +16,7 @@ export class WalletData extends DTO.AbstractWalletData implements Contracts.Wall
 
 	public override balance(): Contracts.WalletBalance {
 		return {
-			available: this.bigNumberService.make((this.data.balance).divide(1e4),
+			available: this.bigNumberService.make(this.data.balance).divide(1e4),
 			fees: this.bigNumberService.make(this.data.balance).divide(1e4),
 		};
 	}


### PR DESCRIPTION
Ensures that decimals are provided consistently to avoid unexpected values for the client.