### PR TITLE
fix(sdk): use `coinName` in `Network#displayName`

### DIFF
--- a/packages/platform-sdk/source/networks/network.ts
+++ b/packages/platform-sdk/source/networks/network.ts
@@ -70,10 +70,10 @@ export class Network {
 	 */
 	public displayName(): string {
 		if (this.isLive()) {
-			return this.coin();
+			return this.coinName();
 		}
 
-		return `${this.coin()} ${this.name()}`;
+		return `${this.coinName()} ${this.name()}`;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Use a networks `coinName` instead of `coin` when building the display name.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
