### PR TITLE
refactor(sdk): implement `Network#displayName`

### DIFF
--- a/packages/platform-sdk-profiles/source/wallet-transaction.service.test.ts
+++ b/packages/platform-sdk-profiles/source/wallet-transaction.service.test.ts
@@ -1059,45 +1059,49 @@ describe("addSignature failures", () => {
 	});
 
 	it("should throw if the signatory cannot act with a multi mnemonic", async () => {
-		await expect(() => subject.addSignature(
-			transactionId,
-			new Signatories.Signatory(
-				new Signatories.MultiMnemonicSignatory([], []),
+		await expect(() =>
+			subject.addSignature(
+				transactionId,
+				new Signatories.Signatory(new Signatories.MultiMnemonicSignatory([], [])),
 			),
-		)).rejects.toThrowError("The signatory cannot act with a multi mnemonic.");
+		).rejects.toThrowError("The signatory cannot act with a multi mnemonic.");
 	});
 
 	it("should throw if the signatory cannot act with a sender public key", async () => {
-		await expect(() => subject.addSignature(
-			transactionId,
-			new Signatories.Signatory(
-				new Signatories.SenderPublicKeySignatory({
-					signingKey: "upset",
-					address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
-					publicKey: "publicKey",
-				}),
+		await expect(() =>
+			subject.addSignature(
+				transactionId,
+				new Signatories.Signatory(
+					new Signatories.SenderPublicKeySignatory({
+						signingKey: "upset",
+						address: "D6i8P5N44rFto6M6RALyUXLLs7Q1A1WREW",
+						publicKey: "publicKey",
+					}),
+				),
 			),
-		)).rejects.toThrowError("The signatory cannot act with a sender public key.");
+		).rejects.toThrowError("The signatory cannot act with a sender public key.");
 	});
 
 	it("should throw if the signatory cannot act with a multi signature", async () => {
-		await expect(() => subject.addSignature(
-			transactionId,
-			new Signatories.Signatory(
-				new Signatories.MultiSignatureSignatory({
-					publicKeys: [],
-					min: 0,
-				}),
+		await expect(() =>
+			subject.addSignature(
+				transactionId,
+				new Signatories.Signatory(
+					new Signatories.MultiSignatureSignatory({
+						publicKeys: [],
+						min: 0,
+					}),
+				),
 			),
-		)).rejects.toThrowError("The signatory cannot act with a multi signature.");
+		).rejects.toThrowError("The signatory cannot act with a multi signature.");
 	});
 
 	it("should throw if the signatory cannot act with a private multi signature", async () => {
-		await expect(() => subject.addSignature(
-			transactionId,
-			new Signatories.Signatory(
-				new Signatories.PrivateMultiSignatureSignatory("key", []),
+		await expect(() =>
+			subject.addSignature(
+				transactionId,
+				new Signatories.Signatory(new Signatories.PrivateMultiSignatureSignatory("key", [])),
 			),
-		)).rejects.toThrowError("The signatory cannot act with a private multi signature.");
+		).rejects.toThrowError("The signatory cannot act with a private multi signature.");
 	});
 });

--- a/packages/platform-sdk-profiles/source/wallet.contract.ts
+++ b/packages/platform-sdk-profiles/source/wallet.contract.ts
@@ -671,7 +671,7 @@ export interface IReadWriteWallet {
 	 * @return {*}  {boolean}
 	 * @memberof IReadWriteWallet
 	 */
-	 actsWithSecret(): boolean;
+	actsWithSecret(): boolean;
 
 	/**
 	 * Determines if the wallet has been imported with a secret with encryption.
@@ -679,5 +679,5 @@ export interface IReadWriteWallet {
 	 * @return {*}  {boolean}
 	 * @memberof IReadWriteWallet
 	 */
-	 actsWithSecretWithEncryption(): boolean;
+	actsWithSecretWithEncryption(): boolean;
 }

--- a/packages/platform-sdk-profiles/source/wallet.factory.contract.ts
+++ b/packages/platform-sdk-profiles/source/wallet.factory.contract.ts
@@ -188,7 +188,7 @@ export interface IWalletFactory {
 	 * @return {Promise<IReadWriteWallet>}
 	 * @memberof IWalletFactory
 	 */
-	 fromSecret(options: ISecretOptions): Promise<IReadWriteWallet>;
+	fromSecret(options: ISecretOptions): Promise<IReadWriteWallet>;
 
 	/**
 	 * Imports a wallet from a WIF.

--- a/packages/platform-sdk-profiles/source/wif.ts
+++ b/packages/platform-sdk-profiles/source/wif.ts
@@ -20,10 +20,7 @@ export class WalletImportFormat implements IWalletImportFormat {
 		}
 
 		return (
-			await this.#wallet
-				.coin()
-				.wif()
-				.fromPrivateKey(decrypt(encryptedKey, password).privateKey.toString("hex"))
+			await this.#wallet.coin().wif().fromPrivateKey(decrypt(encryptedKey, password).privateKey.toString("hex"))
 		).wif;
 	}
 

--- a/packages/platform-sdk-support/source/uri.test.ts
+++ b/packages/platform-sdk-support/source/uri.test.ts
@@ -46,6 +46,6 @@ describe("URI", () => {
 			subject.deserialize(
 				"ark:unknown?coin=ark&network=ark.mainnet&recipient=DNjuJEDQkhrJ7cA9FZ2iVXt5anYiM8Jtc9&amount=ARK&memo=ARK",
 			),
-		).toThrowError('The given method is unknown: unknown');
+		).toThrowError("The given method is unknown: unknown");
 	});
 });

--- a/packages/platform-sdk-support/source/uri.ts
+++ b/packages/platform-sdk-support/source/uri.ts
@@ -60,7 +60,7 @@ export class URI {
 		}
 
 		try {
-			let method: string = parsed[1];
+			const method: string = parsed[1];
 			const params = querystring.parse(parsed[2].substring(1));
 
 			if (!this.#methods.includes(method)) {

--- a/packages/platform-sdk/source/networks/network.test.ts
+++ b/packages/platform-sdk/source/networks/network.test.ts
@@ -24,6 +24,14 @@ it("should have a name", () => {
 	expect(subject.name()).toBe("Devnet");
 });
 
+it("should have a display name ", () => {
+	expect(subject.displayName()).toBe("ARK Devnet");
+
+	jest.spyOn(subject, "isLive").mockReturnValueOnce(true);
+
+	expect(subject.displayName()).toBe("ARK");
+});
+
 it("should have an explorer", () => {
 	expect(subject.explorer()).toBe("https://dexplorer.ark.io");
 });

--- a/packages/platform-sdk/source/networks/network.test.ts
+++ b/packages/platform-sdk/source/networks/network.test.ts
@@ -24,7 +24,7 @@ it("should have a name", () => {
 	expect(subject.name()).toBe("Devnet");
 });
 
-it("should have a display name ", () => {
+it("should have a display name", () => {
 	expect(subject.displayName()).toBe("ARK Devnet");
 
 	jest.spyOn(subject, "isLive").mockReturnValueOnce(true);

--- a/packages/platform-sdk/source/networks/network.ts
+++ b/packages/platform-sdk/source/networks/network.ts
@@ -66,6 +66,17 @@ export class Network {
 	}
 
 	/**
+	 * Get the display name of the network.
+	 */
+	public displayName(): string {
+		if (this.isLive()) {
+			return this.coin();
+		}
+
+		return `${this.coin()} ${this.name()}`;
+	}
+
+	/**
 	 * Get the explorer URL of the coin that is used.
 	 */
 	public explorer(): string {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

There are some occurrences in the Desktop Wallet where the networks coin name is concatenated with the network name, e.g. `` `${network.coin()} ${network.name()}` ``. The DW also uses some hardcoded display names. For `live` networks the network name is generally omitted, hence the check in the `displayName` method.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
